### PR TITLE
[add] ty による型チェックを導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,8 @@ jobs:
       - name: Lint
         run: uv run ruff check
 
+      - name: Typecheck
+        run: uv run ty check
+
       - name: Test
         run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,5 @@ build-backend = "uv_build"
 dev = [
     "pytest>=9.0.3",
     "ruff>=0.15.9",
+    "ty>=0.0.31",
 ]

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -7,8 +7,8 @@ import questionary.prompts.common
 
 from redi.config import editor
 
-questionary.prompts.common.INDICATOR_SELECTED = "[x]"  # pyright: ignore[reportPrivateImportUsage]
-questionary.prompts.common.INDICATOR_UNSELECTED = "[ ]"  # pyright: ignore[reportPrivateImportUsage]
+questionary.prompts.common.INDICATOR_SELECTED = "[x]"  # ty: ignore[invalid-assignment]  # pyright: ignore[reportPrivateImportUsage]
+questionary.prompts.common.INDICATOR_UNSELECTED = "[ ]"  # ty: ignore[invalid-assignment]  # pyright: ignore[reportPrivateImportUsage]
 
 
 SUBCOMMAND_ALIASES: dict[str, str] = {

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -136,6 +136,8 @@ def main() -> None:
                 )
                 handle_issue_create(create_args)
             elif tui_result.action == "comment":
+                if tui_result.issue_id is None:
+                    continue
                 notes = open_editor()
                 if notes:
                     add_note(tui_result.issue_id, notes)

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -76,7 +76,7 @@ def update_config(key: str, value: str, profile: str | None = None) -> None:
         print(f"profile '{target_profile}' not found in {CONFIG_PATH}")
         exit(1)
 
-    doc[target_profile][key] = value
+    doc[target_profile][key] = value  # ty: ignore[invalid-assignment]
     with open(CONFIG_PATH, "w") as f:
         tomlkit.dump(doc, f)
 

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -3,6 +3,7 @@ import tomllib
 from pathlib import Path
 
 import tomlkit
+from tomlkit.items import Table
 
 CONFIG_PATH = Path.home() / ".config" / "redi" / "config.toml"
 
@@ -72,11 +73,12 @@ def update_config(key: str, value: str, profile: str | None = None) -> None:
     if not target_profile:
         print("default_profile not found")
         exit(1)
-    if target_profile not in doc or not isinstance(doc.get(target_profile), dict):
+    profile_table = doc.get(target_profile) if target_profile in doc else None
+    if not isinstance(profile_table, Table):
         print(f"profile '{target_profile}' not found in {CONFIG_PATH}")
         exit(1)
 
-    doc[target_profile][key] = value  # ty: ignore[invalid-assignment]
+    profile_table[key] = value
     with open(CONFIG_PATH, "w") as f:
         tomlkit.dump(doc, f)
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -7,10 +7,11 @@ tasks:
       - task --list-all --sort none
 
   check:
-    desc: format, lint, test
+    desc: format, lint, typecheck, test
     cmds:
       - task: format
       - task: lint
+      - task: typecheck
       - task: test
 
   format:
@@ -22,6 +23,11 @@ tasks:
     desc: lint
     cmds:
       - uv run ruff check
+
+  typecheck:
+    desc: typecheck
+    cmds:
+      - uv run ty check
 
   test:
     desc: run tests

--- a/uv.lock
+++ b/uv.lock
@@ -188,6 +188,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -204,6 +205,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.15.9" },
+    { name = "ty", specifier = ">=0.0.31" },
 ]
 
 [[package]]
@@ -253,6 +255,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.31"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/cc/5ea5d3a72216c8c2bf77d83066dd4f3553532d0aacc03d4a8397dd9845e1/ty-0.0.31.tar.gz", hash = "sha256:4a4094292d9671caf3b510c7edf36991acd9c962bb5d97205374ffed9f541c45", size = 5516619, upload-time = "2026-04-15T15:47:59.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/10/ea805cbbd75d5d50792551a2b383de8521eeab0c44f38c73e12819ced65e/ty-0.0.31-py3-none-linux_armv6l.whl", hash = "sha256:761651dc17ad7bc0abfc1b04b3f0e84df263ed435d34f29760b3da739ab02d35", size = 10834749, upload-time = "2026-04-15T15:48:14.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4c/fabf951850401d24d36b21bced088a366c6827e1c37dab4523afff84c4b2/ty-0.0.31-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c529922395a07231c27488f0290651e05d27d149f7e0aa807678f1f7e9c58a5e", size = 10626012, upload-time = "2026-04-15T15:48:22.554Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b0/4a5aff88d2544f19514a59c8f693d63144aa7307fe2ee5df608333ab5460/ty-0.0.31-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5f345df2b87d747859e72c2cbc9be607ea1bbc8bc93dd32fa3d03ea091cb4fee", size = 10075790, upload-time = "2026-04-15T15:47:46.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/73/9d4dcad12cd4e85274014f2c0510ef93f590b2a1e5148de3a9f276098dad/ty-0.0.31-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4b207eddcfbafd376132689d3435b14efcb531289cb59cd961c6a611133bd54", size = 10590286, upload-time = "2026-04-15T15:48:06.222Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/fe40adde18692359ded174ae7ddbfac056e876eb0f43b65be74fde7f6072/ty-0.0.31-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:663778b220f357067488ce68bfc52335ccbd161549776f70dcbde6bbde82f77a", size = 10623824, upload-time = "2026-04-15T15:48:12.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e8/0ffa2e09b548e6daa9ebc368d68b767dc2405ca4cbeadb7ede0e2cb21059/ty-0.0.31-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3506cfe87dfade0fb2960dd4fffd4fd8089003587b3445c0a1a295c9d83764fb", size = 11156864, upload-time = "2026-04-15T15:48:08.473Z" },
+    { url = "https://files.pythonhosted.org/packages/08/e9/fd44c2075115d569593ee9473d7e2a38b750fd7e783421c95eb528c15df5/ty-0.0.31-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8b3f3d8492f08e81916026354c1d1599e9ddfa1241804141a74d5662fc710085", size = 11696401, upload-time = "2026-04-15T15:48:17.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/50/35aad8eadf964d23e2a4faa5b38a206aa85c78833c8ce335dddd2c34ba63/ty-0.0.31-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a97de32ee6a619393a4c495e056a1c547de7877510f3152e61345c71d774d2d0", size = 11374903, upload-time = "2026-04-15T15:47:55.893Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/37/01eccd25d23f5aaa7f7ff1a87b5b215469f6b202cf689a1812b71c1e7f6b/ty-0.0.31-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c906354ce441e342646582bc9b8f48a676f79f3d061e25de15ff870e015ca14e", size = 11206624, upload-time = "2026-04-15T15:47:51.778Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/70/baad2914cb097453f127a221f8addb2b41926098059cd773c75e6a662fc4/ty-0.0.31-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:275bb7c82afcbf89fe2dbef1b2692f2bc98451f1ee2c8eb809ddd91317822388", size = 10575089, upload-time = "2026-04-15T15:47:49.448Z" },
+    { url = "https://files.pythonhosted.org/packages/83/12/bae3a7bba2e785eb72ce00f9da70eedcb8c5e8299efecbd16e6e436abd82/ty-0.0.31-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:405da247027c6efd1e264886b6ac4a86ab3a4f09200b02e33630efe85f119e53", size = 10642315, upload-time = "2026-04-15T15:48:19.661Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9e/cad04d5d839bc60355cea98c7e09d724ea65f47184def0fae8b90dc54591/ty-0.0.31-py3-none-musllinux_1_2_i686.whl", hash = "sha256:54d9835608eed196853d6643f645c50ce83bcc7fe546cdb3e210c1bcf7c58c09", size = 10834473, upload-time = "2026-04-15T15:48:02.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ba/84112d280182d37690d3d2b4018b2667e42bc281585e607015635310016a/ty-0.0.31-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5ee11be9b07e8c0c6b455ff075a0abe4f194de9476f57624db98eec9df618355", size = 11315785, upload-time = "2026-04-15T15:48:10.754Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9f/ac42dc223d7e0950e97a1854567a8b3e7fe09ad7375adbf91bfb43290482/ty-0.0.31-py3-none-win32.whl", hash = "sha256:7286587aacf3eef0956062d6492b893b02f82b0f22c5e230008e13ff0d216a8b", size = 10187657, upload-time = "2026-04-15T15:48:04.264Z" },
+    { url = "https://files.pythonhosted.org/packages/75/3e/57ba7ea7ecb2f4751644ba91756e2be70e33ef5952c0c41a256a0e4c2437/ty-0.0.31-py3-none-win_amd64.whl", hash = "sha256:81134e25d2a2562ab372f24de8f9bd05034d27d30377a5d7540f259791c6234c", size = 11205258, upload-time = "2026-04-15T15:47:53.759Z" },
+    { url = "https://files.pythonhosted.org/packages/88/39/bca669095ccf0a400af941fdf741578d4c2d6719f1b7f10e6dbec10aa862/ty-0.0.31-py3-none-win_arm64.whl", hash = "sha256:e9cb15fad26545c6a608f40f227af3a5513cb376998ca6feddd47ca7d93ffafa", size = 10590392, upload-time = "2026-04-15T15:47:57.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- dev dependency に [ty](https://github.com/astral-sh/ty) を追加
- `taskfile.yaml` に `typecheck` タスクを追加し `check` タスクに組み込み
- CI (`.github/workflows/ci.yml`) に `ty check` ステップを追加
- 既存の型エラー4件を修正 (または `ty: ignore` を付与)

Closes #56 

## Test plan
- [x] ローカルで `task check` が全てパスすること
- [x] CI で typecheck ステップが実行されること