### PR TITLE
[add] TUI で u キー押下時に issue 更新フローに入れるようにする

### DIFF
--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -1164,11 +1164,13 @@ def main() -> None:
     check_config()
 
     if args.tui and args.command is None:
+        tui_offset = 0
+        tui_cursor = 0
         while True:
-            tui_result = run_issue_tui()
+            tui_result = run_issue_tui(offset=tui_offset, cursor=tui_cursor)
             if tui_result is None:
                 return
-            action, issue_id = tui_result
+            action, issue_id, tui_offset, tui_cursor = tui_result
             if action == "view":
                 read_issue(issue_id)
                 input("Enter で TUI に戻る...")

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -71,7 +71,7 @@ from redi.wiki import (
     read_wiki,
     update_wiki,
 )
-from redi.tui import run_issue_tui
+from redi.tui import TuiPosition, run_issue_tui
 
 questionary.prompts.common.INDICATOR_SELECTED = "[x]"  # pyright: ignore[reportPrivateImportUsage]
 questionary.prompts.common.INDICATOR_UNSELECTED = "[ ]"  # pyright: ignore[reportPrivateImportUsage]
@@ -1164,14 +1164,12 @@ def main() -> None:
     check_config()
 
     if args.tui and args.command is None:
-        tui_offset = 0
-        tui_cursor = 0
+        tui_position = TuiPosition()
         while True:
-            tui_result = run_issue_tui(offset=tui_offset, cursor=tui_cursor)
+            tui_result = run_issue_tui(position=tui_position)
             if tui_result is None:
                 return
-            tui_offset = tui_result.offset
-            tui_cursor = tui_result.cursor
+            tui_position = tui_result.position
             if tui_result.action == "view":
                 read_issue(tui_result.issue_id)
                 input("Enter で TUI に戻る...")

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -1164,36 +1164,37 @@ def main() -> None:
     check_config()
 
     if args.tui and args.command is None:
-        tui_result = run_issue_tui()
-        if tui_result is None:
-            return
-        action, issue_id = tui_result
-        if action == "view":
-            read_issue(issue_id)
-        elif action == "update":
-            update_args = argparse.Namespace(
-                issue_id=issue_id,
-                subject=None,
-                description=None,
-                tracker_id=None,
-                status_id=None,
-                priority_id=None,
-                assigned_to_id=None,
-                fixed_version_id=None,
-                parent_issue_id=None,
-                notes=None,
-                custom_fields=None,
-                relate=None,
-                relate_to=None,
-                delete_relation=False,
-                attach=None,
-                hours=None,
-                activity_id=None,
-                spent_on=None,
-                time_comments=None,
-            )
-            _handle_issue_update(update_args)
-        return
+        while True:
+            tui_result = run_issue_tui()
+            if tui_result is None:
+                return
+            action, issue_id = tui_result
+            if action == "view":
+                read_issue(issue_id)
+                input("Enter で TUI に戻る...")
+            elif action == "update":
+                update_args = argparse.Namespace(
+                    issue_id=issue_id,
+                    subject=None,
+                    description=None,
+                    tracker_id=None,
+                    status_id=None,
+                    priority_id=None,
+                    assigned_to_id=None,
+                    fixed_version_id=None,
+                    parent_issue_id=None,
+                    notes=None,
+                    custom_fields=None,
+                    relate=None,
+                    relate_to=None,
+                    delete_relation=False,
+                    attach=None,
+                    hours=None,
+                    activity_id=None,
+                    spent_on=None,
+                    time_comments=None,
+                )
+                _handle_issue_update(update_args)
 
     if args.command in ("project", "p"):
         _handle_project(args)

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -1170,13 +1170,14 @@ def main() -> None:
             tui_result = run_issue_tui(offset=tui_offset, cursor=tui_cursor)
             if tui_result is None:
                 return
-            action, issue_id, tui_offset, tui_cursor = tui_result
-            if action == "view":
-                read_issue(issue_id)
+            tui_offset = tui_result.offset
+            tui_cursor = tui_result.cursor
+            if tui_result.action == "view":
+                read_issue(tui_result.issue_id)
                 input("Enter で TUI に戻る...")
-            elif action == "update":
+            elif tui_result.action == "update":
                 update_args = argparse.Namespace(
-                    issue_id=issue_id,
+                    issue_id=tui_result.issue_id,
                     subject=None,
                     description=None,
                     tracker_id=None,

--- a/src/redi/cli.py
+++ b/src/redi/cli.py
@@ -1164,7 +1164,35 @@ def main() -> None:
     check_config()
 
     if args.tui and args.command is None:
-        run_issue_tui()
+        tui_result = run_issue_tui()
+        if tui_result is None:
+            return
+        action, issue_id = tui_result
+        if action == "view":
+            read_issue(issue_id)
+        elif action == "update":
+            update_args = argparse.Namespace(
+                issue_id=issue_id,
+                subject=None,
+                description=None,
+                tracker_id=None,
+                status_id=None,
+                priority_id=None,
+                assigned_to_id=None,
+                fixed_version_id=None,
+                parent_issue_id=None,
+                notes=None,
+                custom_fields=None,
+                relate=None,
+                relate_to=None,
+                delete_relation=False,
+                attach=None,
+                hours=None,
+                activity_id=None,
+                spent_on=None,
+                time_comments=None,
+            )
+            _handle_issue_update(update_args)
         return
 
     if args.command in ("project", "p"):

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -10,7 +10,7 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from wcwidth import wcswidth
 
 from redi.config import default_project_id, redmine_url
-from redi.issue import fetch_issues, read_issue
+from redi.issue import fetch_issues
 
 
 def _pad_display(text: str, width: int) -> str:
@@ -26,14 +26,14 @@ class TuiState:
     issues: list[dict] = field(default_factory=list)
 
 
-def run_issue_tui() -> None:
+def run_issue_tui() -> tuple[str, str] | None:
     state = TuiState(page_size=max(1, shutil.get_terminal_size().lines - 1))
     state.issues = fetch_issues(
         project_id=default_project_id, limit=state.page_size, offset=state.offset
     )
     if not state.issues:
         print("イシューが見つかりません")
-        return
+        return None
 
     def render_issues():
         result = []
@@ -90,7 +90,7 @@ def run_issue_tui() -> None:
             (
                 "reverse",
                 f" Page {page} (offset={state.offset})  "
-                "↑↓/jk:移動 ←→/hl:ページ Enter:表示 v:web q:終了 ",
+                "↑↓/jk:移動 ←→/hl:ページ Enter:表示 u:更新 v:web q:終了 ",
             )
         ]
 
@@ -133,7 +133,11 @@ def run_issue_tui() -> None:
 
     @kb.add("enter")
     def _(event):
-        event.app.exit(result=str(state.issues[state.cursor]["id"]))
+        event.app.exit(result=("view", str(state.issues[state.cursor]["id"])))
+
+    @kb.add("u")
+    def _(event):
+        event.app.exit(result=("update", str(state.issues[state.cursor]["id"])))
 
     @kb.add("v")
     def _(event):
@@ -164,6 +168,4 @@ def run_issue_tui() -> None:
         key_bindings=kb,
         full_screen=True,
     )
-    result = app.run()
-    if result is not None:
-        read_issue(result)
+    return app.run()

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -26,14 +26,16 @@ class TuiState:
     issues: list[dict] = field(default_factory=list)
 
 
-def run_issue_tui() -> tuple[str, str] | None:
+def run_issue_tui(offset: int = 0, cursor: int = 0) -> tuple[str, str, int, int] | None:
     state = TuiState(page_size=max(1, shutil.get_terminal_size().lines - 1))
+    state.offset = offset
     state.issues = fetch_issues(
         project_id=default_project_id, limit=state.page_size, offset=state.offset
     )
     if not state.issues:
         print("イシューが見つかりません")
         return None
+    state.cursor = max(0, min(cursor, len(state.issues) - 1))
 
     def render_issues():
         result = []
@@ -133,11 +135,25 @@ def run_issue_tui() -> tuple[str, str] | None:
 
     @kb.add("enter")
     def _(event):
-        event.app.exit(result=("view", str(state.issues[state.cursor]["id"])))
+        event.app.exit(
+            result=(
+                "view",
+                str(state.issues[state.cursor]["id"]),
+                state.offset,
+                state.cursor,
+            )
+        )
 
     @kb.add("u")
     def _(event):
-        event.app.exit(result=("update", str(state.issues[state.cursor]["id"])))
+        event.app.exit(
+            result=(
+                "update",
+                str(state.issues[state.cursor]["id"]),
+                state.offset,
+                state.cursor,
+            )
+        )
 
     @kb.add("v")
     def _(event):

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -31,23 +31,30 @@ TuiAction = Literal["view", "update"]
 
 
 @dataclass
+class TuiPosition:
+    offset: int = 0
+    cursor: int = 0
+
+
+@dataclass
 class TuiResult:
     action: TuiAction
     issue_id: str
-    offset: int
-    cursor: int
+    position: TuiPosition
 
 
-def run_issue_tui(offset: int = 0, cursor: int = 0) -> TuiResult | None:
+def run_issue_tui(position: TuiPosition | None = None) -> TuiResult | None:
+    if position is None:
+        position = TuiPosition()
     state = TuiState(page_size=max(1, shutil.get_terminal_size().lines - 1))
-    state.offset = offset
+    state.offset = position.offset
     state.issues = fetch_issues(
         project_id=default_project_id, limit=state.page_size, offset=state.offset
     )
     if not state.issues:
         print("イシューが見つかりません")
         return None
-    state.cursor = max(0, min(cursor, len(state.issues) - 1))
+    state.cursor = max(0, min(position.cursor, len(state.issues) - 1))
 
     def render_issues():
         result = []
@@ -152,8 +159,7 @@ def run_issue_tui(offset: int = 0, cursor: int = 0) -> TuiResult | None:
         return TuiResult(
             action=action,
             issue_id=str(state.issues[state.cursor]["id"]),
-            offset=state.offset,
-            cursor=state.cursor,
+            position=TuiPosition(offset=state.offset, cursor=state.cursor),
         )
 
     @kb.add("enter")

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -1,6 +1,7 @@
 import shutil
 import webbrowser
 from dataclasses import dataclass, field
+from typing import Literal
 
 from prompt_toolkit import Application
 from prompt_toolkit.key_binding import KeyBindings
@@ -26,7 +27,18 @@ class TuiState:
     issues: list[dict] = field(default_factory=list)
 
 
-def run_issue_tui(offset: int = 0, cursor: int = 0) -> tuple[str, str, int, int] | None:
+TuiAction = Literal["view", "update"]
+
+
+@dataclass
+class TuiResult:
+    action: TuiAction
+    issue_id: str
+    offset: int
+    cursor: int
+
+
+def run_issue_tui(offset: int = 0, cursor: int = 0) -> TuiResult | None:
     state = TuiState(page_size=max(1, shutil.get_terminal_size().lines - 1))
     state.offset = offset
     state.issues = fetch_issues(
@@ -133,27 +145,21 @@ def run_issue_tui(offset: int = 0, cursor: int = 0) -> tuple[str, str, int, int]
             )
             state.cursor = 0
 
+    def _exit_with(action: TuiAction):
+        return TuiResult(
+            action=action,
+            issue_id=str(state.issues[state.cursor]["id"]),
+            offset=state.offset,
+            cursor=state.cursor,
+        )
+
     @kb.add("enter")
     def _(event):
-        event.app.exit(
-            result=(
-                "view",
-                str(state.issues[state.cursor]["id"]),
-                state.offset,
-                state.cursor,
-            )
-        )
+        event.app.exit(result=_exit_with("view"))
 
     @kb.add("u")
     def _(event):
-        event.app.exit(
-            result=(
-                "update",
-                str(state.issues[state.cursor]["id"]),
-                state.offset,
-                state.cursor,
-            )
-        )
+        event.app.exit(result=_exit_with("update"))
 
     @kb.add("v")
     def _(event):

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -146,6 +146,9 @@ def run_issue_tui(offset: int = 0, cursor: int = 0) -> TuiResult | None:
             state.cursor = 0
 
     def _exit_with(action: TuiAction):
+        """
+        直前の位置を引き継いでTUIのアクションを返す
+        """
         return TuiResult(
             action=action,
             issue_id=str(state.issues[state.cursor]["id"]),


### PR DESCRIPTION
resolve #43 

## Summary
- `redi --tui` の issue 一覧でカーソル位置の issue に対して `u` キー押下時に対話更新フロー (既存 `_handle_issue_update` / `_interactive_fill_issue_update_args`) に入れるようにした
- `run_issue_tui()` の戻り値を `(action, issue_id)` のタプルに変更し、`main()` 側で `view`/`update` のアクションに応じて分岐するように責務を整理 (view は従来どおり `read_issue` を呼ぶ)
- ステータスバーのヘルプに `u:更新` を追記

## Test plan
- [x] `redi --tui` 起動後、Enter で従来どおり CLI 詳細表示になること
- [x] `redi --tui` 起動後、`u` で questionary の更新フィールド選択に入り、実際にチケットが更新されること
- [x] `v` で従来どおりブラウザで Redmine issue が開くこと
- [x] `q` / `Esc` / `C-c` で従来どおり即終了できること
- [x] `task check` (format + lint + test) が通ること