### PR TITLE
TUI でコメントの追加・表示に対応

### DIFF
--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -16,6 +16,7 @@ from redi.cli.enumerations_command import (
     add_time_entry_activity_parser,
     add_tracker_parser,
 )
+from redi.cli._common import open_editor
 from redi.cli.issue_command import (
     add_issue_parser,
     handle_issue,
@@ -36,7 +37,7 @@ from redi.api.enumeration import (
     list_issue_priorities,
     list_time_entry_activities,
 )
-from redi.api.issue import read_issue
+from redi.api.issue import add_note
 from redi.api.issue_status import list_issue_statuses
 from redi.api.query import list_queries
 from redi.api.tracker import list_trackers
@@ -100,10 +101,7 @@ def main() -> None:
             if tui_result is None:
                 return
             tui_position = tui_result.position
-            if tui_result.action == "view":
-                read_issue(tui_result.issue_id)
-                input("Enter で TUI に戻る...")
-            elif tui_result.action == "update":
+            if tui_result.action == "update":
                 update_args = argparse.Namespace(
                     issue_id=tui_result.issue_id,
                     subject=None,
@@ -137,6 +135,10 @@ def main() -> None:
                     custom_fields=None,
                 )
                 handle_issue_create(create_args)
+            elif tui_result.action == "comment":
+                notes = open_editor()
+                if notes:
+                    add_note(tui_result.issue_id, notes)
 
     if args.command in ("project", "p"):
         handle_project(args)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -41,7 +41,7 @@ from redi.api.issue import add_note
 from redi.api.issue_status import list_issue_statuses
 from redi.api.query import list_queries
 from redi.api.tracker import list_trackers
-from redi.tui import TuiPosition, run_issue_tui
+from redi.tui import TuiState, run_issue_tui
 
 
 def _build_parser() -> tuple[argparse.ArgumentParser, argparse.ArgumentParser]:
@@ -95,12 +95,12 @@ def main() -> None:
     check_config()
 
     if args.tui and args.command is None:
-        tui_position = TuiPosition()
+        tui_state = TuiState()
         while True:
-            tui_result = run_issue_tui(position=tui_position)
+            tui_result = run_issue_tui(state=tui_state)
             if tui_result is None:
                 return
-            tui_position = tui_result.position
+            tui_state = TuiState(last_result=tui_result)
             if tui_result.action == "update":
                 update_args = argparse.Namespace(
                     issue_id=tui_result.issue_id,

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -19,14 +19,6 @@ def _pad_display(text: str, width: int) -> str:
     return text + " " * padding
 
 
-@dataclass
-class TuiState:
-    page_size: int
-    offset: int = 0
-    cursor: int = 0
-    issues: list[dict] = field(default_factory=list)
-
-
 TuiAction = Literal["update", "create", "comment"]
 
 
@@ -43,10 +35,21 @@ class TuiResult:
     position: TuiPosition
 
 
-def run_issue_tui(position: TuiPosition | None = None) -> TuiResult | None:
-    if position is None:
-        position = TuiPosition()
-    state = TuiState(page_size=max(1, shutil.get_terminal_size().lines - 1))
+@dataclass
+class TuiState:
+    last_result: TuiResult | None = None
+    page_size: int = 0
+    offset: int = 0
+    cursor: int = 0
+    issues: list[dict] = field(default_factory=list)
+
+
+def run_issue_tui(state: TuiState | None = None) -> TuiResult | None:
+    if state is None:
+        state = TuiState()
+    last = state.last_result
+    position = last.position if last else TuiPosition()
+    state.page_size = max(1, shutil.get_terminal_size().lines - 1)
     state.offset = position.offset
     state.issues = fetch_issues(
         project_id=default_project_id, limit=state.page_size, offset=state.offset
@@ -55,6 +58,13 @@ def run_issue_tui(position: TuiPosition | None = None) -> TuiResult | None:
         print("イシューが見つかりません")
         return None
     state.cursor = max(0, min(position.cursor, len(state.issues) - 1))
+    if last and last.action == "comment" and last.issue_id:
+        target_id = int(last.issue_id)
+        for issue in state.issues:
+            if issue.get("id") == target_id:
+                fetched = fetch_issue(last.issue_id, include="journals")
+                issue["journals"] = fetched.get("journals") or []
+                break
 
     def render_issues():
         result = []

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -11,7 +11,7 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from wcwidth import wcswidth
 
 from redi.config import default_project_id, redmine_url
-from redi.api.issue import fetch_issues
+from redi.api.issue import fetch_issue, fetch_issues
 
 
 def _pad_display(text: str, width: int) -> str:
@@ -27,7 +27,7 @@ class TuiState:
     issues: list[dict] = field(default_factory=list)
 
 
-TuiAction = Literal["view", "update", "create"]
+TuiAction = Literal["update", "create", "comment"]
 
 
 @dataclass
@@ -103,6 +103,19 @@ def run_issue_tui(position: TuiPosition | None = None) -> TuiResult | None:
             lines.append("----")
             lines.extend(description.splitlines())
 
+        journals = issue.get("journals") or []
+        notes = [j for j in journals if (j.get("notes") or "").strip()]
+        if notes:
+            lines.append("")
+            lines.append("----")
+            lines.append("コメント:")
+            for j in notes:
+                author = (j.get("user") or {}).get("name", "")
+                created = j.get("created_on", "")
+                lines.append(f"[{created}] {author}")
+                for nl in (j.get("notes") or "").splitlines():
+                    lines.append(f"  {nl}")
+
         return [("", "\n".join(lines))]
 
     def render_status():
@@ -111,7 +124,7 @@ def run_issue_tui(position: TuiPosition | None = None) -> TuiResult | None:
             (
                 "reverse",
                 f" Page {page} (offset={state.offset})  "
-                "↑↓/jk:移動 ←→/hl:ページ Enter:表示 c:作成 u:更新 v:web q:終了 ",
+                "↑↓/jk:移動 ←→/hl:ページ Enter:コメント読込 c:作成 u:更新 n:コメント v:web q:終了 ",
             )
         ]
 
@@ -166,7 +179,14 @@ def run_issue_tui(position: TuiPosition | None = None) -> TuiResult | None:
 
     @kb.add("enter")
     def _(event):
-        event.app.exit(result=_exit_with("view"))
+        if not state.issues:
+            return
+        issue = state.issues[state.cursor]
+        issue_id = issue.get("id")
+        if issue_id is None:
+            return
+        fetched = fetch_issue(str(issue_id), include="journals")
+        issue["journals"] = fetched.get("journals") or []
 
     @kb.add("u")
     def _(event):
@@ -175,6 +195,11 @@ def run_issue_tui(position: TuiPosition | None = None) -> TuiResult | None:
     @kb.add("c")
     def _(event):
         event.app.exit(result=_exit_with("create", issue_id=""))
+
+    # n is first letter of note
+    @kb.add("n")
+    def _(event):
+        event.app.exit(result=_exit_with("comment"))
 
     @kb.add("v")
     def _(event):

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -19,6 +19,11 @@ def _pad_display(text: str, width: int) -> str:
     return text + " " * padding
 
 
+def _load_journals(issue: dict) -> None:
+    fetched = fetch_issue(str(issue["id"]), include="journals")
+    issue["journals"] = fetched.get("journals") or []
+
+
 TuiAction = Literal["update", "create", "comment"]
 
 
@@ -60,11 +65,9 @@ def run_issue_tui(state: TuiState | None = None) -> TuiResult | None:
     state.cursor = max(0, min(position.cursor, len(state.issues) - 1))
     if last and last.action == "comment" and last.issue_id:
         target_id = int(last.issue_id)
-        for issue in state.issues:
-            if issue.get("id") == target_id:
-                fetched = fetch_issue(last.issue_id, include="journals")
-                issue["journals"] = fetched.get("journals") or []
-                break
+        target = next((i for i in state.issues if i.get("id") == target_id), None)
+        if target is not None:
+            _load_journals(target)
 
     def render_issues():
         result = []
@@ -192,11 +195,9 @@ def run_issue_tui(state: TuiState | None = None) -> TuiResult | None:
         if not state.issues:
             return
         issue = state.issues[state.cursor]
-        issue_id = issue.get("id")
-        if issue_id is None:
+        if issue.get("id") is None:
             return
-        fetched = fetch_issue(str(issue_id), include="journals")
-        issue["journals"] = fetched.get("journals") or []
+        _load_journals(issue)
 
     @kb.add("u")
     def _(event):


### PR DESCRIPTION
## Summary
- close #57 
- TUI で `n` キーを押すとエディタが起動し、選択中 issue にコメントを追加できるようにした
- TUI のプレビューペインに `Enter` キーで journals を読み込みコメントを表示するようにした
- コメント投稿後は TUI 再入場時に対象 issue の journals を自動で再取得し、追加したコメントが即反映されるようにした
- `run_issue_tui` の引数を `TuiState` に集約し、`last_result` 経由で再入場時の preload を表現するようリファクタ

## Test plan
- [x] `redi --tui` を起動し、issue 選択状態で `n` を押下 → エディタで書いたコメントが追加されること
- [x] コメント投稿後に TUI に戻ると、プレビューに投稿したコメントが表示されること
- [x] 別の issue にカーソル移動し `Enter` を押すとその issue の journals がプレビューに表示されること
- [x] `c` (作成) / `u` (更新) / `v` (web) が従来通り動くこと