### PR TITLE
ほぼ不変なAPIレスポンスをキャッシュする

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,6 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "pytest>=9.0.3",
     "ruff>=0.15.9",
 ]

--- a/src/redi/cache.py
+++ b/src/redi/cache.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 CACHE_DIR = Path.home() / ".cache" / "redi"
 # キャッシュの生存時間[s]
-DEFAULT_TTL = 30 * 24 * 60 * 60  # 1month
+DEFAULT_TTL = 100 * 12 * 30 * 24 * 60 * 60  # 100 years
 
 
 def _cache_path(key: str) -> Path:

--- a/src/redi/cache.py
+++ b/src/redi/cache.py
@@ -1,0 +1,30 @@
+import json
+import time
+from pathlib import Path
+
+CACHE_DIR = Path.home() / ".cache" / "redi"
+# キャッシュの生存時間[s]
+DEFAULT_TTL = 30 * 24 * 60 * 60  # 1month
+
+
+def _cache_path(key: str) -> Path:
+    return CACHE_DIR / f"{key}.json"
+
+
+def load(key: str, ttl: int = DEFAULT_TTL) -> list[dict] | None:
+    path = _cache_path(key)
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text())
+        if time.time() - data["timestamp"] > ttl:
+            return None
+        return data["value"]
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+def save(key: str, value: list[dict]) -> None:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    data = {"timestamp": time.time(), "value": value}
+    _cache_path(key).write_text(json.dumps(data, ensure_ascii=False))

--- a/src/redi/custom_field.py
+++ b/src/redi/custom_field.py
@@ -1,9 +1,15 @@
 import json
 
+from redi import cache
 from redi.client import client
 
+CACHE_KEY = "custom_fields"
 
-def list_custom_fields(full: bool = False) -> None:
+
+def fetch_custom_fields() -> list[dict]:
+    cached = cache.load(CACHE_KEY)
+    if cached is not None:
+        return cached
     response = client.get("/custom_fields.json")
     if response.status_code == 403:
         # https://www.redmine.org/projects/redmine/wiki/Rest_CustomFields
@@ -11,7 +17,13 @@ def list_custom_fields(full: bool = False) -> None:
         print("カスタムフィールドの取得には管理者権限が必要です")
         exit()
     response.raise_for_status()
-    custom_fields = response.json()["custom_fields"]
+    data = response.json()["custom_fields"]
+    cache.save(CACHE_KEY, data)
+    return data
+
+
+def list_custom_fields(full: bool = False) -> None:
+    custom_fields = fetch_custom_fields()
     if full:
         print(json.dumps(custom_fields, ensure_ascii=False))
     else:

--- a/src/redi/enumeration.py
+++ b/src/redi/enumeration.py
@@ -1,12 +1,18 @@
 import json
 
+from redi import cache
 from redi.client import client
 
 
 def _fetch_enumeration(resource: str) -> list[dict]:
+    cached = cache.load(resource)
+    if cached is not None:
+        return cached
     response = client.get(f"/enumerations/{resource}.json")
     response.raise_for_status()
-    return response.json()[resource]
+    data = response.json()[resource]
+    cache.save(resource, data)
+    return data
 
 
 def _list_enumeration(resource: str, full: bool = False) -> None:

--- a/src/redi/issue_status.py
+++ b/src/redi/issue_status.py
@@ -1,12 +1,20 @@
 import json
 
+from redi import cache
 from redi.client import client
+
+CACHE_KEY = "issue_statuses"
 
 
 def fetch_issue_statuses() -> list[dict]:
+    cached = cache.load(CACHE_KEY)
+    if cached is not None:
+        return cached
     response = client.get("/issue_statuses.json")
     response.raise_for_status()
-    return response.json()["issue_statuses"]
+    data = response.json()["issue_statuses"]
+    cache.save(CACHE_KEY, data)
+    return data
 
 
 def list_issue_statuses(full: bool = False) -> None:

--- a/src/redi/tracker.py
+++ b/src/redi/tracker.py
@@ -1,12 +1,20 @@
 import json
 
+from redi import cache
 from redi.client import client
+
+CACHE_KEY = "trackers"
 
 
 def fetch_trackers() -> list[dict]:
+    cached = cache.load(CACHE_KEY)
+    if cached is not None:
+        return cached
     response = client.get("/trackers.json")
     response.raise_for_status()
-    return response.json()["trackers"]
+    data = response.json()["trackers"]
+    cache.save(CACHE_KEY, data)
+    return data
 
 
 def list_trackers(full: bool = False) -> None:

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -6,6 +6,11 @@ tasks:
     cmds:
       - task --list-all --sort none
 
+  test:
+    desc: run tests
+    cmds:
+      - uv run pytest -v
+
   format:
     desc: format
     cmds:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+def pytest_itemcollected(item):
+    """テストの表示名をdocstringの日本語に差し替える"""
+    doc = item.obj.__doc__
+    if doc:
+        parent_doc = ""
+        if item.parent and hasattr(item.parent, "obj") and item.parent.obj.__doc__:
+            parent_doc = item.parent.obj.__doc__ + " > "
+        item._nodeid = f"{item.path.name}::{parent_doc}{doc}"

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,0 +1,73 @@
+import json
+import time
+
+from redi import cache
+
+
+class TestSave:
+    """save()はキャッシュディレクトリにJSONファイルを保存する"""
+
+    def test_creates_nested_directories(self, tmp_path, monkeypatch):
+        """存在しないディレクトリでも自動作成して保存できる"""
+        cache_dir = tmp_path / "nested" / "cache"
+        monkeypatch.setattr(cache, "CACHE_DIR", cache_dir)
+        cache.save("statuses", [{"id": 1}])
+        assert (cache_dir / "statuses.json").exists()
+
+    def test_overwrites_with_latest_data(self, tmp_path, monkeypatch):
+        """同じキーで上書き保存すると最新のデータに更新される"""
+        monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        cache.save("statuses", [{"id": 1, "name": "旧データ"}])
+        cache.save("statuses", [{"id": 1, "name": "新データ"}])
+        assert cache.load("statuses") == [{"id": 1, "name": "新データ"}]
+
+
+class TestLoad:
+    """load()はキャッシュファイルからデータを読み込む"""
+
+    def test_returns_saved_data(self, tmp_path, monkeypatch):
+        """保存したデータがそのまま返る"""
+        monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        data = [{"id": 1, "name": "新規"}]
+        cache.save("statuses", data)
+
+        assert cache.load("statuses") == data
+
+    def test_returns_none_for_missing_key(self, tmp_path, monkeypatch):
+        """存在しないキーを指定するとNoneが返る"""
+        monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+
+        assert cache.load("nonexistent") is None
+
+    def test_returns_none_when_expired(self, tmp_path, monkeypatch):
+        """保存時刻からTTLを過ぎるとNoneが返る"""
+        monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        data = [{"id": 1, "name": "新規"}]
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache.save("statuses", data)
+        monkeypatch.setattr(time, "time", lambda: 1100.0)  # 保存してから100秒経過
+
+        assert cache.load("statuses", ttl=50) is None
+
+    def test_returns_data_within_ttl(self, tmp_path, monkeypatch):
+        """TTL以内であればデータが返る"""
+        monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        data = [{"id": 1, "name": "新規"}]
+        monkeypatch.setattr(time, "time", lambda: 1000.0)
+        cache.save("statuses", data)
+        monkeypatch.setattr(time, "time", lambda: 1030.0)  # 保存してから30秒経過
+        assert cache.load("statuses", ttl=50) == data
+
+    def test_returns_none_for_invalid_json(self, tmp_path, monkeypatch):
+        """不正なJSONの場合Noneが返る"""
+        monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        path = tmp_path / "statuses.json"
+        path.write_text("invalid json")
+        assert cache.load("statuses") is None
+
+    def test_returns_none_for_missing_value_key(self, tmp_path, monkeypatch):
+        """valueキーが欠落したJSONの場合Noneが返る"""
+        monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        path = tmp_path / "statuses.json"
+        path.write_text(json.dumps({"timestamp": time.time()}))
+        assert cache.load("statuses") is None

--- a/uv.lock
+++ b/uv.lock
@@ -78,12 +78,48 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -96,6 +132,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -124,6 +185,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -137,7 +199,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.15.9" }]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.9" },
+]
 
 [[package]]
 name = "requests"


### PR DESCRIPTION
resolve #35 

## Summary
- `~/.cache/redi/` にAPIレスポンスをJSONキャッシュとして保存する `cache` モジュールを追加
- `issue_statuses`, `trackers`, `issue_priorities`, `time_entry_activities`, `custom_fields` のfetch関数にキャッシュを適用
- `cache.py` のユニットテストとテスト表示名を日本語にする `conftest.py` を追加

## Test plan
- [x] `task test` で全テストがパスすること
- [x] `redi issue create` などの対話的操作でキャッシュが `~/.cache/redi/` に作成されること
- [x] キャッシュ済みの状態で再度実行するとAPIリクエストが発生しないこと（`--debug` で確認）
  - TTLを10(s)して確認した