### PR TITLE
version update を対話的に実行できるようにした (refs #51 )

### DIFF
--- a/src/redi/api/version.py
+++ b/src/redi/api/version.py
@@ -72,7 +72,7 @@ def update_version(
         print(e.response.text)
         print("バージョンの更新に失敗しました")
         exit(1)
-    print(f"バージョンを更新しました: {version_id}")
+    print(f"バージョンを更新しました: {version_id} {redmine_url}/versions/{version_id}")
 
 
 def fetch_version(version_id: str) -> dict:

--- a/src/redi/api/version.py
+++ b/src/redi/api/version.py
@@ -75,18 +75,22 @@ def update_version(
     print(f"バージョンを更新しました: {version_id}")
 
 
+def fetch_version(version_id: str) -> dict:
+    response = client.get(f"/versions/{version_id}.json")
+    if response.status_code == 404:
+        print(f"バージョンが見つかりません: {version_id}")
+        exit(1)
+    response.raise_for_status()
+    return response.json()["version"]
+
+
 def read_version(version_id: str, full: bool = False, web: bool = False) -> None:
     if web:
         url = f"{redmine_url}/versions/{version_id}"
         print(url)
         webbrowser.open(url)
         return
-    response = client.get(f"/versions/{version_id}.json")
-    if response.status_code == 404:
-        print(f"バージョンが見つかりません: {version_id}")
-        exit(1)
-    response.raise_for_status()
-    version = response.json()["version"]
+    version = fetch_version(version_id)
     if full:
         print(json.dumps(version, ensure_ascii=False))
         return

--- a/src/redi/api/version.py
+++ b/src/redi/api/version.py
@@ -53,9 +53,9 @@ def update_version(
         version_data["name"] = name
     if status:
         version_data["status"] = status
-    if due_date:
+    if due_date is not None:
         version_data["due_date"] = due_date
-    if description:
+    if description is not None:
         version_data["description"] = description
     if sharing:
         version_data["sharing"] = sharing

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -4,6 +4,10 @@ import tempfile
 
 import questionary
 import questionary.prompts.common
+from prompt_toolkit import Application
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.layout import HSplit, Layout, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
 
 from redi.config import editor
 
@@ -23,6 +27,70 @@ def resolve_alias(command: str | None) -> str | None:
     if command is None:
         return None
     return SUBCOMMAND_ALIASES.get(command, command)
+
+
+def inline_choice(
+    message: str,
+    options: list[tuple[str, str]],
+    default: str | None = None,
+) -> str:
+    keys = [v for v, _ in options]
+    cursor = keys.index(default) if default in keys else 0
+
+    def render():
+        fragments: list[tuple[str, str]] = []
+        for i, (_, label) in enumerate(options):
+            prefix = "> " if i == cursor else "  "
+            fragments.append(("", f"{prefix}{label}\n"))
+        return fragments
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    @kb.add("c-p")
+    @kb.add("k")
+    def _up(event):
+        nonlocal cursor
+        cursor = max(0, cursor - 1)
+
+    @kb.add("down")
+    @kb.add("c-n")
+    @kb.add("j")
+    def _down(event):
+        nonlocal cursor
+        cursor = min(len(options) - 1, cursor + 1)
+
+    @kb.add("enter")
+    def _accept(event):
+        event.app.exit(result=options[cursor][0])
+
+    @kb.add("c-c")
+    def _cancel(event):
+        event.app.exit(exception=KeyboardInterrupt())
+
+    layout = Layout(
+        HSplit(
+            [
+                Window(
+                    FormattedTextControl(message),
+                    dont_extend_height=True,
+                    height=1,
+                ),
+                Window(
+                    FormattedTextControl(render, focusable=True, show_cursor=False),
+                    dont_extend_height=True,
+                ),
+            ]
+        ),
+    )
+    app: Application[str] = Application(
+        layout=layout,
+        key_bindings=kb,
+        full_screen=False,
+        # 描画した選択候補一覧を選択後に消去
+        erase_when_done=True,
+    )
+    return app.run()
 
 
 def open_editor(initial_text: str = "") -> str:

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -29,6 +29,81 @@ def resolve_alias(command: str | None) -> str | None:
     return SUBCOMMAND_ALIASES.get(command, command)
 
 
+def inline_checkbox(
+    message: str,
+    values: list[tuple[str, str]],
+) -> list[str]:
+    cursor = 0
+    checked: set[str] = set()
+
+    def render():
+        fragments = []
+        for i, (value, label) in enumerate(values):
+            is_checked = value in checked
+            mark = "[x]" if is_checked else "[ ]"
+            prefix = "> " if i == cursor else "  "
+            mark_style = "ansigreen" if is_checked else ""
+            fragments.append(("", prefix))
+            fragments.append((mark_style, mark))
+            fragments.append(("", f" {label}\n"))
+        return fragments
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    @kb.add("c-p")
+    @kb.add("k")
+    def _up(event):
+        nonlocal cursor
+        cursor = max(0, cursor - 1)
+
+    @kb.add("down")
+    @kb.add("c-n")
+    @kb.add("j")
+    def _down(event):
+        nonlocal cursor
+        cursor = min(len(values) - 1, cursor + 1)
+
+    @kb.add(" ")
+    def _toggle(event):
+        value = values[cursor][0]
+        if value in checked:
+            checked.remove(value)
+        else:
+            checked.add(value)
+
+    @kb.add("enter")
+    def _accept(event):
+        event.app.exit(result=[v for v, _ in values if v in checked])
+
+    @kb.add("c-c")
+    def _cancel(event):
+        event.app.exit(exception=KeyboardInterrupt())
+
+    layout = Layout(
+        HSplit(
+            [
+                Window(
+                    FormattedTextControl(message),
+                    dont_extend_height=True,
+                    height=1,
+                ),
+                Window(
+                    FormattedTextControl(render, focusable=True, show_cursor=False),
+                    dont_extend_height=True,
+                ),
+            ]
+        ),
+    )
+    app: Application[list[str]] = Application(
+        layout=layout,
+        key_bindings=kb,
+        full_screen=False,
+        erase_when_done=True,
+    )
+    return app.run()
+
+
 def inline_choice(
     message: str,
     options: list[tuple[str, str]],

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -145,18 +145,68 @@ def _inline_checkbox(
     return app.run()
 
 
-def _make_choice_key_bindings() -> KeyBindings:
+def _inline_choice(
+    message: str,
+    options: list[tuple[str, str]],
+    default: str | None = None,
+) -> str:
+    keys = [v for v, _ in options]
+    cursor = keys.index(default) if default in keys else 0
+
+    def render():
+        fragments: list[tuple[str, str]] = []
+        for i, (_, label) in enumerate(options):
+            prefix = "> " if i == cursor else "  "
+            fragments.append(("", f"{prefix}{label}\n"))
+        return fragments
+
     kb = KeyBindings()
 
+    @kb.add("up")
     @kb.add("c-p")
-    def _move_up(event):
-        event.app.key_processor.feed(KeyPress(Keys.Up))
+    @kb.add("k")
+    def _up(event):
+        nonlocal cursor
+        cursor = max(0, cursor - 1)
 
+    @kb.add("down")
     @kb.add("c-n")
-    def _move_down(event):
-        event.app.key_processor.feed(KeyPress(Keys.Down))
+    @kb.add("j")
+    def _down(event):
+        nonlocal cursor
+        cursor = min(len(options) - 1, cursor + 1)
 
-    return kb
+    @kb.add("enter")
+    def _accept(event):
+        event.app.exit(result=options[cursor][0])
+
+    @kb.add("c-c")
+    def _cancel(event):
+        event.app.exit(exception=KeyboardInterrupt())
+
+    layout = Layout(
+        HSplit(
+            [
+                Window(
+                    FormattedTextControl(message),
+                    dont_extend_height=True,
+                    height=1,
+                ),
+                Window(
+                    FormattedTextControl(render, focusable=True, show_cursor=False),
+                    dont_extend_height=True,
+                ),
+            ]
+        ),
+    )
+    app: Application[str] = Application(
+        layout=layout,
+        key_bindings=kb,
+        full_screen=False,
+        # 描画した選択候補一覧を選択後に消去
+        erase_when_done=True,
+    )
+    return app.run()
 
 
 def _interactive_select_version_id(project_id: str) -> str:
@@ -167,15 +217,14 @@ def _interactive_select_version_id(project_id: str) -> str:
     options: list[tuple[str, str]] = [
         (str(v["id"]), f"{v['id']} {v['name']} ({v['status']})") for v in versions
     ]
+    labels = dict(options)
     try:
-        return choice(
-            "更新するバージョンを選択",
-            options=options,
-            key_bindings=_make_choice_key_bindings(),
-        )
+        selected = _inline_choice("更新するバージョンを選択", options)
     except KeyboardInterrupt:
         print("キャンセルしました")
         exit(1)
+    print(f"更新するバージョン: {labels[selected]}")
+    return selected
 
 
 def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
@@ -209,12 +258,12 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
                 ("locked", "locked"),
                 ("closed", "closed"),
             ]
-            args.status = choice(
+            args.status = _inline_choice(
                 "ステータス",
-                options=status_options,
+                status_options,
                 default=current.get("status") or "open",
-                key_bindings=_make_choice_key_bindings(),
             )
+            print(f"ステータス: {args.status}")
 
         if "due_date" in selected:
             args.due_date = prompt(
@@ -234,12 +283,12 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
                 ("tree", "tree"),
                 ("system", "system"),
             ]
-            args.sharing = choice(
+            args.sharing = _inline_choice(
                 "共有設定",
-                options=sharing_options,
+                sharing_options,
                 default=current.get("sharing") or "none",
-                key_bindings=_make_choice_key_bindings(),
             )
+            print(f"共有設定: {args.sharing}")
     except (KeyboardInterrupt, EOFError):
         print("キャンセルしました")
         exit(1)

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -1,9 +1,11 @@
 import argparse
 
-from prompt_toolkit import prompt
+from prompt_toolkit import Application, prompt
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPress
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.layout import HSplit, Layout, Window
+from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.shortcuts import choice
 from prompt_toolkit.validation import Validator
 
@@ -68,6 +70,78 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+def _inline_checkbox(
+    message: str,
+    values: list[tuple[str, str]],
+) -> list[str]:
+    cursor = 0
+    checked: set[str] = set()
+
+    def render():
+        lines = []
+        for i, (value, label) in enumerate(values):
+            mark = "[x]" if value in checked else "[ ]"
+            prefix = "> " if i == cursor else "  "
+            style = "reverse" if i == cursor else ""
+            lines.append((style, f"{prefix}{mark} {label}\n"))
+        return lines
+
+    kb = KeyBindings()
+
+    @kb.add("up")
+    @kb.add("c-p")
+    @kb.add("k")
+    def _up(event):
+        nonlocal cursor
+        cursor = max(0, cursor - 1)
+
+    @kb.add("down")
+    @kb.add("c-n")
+    @kb.add("j")
+    def _down(event):
+        nonlocal cursor
+        cursor = min(len(values) - 1, cursor + 1)
+
+    @kb.add(" ")
+    def _toggle(event):
+        value = values[cursor][0]
+        if value in checked:
+            checked.remove(value)
+        else:
+            checked.add(value)
+
+    @kb.add("enter")
+    def _accept(event):
+        event.app.exit(result=[v for v, _ in values if v in checked])
+
+    @kb.add("c-c")
+    def _cancel(event):
+        event.app.exit(exception=KeyboardInterrupt())
+
+    layout = Layout(
+        HSplit(
+            [
+                Window(
+                    FormattedTextControl(message),
+                    dont_extend_height=True,
+                    height=1,
+                ),
+                Window(
+                    FormattedTextControl(render, focusable=True),
+                    dont_extend_height=True,
+                ),
+            ]
+        ),
+    )
+    app: Application[list[str]] = Application(
+        layout=layout,
+        key_bindings=kb,
+        full_screen=False,
+        erase_when_done=True,
+    )
+    return app.run()
+
+
 def _make_choice_key_bindings() -> KeyBindings:
     kb = KeyBindings()
 
@@ -103,57 +177,66 @@ def _interactive_select_version_id(project_id: str) -> str:
 
 def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
     current = fetch_version(args.version_id)
-    skip_label = "変更しない"
+    field_values: list[tuple[str, str]] = [
+        ("name", "バージョン名 (name)"),
+        ("status", "ステータス (status)"),
+        ("due_date", "期日 (due_date)"),
+        ("description", "説明 (description)"),
+        ("sharing", "共有設定 (sharing)"),
+    ]
     try:
-        name = prompt(
-            f"バージョン名（現在: {current.get('name') or '未設定'}、空で変更しない）: "
-        ).strip()
-        if name:
-            args.name = name
-
-        status_options: list[tuple[str | None, str]] = [
-            (None, skip_label),
-            ("open", "open"),
-            ("locked", "locked"),
-            ("closed", "closed"),
-        ]
-        status = choice(
-            f"ステータス（現在: {current.get('status') or '未設定'}）",
-            options=status_options,
-            default=None,
-            key_bindings=_make_choice_key_bindings(),
+        selected = _inline_checkbox(
+            "更新する項目を選択 (Spaceで選択、Enterで確定)", field_values
         )
-        if status:
-            args.status = status
+    except KeyboardInterrupt:
+        print("キャンセルしました")
+        exit(1)
+    if not selected:
+        print("更新する項目が選択されていないためキャンセルしました")
+        exit(1)
+    try:
+        if "name" in selected:
+            args.name = prompt(
+                "バージョン名: ", default=current.get("name") or ""
+            ).strip()
 
-        due_date = prompt(
-            f"期日（現在: {current.get('due_date') or '未設定'}、YYYY-MM-DD、空で変更しない）: "
-        ).strip()
-        if due_date:
-            args.due_date = due_date
+        if "status" in selected:
+            status_options: list[tuple[str, str]] = [
+                ("open", "open"),
+                ("locked", "locked"),
+                ("closed", "closed"),
+            ]
+            args.status = choice(
+                "ステータス",
+                options=status_options,
+                default=current.get("status") or "open",
+                key_bindings=_make_choice_key_bindings(),
+            )
 
-        description = prompt(
-            f"説明（現在: {current.get('description') or '未設定'}、空で変更しない）: "
-        ).strip()
-        if description:
-            args.description = description
+        if "due_date" in selected:
+            args.due_date = prompt(
+                "期日（YYYY-MM-DD）: ", default=current.get("due_date") or ""
+            ).strip()
 
-        sharing_options: list[tuple[str | None, str]] = [
-            (None, skip_label),
-            ("none", "none"),
-            ("descendants", "descendants"),
-            ("hierarchy", "hierarchy"),
-            ("tree", "tree"),
-            ("system", "system"),
-        ]
-        sharing = choice(
-            f"共有設定（現在: {current.get('sharing') or '未設定'}）",
-            options=sharing_options,
-            default=None,
-            key_bindings=_make_choice_key_bindings(),
-        )
-        if sharing:
-            args.sharing = sharing
+        if "description" in selected:
+            args.description = prompt(
+                "説明: ", default=current.get("description") or ""
+            ).strip()
+
+        if "sharing" in selected:
+            sharing_options: list[tuple[str, str]] = [
+                ("none", "none"),
+                ("descendants", "descendants"),
+                ("hierarchy", "hierarchy"),
+                ("tree", "tree"),
+                ("system", "system"),
+            ]
+            args.sharing = choice(
+                "共有設定",
+                options=sharing_options,
+                default=current.get("sharing") or "none",
+                key_bindings=_make_choice_key_bindings(),
+            )
     except (KeyboardInterrupt, EOFError):
         print("キャンセルしました")
         exit(1)

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -246,6 +246,8 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
     if not selected:
         print("更新する項目が選択されていないためキャンセルしました")
         exit(1)
+    labels = dict(field_values)
+    print(f"更新する項目: {', '.join(labels[v] for v in selected)}")
     try:
         if "name" in selected:
             args.name = prompt(

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -1,15 +1,13 @@
 import argparse
 
-from prompt_toolkit import Application, prompt
+from prompt_toolkit import prompt
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.key_binding.key_processor import KeyPress
 from prompt_toolkit.keys import Keys
-from prompt_toolkit.layout import HSplit, Layout, Window
-from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.shortcuts import choice
 from prompt_toolkit.validation import Validator
 
-from redi.cli._common import inline_choice, resolve_alias
+from redi.cli._common import inline_checkbox, inline_choice, resolve_alias
 from redi.config import default_project_id
 from redi.api.version import (
     create_version,
@@ -70,81 +68,6 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _inline_checkbox(
-    message: str,
-    values: list[tuple[str, str]],
-) -> list[str]:
-    cursor = 0
-    checked: set[str] = set()
-
-    def render():
-        fragments = []
-        for i, (value, label) in enumerate(values):
-            is_checked = value in checked
-            mark = "[x]" if is_checked else "[ ]"
-            prefix = "> " if i == cursor else "  "
-            mark_style = "ansigreen" if is_checked else ""
-            fragments.append(("", prefix))
-            fragments.append((mark_style, mark))
-            fragments.append(("", f" {label}\n"))
-        return fragments
-
-    kb = KeyBindings()
-
-    @kb.add("up")
-    @kb.add("c-p")
-    @kb.add("k")
-    def _up(event):
-        nonlocal cursor
-        cursor = max(0, cursor - 1)
-
-    @kb.add("down")
-    @kb.add("c-n")
-    @kb.add("j")
-    def _down(event):
-        nonlocal cursor
-        cursor = min(len(values) - 1, cursor + 1)
-
-    @kb.add(" ")
-    def _toggle(event):
-        value = values[cursor][0]
-        if value in checked:
-            checked.remove(value)
-        else:
-            checked.add(value)
-
-    @kb.add("enter")
-    def _accept(event):
-        event.app.exit(result=[v for v, _ in values if v in checked])
-
-    @kb.add("c-c")
-    def _cancel(event):
-        event.app.exit(exception=KeyboardInterrupt())
-
-    layout = Layout(
-        HSplit(
-            [
-                Window(
-                    FormattedTextControl(message),
-                    dont_extend_height=True,
-                    height=1,
-                ),
-                Window(
-                    FormattedTextControl(render, focusable=True, show_cursor=False),
-                    dont_extend_height=True,
-                ),
-            ]
-        ),
-    )
-    app: Application[list[str]] = Application(
-        layout=layout,
-        key_bindings=kb,
-        full_screen=False,
-        erase_when_done=True,
-    )
-    return app.run()
-
-
 def _interactive_select_version_id(project_id: str) -> str:
     versions = fetch_versions(project_id)
     if not versions:
@@ -173,7 +96,7 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
         ("sharing", "共有設定 (sharing)"),
     ]
     try:
-        selected = _inline_checkbox(
+        selected = inline_checkbox(
             "更新する項目を選択 (Spaceで選択、Enterで確定)", field_values
         )
     except KeyboardInterrupt:

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -78,13 +78,16 @@ def _inline_checkbox(
     checked: set[str] = set()
 
     def render():
-        lines = []
+        fragments = []
         for i, (value, label) in enumerate(values):
-            mark = "[x]" if value in checked else "[ ]"
+            is_checked = value in checked
+            mark = "[x]" if is_checked else "[ ]"
             prefix = "> " if i == cursor else "  "
-            style = "reverse" if i == cursor else ""
-            lines.append((style, f"{prefix}{mark} {label}\n"))
-        return lines
+            mark_style = "ansigreen" if is_checked else ""
+            fragments.append(("", prefix))
+            fragments.append((mark_style, mark))
+            fragments.append(("", f" {label}\n"))
+        return fragments
 
     kb = KeyBindings()
 

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -9,7 +9,14 @@ from prompt_toolkit.validation import Validator
 
 from redi.cli._common import resolve_alias
 from redi.config import default_project_id
-from redi.api.version import create_version, list_versions, read_version, update_version
+from redi.api.version import (
+    create_version,
+    fetch_version,
+    fetch_versions,
+    list_versions,
+    read_version,
+    update_version,
+)
 
 
 def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -45,7 +52,9 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
     v_update_parser = v_subparsers.add_parser(
         "update", aliases=["u"], help="バージョン更新"
     )
-    v_update_parser.add_argument("version_id", help="バージョンID")
+    v_update_parser.add_argument(
+        "version_id", nargs="?", help="バージョンID（省略で対話的に選択）"
+    )
     v_update_parser.add_argument("--name", "-n", help="バージョン名")
     v_update_parser.add_argument(
         "--status", choices=["open", "locked", "closed"], help="ステータス"
@@ -57,6 +66,97 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
         choices=["none", "descendants", "hierarchy", "tree", "system"],
         help="共有設定",
     )
+
+
+def _make_choice_key_bindings() -> KeyBindings:
+    kb = KeyBindings()
+
+    @kb.add("c-p")
+    def _move_up(event):
+        event.app.key_processor.feed(KeyPress(Keys.Up))
+
+    @kb.add("c-n")
+    def _move_down(event):
+        event.app.key_processor.feed(KeyPress(Keys.Down))
+
+    return kb
+
+
+def _interactive_select_version_id(project_id: str) -> str:
+    versions = fetch_versions(project_id)
+    if not versions:
+        print("選択可能なバージョンがありません")
+        exit(1)
+    options: list[tuple[str, str]] = [
+        (str(v["id"]), f"{v['id']} {v['name']} ({v['status']})") for v in versions
+    ]
+    try:
+        return choice(
+            "更新するバージョンを選択",
+            options=options,
+            key_bindings=_make_choice_key_bindings(),
+        )
+    except KeyboardInterrupt:
+        print("キャンセルしました")
+        exit(1)
+
+
+def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
+    current = fetch_version(args.version_id)
+    skip_label = "変更しない"
+    try:
+        name = prompt(
+            f"バージョン名（現在: {current.get('name') or '未設定'}、空で変更しない）: "
+        ).strip()
+        if name:
+            args.name = name
+
+        status_options: list[tuple[str | None, str]] = [
+            (None, skip_label),
+            ("open", "open"),
+            ("locked", "locked"),
+            ("closed", "closed"),
+        ]
+        status = choice(
+            f"ステータス（現在: {current.get('status') or '未設定'}）",
+            options=status_options,
+            default=None,
+            key_bindings=_make_choice_key_bindings(),
+        )
+        if status:
+            args.status = status
+
+        due_date = prompt(
+            f"期日（現在: {current.get('due_date') or '未設定'}、YYYY-MM-DD、空で変更しない）: "
+        ).strip()
+        if due_date:
+            args.due_date = due_date
+
+        description = prompt(
+            f"説明（現在: {current.get('description') or '未設定'}、空で変更しない）: "
+        ).strip()
+        if description:
+            args.description = description
+
+        sharing_options: list[tuple[str | None, str]] = [
+            (None, skip_label),
+            ("none", "none"),
+            ("descendants", "descendants"),
+            ("hierarchy", "hierarchy"),
+            ("tree", "tree"),
+            ("system", "system"),
+        ]
+        sharing = choice(
+            f"共有設定（現在: {current.get('sharing') or '未設定'}）",
+            options=sharing_options,
+            default=None,
+            key_bindings=_make_choice_key_bindings(),
+        )
+        if sharing:
+            args.sharing = sharing
+    except (KeyboardInterrupt, EOFError):
+        print("キャンセルしました")
+        exit(1)
 
 
 def _interactive_create_version(project_id: str, args: argparse.Namespace) -> None:
@@ -141,6 +241,21 @@ def handle_version(args: argparse.Namespace) -> None:
                 sharing=args.sharing,
             )
     elif cmd == "update":
+        if not args.version_id:
+            project_id = args.project_id or default_project_id
+            if not project_id:
+                print("project_idを指定するか、default_project_idを設定してください")
+                exit(1)
+            args.version_id = _interactive_select_version_id(project_id)
+        no_args_provided = not (
+            args.name
+            or args.status
+            or args.due_date
+            or args.description
+            or args.sharing
+        )
+        if no_args_provided:
+            _interactive_fill_version_update_args(args)
         update_version(
             version_id=args.version_id,
             name=args.name,

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -127,7 +127,7 @@ def _inline_checkbox(
                     height=1,
                 ),
                 Window(
-                    FormattedTextControl(render, focusable=True),
+                    FormattedTextControl(render, focusable=True, show_cursor=False),
                     dont_extend_height=True,
                 ),
             ]

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -110,7 +110,7 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
     try:
         if "name" in selected:
             args.name = prompt(
-                "バージョン名: ", default=current.get("name") or ""
+                "バージョン名: ", default=current.get("name", "")
             ).strip()
 
         if "status" in selected:
@@ -120,20 +120,18 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
                 ("closed", "closed"),
             ]
             args.status = inline_choice(
-                "ステータス",
-                status_options,
-                default=current.get("status") or "open",
+                "ステータス", status_options, default=current.get("status", "open")
             )
             print(f"ステータス: {args.status}")
 
         if "due_date" in selected:
             args.due_date = prompt(
-                "期日（YYYY-MM-DD）: ", default=current.get("due_date") or ""
+                "期日（YYYY-MM-DD）: ", default=current.get("due_date", "")
             ).strip()
 
         if "description" in selected:
             args.description = prompt(
-                "説明: ", default=current.get("description") or ""
+                "説明: ", default=current.get("description", "")
             ).strip()
 
         if "sharing" in selected:
@@ -147,7 +145,7 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
             args.sharing = inline_choice(
                 "共有設定",
                 sharing_options,
-                default=current.get("sharing") or "none",
+                default=current.get("sharing", "none"),
             )
             print(f"共有設定: {args.sharing}")
     except (KeyboardInterrupt, EOFError):

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -9,7 +9,7 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.shortcuts import choice
 from prompt_toolkit.validation import Validator
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import inline_choice, resolve_alias
 from redi.config import default_project_id
 from redi.api.version import (
     create_version,
@@ -145,70 +145,6 @@ def _inline_checkbox(
     return app.run()
 
 
-def _inline_choice(
-    message: str,
-    options: list[tuple[str, str]],
-    default: str | None = None,
-) -> str:
-    keys = [v for v, _ in options]
-    cursor = keys.index(default) if default in keys else 0
-
-    def render():
-        fragments: list[tuple[str, str]] = []
-        for i, (_, label) in enumerate(options):
-            prefix = "> " if i == cursor else "  "
-            fragments.append(("", f"{prefix}{label}\n"))
-        return fragments
-
-    kb = KeyBindings()
-
-    @kb.add("up")
-    @kb.add("c-p")
-    @kb.add("k")
-    def _up(event):
-        nonlocal cursor
-        cursor = max(0, cursor - 1)
-
-    @kb.add("down")
-    @kb.add("c-n")
-    @kb.add("j")
-    def _down(event):
-        nonlocal cursor
-        cursor = min(len(options) - 1, cursor + 1)
-
-    @kb.add("enter")
-    def _accept(event):
-        event.app.exit(result=options[cursor][0])
-
-    @kb.add("c-c")
-    def _cancel(event):
-        event.app.exit(exception=KeyboardInterrupt())
-
-    layout = Layout(
-        HSplit(
-            [
-                Window(
-                    FormattedTextControl(message),
-                    dont_extend_height=True,
-                    height=1,
-                ),
-                Window(
-                    FormattedTextControl(render, focusable=True, show_cursor=False),
-                    dont_extend_height=True,
-                ),
-            ]
-        ),
-    )
-    app: Application[str] = Application(
-        layout=layout,
-        key_bindings=kb,
-        full_screen=False,
-        # 描画した選択候補一覧を選択後に消去
-        erase_when_done=True,
-    )
-    return app.run()
-
-
 def _interactive_select_version_id(project_id: str) -> str:
     versions = fetch_versions(project_id)
     if not versions:
@@ -219,7 +155,7 @@ def _interactive_select_version_id(project_id: str) -> str:
     ]
     labels = dict(options)
     try:
-        selected = _inline_choice("更新するバージョンを選択", options)
+        selected = inline_choice("更新するバージョンを選択", options)
     except KeyboardInterrupt:
         print("キャンセルしました")
         exit(1)
@@ -260,7 +196,7 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
                 ("locked", "locked"),
                 ("closed", "closed"),
             ]
-            args.status = _inline_choice(
+            args.status = inline_choice(
                 "ステータス",
                 status_options,
                 default=current.get("status") or "open",
@@ -285,7 +221,7 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
                 ("tree", "tree"),
                 ("system", "system"),
             ]
-            args.sharing = _inline_choice(
+            args.sharing = inline_choice(
                 "共有設定",
                 sharing_options,
                 default=current.get("sharing") or "none",


### PR DESCRIPTION
## Summary
- `redi version update` で `version_id` や更新フィールドを省略すると prompt_toolkit で対話的に入力できるようにした
- 対話 UI のスタイルは #31 の version create interactive と同じく prompt_toolkit ベース（`prompt` / `choice`、C-p/C-n で選択肢を上下移動）で統一
- バージョン選択用に `fetch_version` ヘルパーを `version.py` に追加

## Test plan
- [x] `redi version update` を `version_id` なしで実行し、対話的にバージョンを選択して更新できる
- [x] `redi version update <version_id>` を他フラグなしで実行し、各フィールドを対話的に入力して更新できる
- [x] 各フィールドで空入力にした場合、当該フィールドが更新対象に含まれないこと
- [x] `redi version update <version_id> --name foo` のように従来のフラグ指定でも動作すること
- [x] `task check` が通ること