### PR TITLE
issue #36 redi issue に --query_id オプションを追加

### DIFF
--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -167,6 +167,11 @@ def _add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     i_parser.add_argument("--tracker_id", "-t", help="トラッカーIDでフィルタリング")
     i_parser.add_argument("--priority_id", help="優先度IDでフィルタリング")
+    i_parser.add_argument(
+        "--query_id",
+        "-q",
+        help="カスタムクエリIDでフィルタリング（`redi query`で取得可）",
+    )
     i_parser.add_argument("--limit", "-l", type=int, help="取得件数")
     i_parser.add_argument("--offset", "-o", type=int, help="オフセット")
     i_subparsers = i_parser.add_subparsers(dest="issue_command")
@@ -821,6 +826,7 @@ def _handle_issue(args: argparse.Namespace) -> None:
             status_id=args.status_id,
             tracker_id=args.tracker_id,
             priority_id=args.priority_id,
+            query_id=args.query_id,
             limit=args.limit,
             offset=args.offset,
             full=args.full,

--- a/src/redi/issue.py
+++ b/src/redi/issue.py
@@ -14,6 +14,7 @@ def fetch_issues(
     status_id: str | None = None,
     tracker_id: str | None = None,
     priority_id: str | None = None,
+    query_id: str | None = None,
     limit: int | None = None,
     offset: int | None = None,
 ) -> list[dict]:
@@ -30,6 +31,8 @@ def fetch_issues(
         params["tracker_id"] = tracker_id
     if priority_id:
         params["priority_id"] = priority_id
+    if query_id:
+        params["query_id"] = query_id
     if limit is not None:
         params["limit"] = limit
     if offset is not None:
@@ -46,6 +49,7 @@ def list_issues(
     status_id: str | None = None,
     tracker_id: str | None = None,
     priority_id: str | None = None,
+    query_id: str | None = None,
     limit: int | None = None,
     offset: int | None = None,
     full: bool = False,
@@ -57,6 +61,7 @@ def list_issues(
         status_id=status_id,
         tracker_id=tracker_id,
         priority_id=priority_id,
+        query_id=query_id,
         limit=limit,
         offset=offset,
     )


### PR DESCRIPTION
resolve #36

## Summary
- `redi issue` コマンドに `--query_id` (`-q`) オプションを追加
- Redmine の保存済みカスタムクエリを指定してイシュー一覧を絞り込める
- クエリIDは `redi query` で取得可能

## Test plan
- [ ] `redi query` で取得したカスタムクエリIDを指定して `redi issue --query_id <id>` を実行し、期待する絞り込み結果が得られること
- [ ] `redi issue -q <id>` のショートオプションが動作すること
- [ ] 他のフィルタオプション（`--project_id` など）と併用した場合の挙動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)