### PR TITLE
#42 TUIにissueプレビューペインを追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "questionary>=2.1.1",
     "requests>=2.33.1",
     "tomlkit>=0.14.0",
+    "wcwidth>=0.2.13",
 ]
 
 [project.scripts]

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -6,9 +6,15 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import Layout
 from prompt_toolkit.layout.containers import HSplit, VSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
+from wcwidth import wcswidth
 
 from redi.config import default_project_id
 from redi.issue import fetch_issues, read_issue
+
+
+def _pad_display(text: str, width: int) -> str:
+    padding = max(0, width - wcswidth(text))
+    return text + " " * padding
 
 
 @dataclass
@@ -64,10 +70,10 @@ def run_issue_tui() -> None:
             ("作成", issue.get("created_on") or ""),
             ("更新", issue.get("updated_on") or ""),
         ]
-        label_width = max(len(label) for label, _ in meta)
+        label_width = max(wcswidth(label) for label, _ in meta)
         for label, value in meta:
             if value:
-                lines.append(f"[{label.ljust(label_width)}] {value}")
+                lines.append(f"[{_pad_display(label, label_width)}] {value}")
 
         description = issue.get("description") or ""
         if description:

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -72,8 +72,8 @@ def run_issue_tui() -> None:
         ]
         label_width = max(wcswidth(label) for label, _ in meta)
         for label, value in meta:
-            if value:
-                lines.append(f"[{_pad_display(label, label_width)}] {value}")
+            display_value = value if value else "-"
+            lines.append(f"[{_pad_display(label, label_width)}] {display_value}")
 
         description = issue.get("description") or ""
         if description:

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -1,4 +1,5 @@
 import shutil
+import webbrowser
 from dataclasses import dataclass, field
 
 from prompt_toolkit import Application
@@ -8,7 +9,7 @@ from prompt_toolkit.layout.containers import HSplit, VSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 from wcwidth import wcswidth
 
-from redi.config import default_project_id
+from redi.config import default_project_id, redmine_url
 from redi.issue import fetch_issues, read_issue
 
 
@@ -89,7 +90,7 @@ def run_issue_tui() -> None:
             (
                 "reverse",
                 f" Page {page} (offset={state.offset})  "
-                "↑↓/jk:移動 ←→/hl:ページ Enter:表示 q:終了 ",
+                "↑↓/jk:移動 ←→/hl:ページ Enter:表示 v:web q:終了 ",
             )
         ]
 
@@ -133,6 +134,11 @@ def run_issue_tui() -> None:
     @kb.add("enter")
     def _(event):
         event.app.exit(result=str(state.issues[state.cursor]["id"]))
+
+    @kb.add("v")
+    def _(event):
+        issue_id = state.issues[state.cursor]["id"]
+        webbrowser.open(f"{redmine_url}/issues/{issue_id}")
 
     @kb.add("q")
     @kb.add("escape")

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from prompt_toolkit import Application
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import Layout
-from prompt_toolkit.layout.containers import HSplit, Window
+from prompt_toolkit.layout.containers import HSplit, VSplit, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from redi.config import default_project_id
@@ -34,6 +34,48 @@ def run_issue_tui() -> None:
             text = f"#{issue['id']} {issue['subject']}\n"
             result.append(("reverse" if i == state.cursor else "", text))
         return result
+
+    def render_preview():
+        if not state.issues:
+            return []
+        issue = state.issues[state.cursor]
+        lines = [f"#{issue.get('id', '')} {issue.get('subject', '')}", ""]
+
+        def named(field: str) -> str:
+            value = issue.get(field)
+            if isinstance(value, dict):
+                return value.get("name", "")
+            return ""
+
+        meta = [
+            ("ステータス", named("status")),
+            ("優先度", named("priority")),
+            ("トラッカー", named("tracker")),
+            ("担当者", named("assigned_to")),
+            ("作成者", named("author")),
+            ("開始日", issue.get("start_date") or ""),
+            ("期日", issue.get("due_date") or ""),
+            (
+                "進捗",
+                f"{issue['done_ratio']}%"
+                if issue.get("done_ratio") is not None
+                else "",
+            ),
+            ("作成", issue.get("created_on") or ""),
+            ("更新", issue.get("updated_on") or ""),
+        ]
+        label_width = max(len(label) for label, _ in meta)
+        for label, value in meta:
+            if value:
+                lines.append(f"[{label.ljust(label_width)}] {value}")
+
+        description = issue.get("description") or ""
+        if description:
+            lines.append("")
+            lines.append("----")
+            lines.extend(description.splitlines())
+
+        return [("", "\n".join(lines))]
 
     def render_status():
         page = state.offset // state.page_size + 1
@@ -96,7 +138,13 @@ def run_issue_tui() -> None:
         layout=Layout(
             HSplit(
                 [
-                    Window(FormattedTextControl(render_issues)),
+                    VSplit(
+                        [
+                            Window(FormattedTextControl(render_issues)),
+                            Window(width=1, char="│"),
+                            Window(FormattedTextControl(render_preview)),
+                        ]
+                    ),
                     Window(FormattedTextControl(render_status), height=1),
                 ]
             )

--- a/uv.lock
+++ b/uv.lock
@@ -181,6 +181,7 @@ dependencies = [
     { name = "questionary" },
     { name = "requests" },
     { name = "tomlkit" },
+    { name = "wcwidth" },
 ]
 
 [package.dev-dependencies]
@@ -196,6 +197,7 @@ requires-dist = [
     { name = "questionary", specifier = ">=2.1.1" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "tomlkit", specifier = ">=0.14.0" },
+    { name = "wcwidth", specifier = ">=0.2.13" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- `redi --tui` の画面を左右2カラム化し、カーソル位置issueの詳細 (ステータス / 優先度 / トラッカー / 担当者 / 作成者 / 開始日 / 期日 / 進捗 / 作成日時 / 更新日時 / description) を右ペインにプレビュー表示
- プレビューは `fetch_issues()` のレスポンスのみを利用し、カーソル移動時に追加APIコールを発生させない
- ラベル整列は `wcwidth.wcswidth` で表示幅を計算して全角/半角混在でも桁が揃うよう調整
- 値が空のフィールドも `-` をプレースホルダとして行を表示する
- `v` キーでカーソル位置issueをブラウザで開く (`webbrowser.open`) バインドを追加

closes #42 

## Test plan
- [x] `redi --tui` 起動時、左ペインにissue一覧、右ペインに詳細プレビューが表示される
- [x] `j` / `k` / `↑` / `↓` でカーソル移動するとプレビューが即座に切り替わる
- [x] `←` / `→` / `h` / `l` でページ遷移後もプレビューが先頭issueを反映する
- [x] description が無いissueでもクラッシュせず、「----」以降が省略される
- [x] 担当者/期日等が未設定のissueで該当行に `-` が表示される
- [x] 全角ラベルの桁が縦に揃って表示される
- [x] `v` キーで `{redmine_url}/issues/{id}` がデフォルトブラウザで開く
- [x] `Enter` で従来通り `read_issue` の結果が表示される
- [x] `q` / `Esc` / `Ctrl+C` で終了できる