### PR TITLE
wiki create/update (interactive)

### DIFF
--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -1,7 +1,6 @@
 # PYTHON_ARGCOMPLETE_OK
 import argcomplete
 import argparse
-from collections import defaultdict
 import os
 import subprocess
 import tempfile
@@ -46,6 +45,7 @@ from redi.tracker import fetch_trackers, list_trackers
 from redi.user import list_users
 from redi.version import create_version, fetch_versions, list_versions, update_version
 from redi.wiki import (
+    build_children_map,
     create_wiki,
     fetch_wiki,
     fetch_wikis,
@@ -54,6 +54,19 @@ from redi.wiki import (
     read_wiki,
     update_wiki,
 )
+
+
+def build_wiki_tree_choices(pages: list[dict]) -> list[questionary.Choice]:
+    children_map = build_children_map(pages)
+    choices: list[questionary.Choice] = []
+
+    def walk(parent: str | None, depth: int) -> None:
+        for title in children_map.get(parent, []):
+            choices.append(questionary.Choice("  " * depth + title, value=title))
+            walk(title, depth + 1)
+
+    walk(None, 0)
+    return choices
 
 
 def open_editor(initial_text: str = "") -> str:
@@ -625,43 +638,26 @@ def main() -> None:
             if page_title is None:
                 pages = fetch_wikis(project_id)
                 existing_titles = {normalize_title(p["title"]) for p in pages}
+
+                def validate_page_title(value: str) -> bool | str:
+                    stripped = value.strip()
+                    if not stripped:
+                        return "ページタイトルを入力してください"
+                    if normalize_title(stripped) in existing_titles:
+                        return "既存のページタイトルと重複しています"
+                    return True
+
                 page_title = questionary.text(
                     "ページタイトル",
-                    validate=lambda page_title_input: (
-                        True
-                        if page_title_input.strip()
-                        and normalize_title(page_title_input) not in existing_titles
-                        else "既存のページタイトルと重複しています"
-                        if len(page_title_input.strip())
-                        else "ページタイトルを入力してください"
-                    ),
+                    validate=validate_page_title,
                 ).ask(kbi_msg="")
                 if not page_title:
                     print("ページタイトルが空のためキャンセルしました")
                     exit(1)
-                page_title = page_title.strip()
                 if parent_title is None:
-                    children_map: dict[str | None, list[str]] = defaultdict(list)
-                    for page in pages:
-                        parent = (
-                            page.get("parent", {}).get("title")
-                            if "parent" in page
-                            else None
-                        )
-                        children_map[parent].append(page["title"])
-                    parent_choices = []
-
-                    def add_choices(parent: str | None, depth: int) -> None:
-                        for title in sorted(children_map.get(parent, [])):
-                            parent_choices.append(
-                                questionary.Choice("  " * depth + title, value=title)
-                            )
-                            add_choices(title, depth + 1)
-
-                    add_choices(None, 0)
                     parent_title = questionary.select(
                         "親ページ",
-                        choices=parent_choices,
+                        choices=build_wiki_tree_choices(pages),
                     ).ask(kbi_msg="")
             if args.description and args.description != "":
                 text = args.description
@@ -669,6 +665,8 @@ def main() -> None:
                 text = open_editor()
             if text:
                 page_title = normalize_title(page_title)
+                if parent_title:
+                    parent_title = normalize_title(parent_title)
                 create_wiki(project_id, page_title, text, parent_title=parent_title)
             else:
                 print("テキストが空のためキャンセルしました")
@@ -679,27 +677,9 @@ def main() -> None:
                 if not pages:
                     print("Wikiページが存在しません")
                     exit(1)
-                children_map: dict[str | None, list[str]] = defaultdict(list)
-                for page in pages:
-                    parent = (
-                        page.get("parent", {}).get("title")
-                        if "parent" in page
-                        else None
-                    )
-                    children_map[parent].append(page["title"])
-                page_choices: list = []
-
-                def add_page_choices(parent: str | None, depth: int) -> None:
-                    for title in sorted(children_map.get(parent, [])):
-                        page_choices.append(
-                            questionary.Choice("  " * depth + title, value=title)
-                        )
-                        add_page_choices(title, depth + 1)
-
-                add_page_choices(None, 0)
                 page_title = questionary.select(
                     "編集するページ",
-                    choices=page_choices,
+                    choices=build_wiki_tree_choices(pages),
                 ).ask(kbi_msg="")
                 if not page_title:
                     print("キャンセルしました")

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -44,7 +44,14 @@ from redi.custom_field import list_custom_fields
 from redi.tracker import fetch_trackers, list_trackers
 from redi.user import list_users
 from redi.version import create_version, fetch_versions, list_versions, update_version
-from redi.wiki import create_wiki, fetch_wiki, list_wikis, read_wiki, update_wiki
+from redi.wiki import (
+    create_wiki,
+    fetch_wiki,
+    fetch_wikis,
+    list_wikis,
+    read_wiki,
+    update_wiki,
+)
 
 
 def open_editor(initial_text: str = "") -> str:
@@ -230,7 +237,9 @@ def main() -> None:
         "--full", action="store_true", help="JSON形式で全情報を出力"
     )
     w_create_parser = w_subparsers.add_parser("create", help="Wikiページ作成")
-    w_create_parser.add_argument("page_title", help="Wikiページタイトル")
+    w_create_parser.add_argument(
+        "page_title", nargs="?", help="Wikiページタイトル（省略で対話的に入力）"
+    )
     w_create_parser.add_argument("--parent_title", help="親ページタイトル")
     w_create_parser.add_argument(
         "--description",
@@ -607,13 +616,33 @@ def main() -> None:
         if args.wiki_command == "view":
             read_wiki(project_id, args.page_title, full=args.full)
         elif args.wiki_command == "create":
+            page_title = args.page_title
+            parent_title = args.parent_title
+            if page_title is None:
+                page_title = questionary.text("ページタイトル").ask(kbi_msg="")
+                if not page_title:
+                    print("ページタイトルが空のためキャンセルしました")
+                    exit(1)
+                page_title = page_title.strip()
+                if parent_title is None:
+                    pages = fetch_wikis(project_id)
+                    parent_choices = [
+                        questionary.Choice("(なし)", value=None)
+                    ] + [
+                        questionary.Choice(p["title"], value=p["title"])
+                        for p in sorted(pages, key=lambda p: p["title"])
+                    ]
+                    parent_title = questionary.select(
+                        "親ページ",
+                        choices=parent_choices,
+                    ).ask(kbi_msg="")
             if args.description and args.description != "":
                 text = args.description
             else:
                 text = open_editor()
             if text:
                 create_wiki(
-                    project_id, args.page_title, text, parent_title=args.parent_title
+                    project_id, page_title, text, parent_title=parent_title
                 )
             else:
                 print("テキストが空のためキャンセルしました")

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -1,6 +1,7 @@
 # PYTHON_ARGCOMPLETE_OK
 import argcomplete
 import argparse
+from collections import defaultdict
 import os
 import subprocess
 import tempfile
@@ -626,12 +627,25 @@ def main() -> None:
                 page_title = page_title.strip()
                 if parent_title is None:
                     pages = fetch_wikis(project_id)
-                    parent_choices = [
-                        questionary.Choice("(なし)", value=None)
-                    ] + [
-                        questionary.Choice(p["title"], value=p["title"])
-                        for p in sorted(pages, key=lambda p: p["title"])
-                    ]
+
+                    children_map: dict[str | None, list[str]] = defaultdict(list)
+                    for page in pages:
+                        parent = (
+                            page.get("parent", {}).get("title")
+                            if "parent" in page
+                            else None
+                        )
+                        children_map[parent].append(page["title"])
+                    parent_choices = []
+
+                    def add_choices(parent: str | None, depth: int) -> None:
+                        for title in sorted(children_map.get(parent, [])):
+                            parent_choices.append(
+                                questionary.Choice("  " * depth + title, value=title)
+                            )
+                            add_choices(title, depth + 1)
+
+                    add_choices(None, 0)
                     parent_title = questionary.select(
                         "親ページ",
                         choices=parent_choices,
@@ -641,9 +655,7 @@ def main() -> None:
             else:
                 text = open_editor()
             if text:
-                create_wiki(
-                    project_id, page_title, text, parent_title=parent_title
-                )
+                create_wiki(project_id, page_title, text, parent_title=parent_title)
             else:
                 print("テキストが空のためキャンセルしました")
         elif args.wiki_command == "update":

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -620,14 +620,30 @@ def main() -> None:
             page_title = args.page_title
             parent_title = args.parent_title
             if page_title is None:
-                page_title = questionary.text("ページタイトル").ask(kbi_msg="")
+                pages = fetch_wikis(project_id)
+
+                # redmineで空白文字を含んでwikiのpageを作成するとURLの都合か`_`に置き換えられている
+                # 既存のwikiのタイトルの先頭文字が大文字になっている
+                def normalize_title(t: str) -> str:
+                    return t.strip().replace(" ", "_").lower()
+
+                existing_titles = {normalize_title(p["title"]) for p in pages}
+                page_title = questionary.text(
+                    "ページタイトル",
+                    validate=lambda page_title_input: (
+                        True
+                        if page_title_input.strip()
+                        and normalize_title(page_title_input) not in existing_titles
+                        else "既存のページタイトルと重複しています"
+                        if normalize_title(page_title_input) in existing_titles
+                        else "ページタイトルを入力してください"
+                    ),
+                ).ask(kbi_msg="")
                 if not page_title:
                     print("ページタイトルが空のためキャンセルしました")
                     exit(1)
                 page_title = page_title.strip()
                 if parent_title is None:
-                    pages = fetch_wikis(project_id)
-
                     children_map: dict[str | None, list[str]] = defaultdict(list)
                     for page in pages:
                         parent = (

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -50,6 +50,7 @@ from redi.wiki import (
     fetch_wiki,
     fetch_wikis,
     list_wikis,
+    normalize_title,
     read_wiki,
     update_wiki,
 )
@@ -621,12 +622,6 @@ def main() -> None:
             parent_title = args.parent_title
             if page_title is None:
                 pages = fetch_wikis(project_id)
-
-                # redmineで空白文字を含んでwikiのpageを作成するとURLの都合か`_`に置き換えられている
-                # 既存のwikiのタイトルの先頭文字が大文字になっている
-                def normalize_title(t: str) -> str:
-                    return t.strip().replace(" ", "_").lower()
-
                 existing_titles = {normalize_title(p["title"]) for p in pages}
                 page_title = questionary.text(
                     "ページタイトル",
@@ -635,7 +630,7 @@ def main() -> None:
                         if page_title_input.strip()
                         and normalize_title(page_title_input) not in existing_titles
                         else "既存のページタイトルと重複しています"
-                        if normalize_title(page_title_input) in existing_titles
+                        if len(page_title_input.strip())
                         else "ページタイトルを入力してください"
                     ),
                 ).ask(kbi_msg="")
@@ -671,6 +666,7 @@ def main() -> None:
             else:
                 text = open_editor()
             if text:
+                page_title = normalize_title(page_title)
                 create_wiki(project_id, page_title, text, parent_title=parent_title)
             else:
                 print("テキストが空のためキャンセルしました")

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -252,7 +252,9 @@ def main() -> None:
         help="説明（値省略でエディタ起動）",
     )
     w_update_parser = w_subparsers.add_parser("update", help="Wikiページ更新")
-    w_update_parser.add_argument("page_title", help="Wikiページタイトル")
+    w_update_parser.add_argument(
+        "page_title", nargs="?", help="Wikiページタイトル（省略で対話的に選択）"
+    )
     w_update_parser.add_argument(
         "--description",
         "-d",
@@ -671,13 +673,44 @@ def main() -> None:
             else:
                 print("テキストが空のためキャンセルしました")
         elif args.wiki_command == "update":
+            page_title = args.page_title
+            if page_title is None:
+                pages = fetch_wikis(project_id)
+                if not pages:
+                    print("Wikiページが存在しません")
+                    exit(1)
+                children_map: dict[str | None, list[str]] = defaultdict(list)
+                for page in pages:
+                    parent = (
+                        page.get("parent", {}).get("title")
+                        if "parent" in page
+                        else None
+                    )
+                    children_map[parent].append(page["title"])
+                page_choices: list = []
+
+                def add_page_choices(parent: str | None, depth: int) -> None:
+                    for title in sorted(children_map.get(parent, [])):
+                        page_choices.append(
+                            questionary.Choice("  " * depth + title, value=title)
+                        )
+                        add_page_choices(title, depth + 1)
+
+                add_page_choices(None, 0)
+                page_title = questionary.select(
+                    "編集するページ",
+                    choices=page_choices,
+                ).ask(kbi_msg="")
+                if not page_title:
+                    print("キャンセルしました")
+                    exit(1)
             if args.description and args.description != "":
                 text = args.description
             else:
-                current = fetch_wiki(project_id, args.page_title)
+                current = fetch_wiki(project_id, page_title)
                 text = open_editor(current.get("text") or "")
             if text:
-                update_wiki(project_id, args.page_title, text)
+                update_wiki(project_id, page_title, text)
             else:
                 print("テキストが空のためキャンセルしました")
         else:

--- a/src/redi/wiki.py
+++ b/src/redi/wiki.py
@@ -6,12 +6,17 @@ import requests
 from redi.config import redmine_api_key, redmine_url
 
 
-def list_wikis(project_id: str) -> None:
+def fetch_wikis(project_id: str) -> list[dict]:
     response = requests.get(
         f"{redmine_url}/projects/{project_id}/wiki/index.json",
         headers={"X-Redmine-API-Key": redmine_api_key},
     )
-    pages = response.json()["wiki_pages"]
+    response.raise_for_status()
+    return response.json()["wiki_pages"]
+
+
+def list_wikis(project_id: str) -> None:
+    pages = fetch_wikis(project_id)
 
     children_map = defaultdict(list)
     for page in pages:

--- a/src/redi/wiki.py
+++ b/src/redi/wiki.py
@@ -24,16 +24,21 @@ def fetch_wikis(project_id: str) -> list[dict]:
     return response.json()["wiki_pages"]
 
 
-def list_wikis(project_id: str) -> None:
-    pages = fetch_wikis(project_id)
-
-    children_map = defaultdict(list)
+def build_children_map(pages: list[dict]) -> dict[str | None, list[str]]:
+    children_map: dict[str | None, list[str]] = defaultdict(list)
     for page in pages:
         parent = page.get("parent", {}).get("title") if "parent" in page else None
         children_map[parent].append(page["title"])
+    for titles in children_map.values():
+        titles.sort()
+    return children_map
+
+
+def list_wikis(project_id: str) -> None:
+    children_map = build_children_map(fetch_wikis(project_id))
 
     def print_tree(parent: str | None, prefix: str = "") -> None:
-        children = sorted(children_map.get(parent, []))
+        children = children_map.get(parent, [])
         for i, title in enumerate(children):
             is_last = i == len(children) - 1
             connector = "└── " if is_last else "├── "

--- a/src/redi/wiki.py
+++ b/src/redi/wiki.py
@@ -6,6 +6,15 @@ import requests
 from redi.config import redmine_api_key, redmine_url
 
 
+# redmineで空白文字を含んでwikiのpageを作成するとURLの都合か`_`に置き換えられている
+# 既存のwikiのタイトルの先頭文字が大文字になっている
+def normalize_title(t: str) -> str:
+    normalized = t.strip().replace(" ", "_")
+    if normalized and "a" <= normalized[0] <= "z":
+        normalized = normalized[0].upper() + normalized[1:]
+    return normalized
+
+
 def fetch_wikis(project_id: str) -> list[dict]:
     response = requests.get(
         f"{redmine_url}/projects/{project_id}/wiki/index.json",


### PR DESCRIPTION
- **[update] タイトルを入力して親ページを選択させてwikiを作成できるようにした**
- **[update] wikiのページ一覧を階層化して表示**
- **[update] 既存ページと同じ名前のページを入力するとそのページの更新に切り替わるのでそれを防ぐようにバリデーションする**
- **[update] page_title の変換方法を更新; ページ作成の前に処理を実行する**
- **[update] wiki update で編集対象の候補のページを選択できるようにした**
