### PR TITLE
[add] config create サブコマンドを追加 (close #60 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ echo 'eval "$(register-python-argcomplete redi)"' >> ~/.zshrc
 ```sh
 # config (alias: c)
 redi config
+redi config create <profile_name> --url <url> --api_key <key> # create new profile
+redi config create <profile_name> --url <url> --api_key <key> --set-default
 redi config update --default_profile <profile_name> # switch profile
 redi config update <profile_name> --editor nvim # update profile
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ echo 'eval "$(register-python-argcomplete redi)"' >> ~/.zshrc
 # config (alias: c)
 redi config
 redi config create <profile_name> --url <url> --api_key <key> # create new profile
-redi config create <profile_name> --url <url> --api_key <key> --set-default
+redi config create <profile_name> --url <url> --api_key <key> --set_default
 redi config update --default_profile <profile_name> # switch profile
 redi config update <profile_name> --editor nvim # update profile
 

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -36,8 +36,7 @@ def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
     c_create_parser.add_argument("--wiki_project_id", help="Wiki用プロジェクトID")
     c_create_parser.add_argument("--editor", help="エディタ")
     c_create_parser.add_argument(
-        "--set-default",
-        dest="set_default",
+        "--set_default",
         action="store_true",
         help="作成したプロファイルをdefault_profileに設定",
     )

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -1,7 +1,12 @@
 import argparse
 
 from redi.cli._common import resolve_alias
-from redi.config import set_default_profile, show_config, update_config
+from redi.config import (
+    create_profile,
+    set_default_profile,
+    show_config,
+    update_config,
+)
 
 
 def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -21,10 +26,41 @@ def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
     c_update_parser.add_argument(
         "--default_profile", help="デフォルトプロファイルを設定"
     )
+    c_create_parser = c_subparsers.add_parser(
+        "create", aliases=["c"], help="プロファイル作成"
+    )
+    c_create_parser.add_argument("profile_name", help="作成するプロファイル名")
+    c_create_parser.add_argument("--url", help="Redmine URL")
+    c_create_parser.add_argument("--api_key", help="Redmine APIキー")
+    c_create_parser.add_argument("--project_id", help="デフォルトプロジェクトID")
+    c_create_parser.add_argument("--wiki_project_id", help="Wiki用プロジェクトID")
+    c_create_parser.add_argument("--editor", help="エディタ")
+    c_create_parser.add_argument(
+        "--set-default",
+        dest="set_default",
+        action="store_true",
+        help="作成したプロファイルをdefault_profileに設定",
+    )
 
 
 def handle_config(args: argparse.Namespace) -> None:
-    if resolve_alias(args.config_command) != "update":
+    cmd = resolve_alias(args.config_command)
+    if cmd == "create":
+        created = create_profile(
+            profile_name=args.profile_name,
+            redmine_url=args.url,
+            redmine_api_key=args.api_key,
+            default_project_id=args.project_id,
+            wiki_project_id=args.wiki_project_id,
+            editor=args.editor,
+        )
+        if not created:
+            exit(1)
+        print(f"profile '{args.profile_name}' を作成しました")
+        if args.set_default and set_default_profile(args.profile_name):
+            print(f"default_profileを {args.profile_name} に設定しました")
+        return
+    if cmd != "update":
         show_config()
         return
     updated = False

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -46,7 +46,7 @@ def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
 def handle_config(args: argparse.Namespace) -> None:
     cmd = resolve_alias(args.config_command)
     if cmd == "create":
-        created = create_profile(
+        result = create_profile(
             profile_name=args.profile_name,
             redmine_url=args.url,
             redmine_api_key=args.api_key,
@@ -54,10 +54,12 @@ def handle_config(args: argparse.Namespace) -> None:
             wiki_project_id=args.wiki_project_id,
             editor=args.editor,
         )
-        if not created:
+        if not result.created:
             exit(1)
         print(f"profile '{args.profile_name}' を作成しました")
-        if args.set_default and set_default_profile(args.profile_name):
+        if result.set_as_default:
+            print(f"default_profileを {args.profile_name} に設定しました")
+        elif args.set_default and set_default_profile(args.profile_name):
             print(f"default_profileを {args.profile_name} に設定しました")
         return
     if cmd != "update":

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -1,6 +1,7 @@
 import os
 import tomllib
 from pathlib import Path
+from typing import NamedTuple
 
 import tomlkit
 from tomlkit.items import Table
@@ -83,6 +84,11 @@ def update_config(key: str, value: str, profile: str | None = None) -> None:
         tomlkit.dump(doc, f)
 
 
+class CreateProfileResult(NamedTuple):
+    created: bool
+    set_as_default: bool
+
+
 def create_profile(
     profile_name: str,
     redmine_url: str | None = None,
@@ -90,7 +96,7 @@ def create_profile(
     default_project_id: str | None = None,
     wiki_project_id: str | None = None,
     editor: str | None = None,
-) -> bool:
+) -> CreateProfileResult:
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     if CONFIG_PATH.exists():
         with open(CONFIG_PATH) as f:
@@ -100,7 +106,7 @@ def create_profile(
 
     if profile_name in doc:
         print(f"profile '{profile_name}' は既に存在します")
-        return False
+        return CreateProfileResult(created=False, set_as_default=False)
 
     table = tomlkit.table()
     if redmine_url is not None:
@@ -115,9 +121,14 @@ def create_profile(
         table["editor"] = editor
     doc[profile_name] = table
 
+    profile_names = [k for k, v in doc.items() if isinstance(v, Table)]
+    set_as_default = profile_names == [profile_name]
+    if set_as_default:
+        doc["default_profile"] = profile_name
+
     with open(CONFIG_PATH, "w") as f:
         tomlkit.dump(doc, f)
-    return True
+    return CreateProfileResult(created=True, set_as_default=set_as_default)
 
 
 def set_default_profile(profile_name: str) -> bool:

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -96,10 +96,12 @@ def create_profile(
     default_project_id: str | None = None,
     wiki_project_id: str | None = None,
     editor: str | None = None,
+    config_path: Path | None = None,
 ) -> CreateProfileResult:
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if CONFIG_PATH.exists():
-        with open(CONFIG_PATH) as f:
+    path = config_path or CONFIG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        with open(path) as f:
             doc = tomlkit.load(f)
     else:
         doc = tomlkit.document()
@@ -126,7 +128,7 @@ def create_profile(
     if set_as_default:
         doc["default_profile"] = profile_name
 
-    with open(CONFIG_PATH, "w") as f:
+    with open(path, "w") as f:
         tomlkit.dump(doc, f)
     return CreateProfileResult(created=True, set_as_default=set_as_default)
 

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -83,6 +83,43 @@ def update_config(key: str, value: str, profile: str | None = None) -> None:
         tomlkit.dump(doc, f)
 
 
+def create_profile(
+    profile_name: str,
+    redmine_url: str | None = None,
+    redmine_api_key: str | None = None,
+    default_project_id: str | None = None,
+    wiki_project_id: str | None = None,
+    editor: str | None = None,
+) -> bool:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH) as f:
+            doc = tomlkit.load(f)
+    else:
+        doc = tomlkit.document()
+
+    if profile_name in doc:
+        print(f"profile '{profile_name}' は既に存在します")
+        return False
+
+    table = tomlkit.table()
+    if redmine_url is not None:
+        table["redmine_url"] = redmine_url
+    if redmine_api_key is not None:
+        table["redmine_api_key"] = redmine_api_key
+    if default_project_id is not None:
+        table["default_project_id"] = default_project_id
+    if wiki_project_id is not None:
+        table["wiki_project_id"] = wiki_project_id
+    if editor is not None:
+        table["editor"] = editor
+    doc[profile_name] = table
+
+    with open(CONFIG_PATH, "w") as f:
+        tomlkit.dump(doc, f)
+    return True
+
+
 def set_default_profile(profile_name: str) -> bool:
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     if CONFIG_PATH.exists():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -11,7 +11,7 @@ class TestCreateProfile:
         config_path = tmp_path / "config.toml"
         monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        created = config.create_profile(
+        result = config.create_profile(
             "main",
             redmine_url="https://example.com",
             redmine_api_key="secret",
@@ -20,7 +20,7 @@ class TestCreateProfile:
             editor="nvim",
         )
 
-        assert created is True
+        assert result.created is True
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["main"] == {
@@ -75,9 +75,39 @@ class TestCreateProfile:
         config_path.write_text('[main]\nredmine_url = "https://original"\n')
         monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        created = config.create_profile("main", redmine_url="https://overwrite")
+        result = config.create_profile("main", redmine_url="https://overwrite")
 
-        assert created is False
+        assert result.created is False
+        assert result.set_as_default is False
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["main"]["redmine_url"] == "https://original"
+
+    def test_sets_as_default_when_only_profile(self, tmp_path, monkeypatch):
+        """作成したプロファイルが唯一のプロファイルであればdefault_profileに設定される"""
+        config_path = tmp_path / "config.toml"
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        result = config.create_profile("main", redmine_url="https://example.com")
+
+        assert result.set_as_default is True
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["default_profile"] == "main"
+
+    def test_keeps_existing_default_when_other_profiles_exist(
+        self, tmp_path, monkeypatch
+    ):
+        """既存プロファイルがある場合はdefault_profileを変更しない"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n'
+        )
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        result = config.create_profile("sub", redmine_url="https://sub")
+
+        assert result.set_as_default is False
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["default_profile"] == "main"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,83 @@
+import tomllib
+
+from redi import config
+
+
+class TestCreateProfile:
+    """create_profile()はconfig.tomlに新しいプロファイルセクションを追加する"""
+
+    def test_creates_new_profile_section(self, tmp_path, monkeypatch):
+        """指定したプロファイル名でセクションを作成し、指定した値が書き込まれる"""
+        config_path = tmp_path / "config.toml"
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        created = config.create_profile(
+            "main",
+            redmine_url="https://example.com",
+            redmine_api_key="secret",
+            default_project_id="1",
+            wiki_project_id="2",
+            editor="nvim",
+        )
+
+        assert created is True
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["main"] == {
+            "redmine_url": "https://example.com",
+            "redmine_api_key": "secret",
+            "default_project_id": "1",
+            "wiki_project_id": "2",
+            "editor": "nvim",
+        }
+
+    def test_skips_unspecified_keys(self, tmp_path, monkeypatch):
+        """指定されなかった項目はセクションに書き込まない"""
+        config_path = tmp_path / "config.toml"
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        config.create_profile("main", redmine_url="https://example.com")
+
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["main"] == {"redmine_url": "https://example.com"}
+
+    def test_creates_parent_directory(self, tmp_path, monkeypatch):
+        """親ディレクトリが存在しなくても自動作成する"""
+        config_path = tmp_path / "nested" / "config.toml"
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        config.create_profile("main")
+
+        assert config_path.exists()
+
+    def test_preserves_existing_profiles(self, tmp_path, monkeypatch):
+        """既存プロファイルを保持したまま新しいプロファイルを追記する"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n'
+        )
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        config.create_profile("sub", redmine_url="https://sub")
+
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["default_profile"] == "main"
+        assert doc["main"]["redmine_url"] == "https://main"
+        assert doc["sub"]["redmine_url"] == "https://sub"
+
+    def test_returns_false_when_profile_already_exists(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """同名プロファイルが既に存在する場合はFalseを返し、内容を変更しない"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[main]\nredmine_url = "https://original"\n')
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        created = config.create_profile("main", redmine_url="https://overwrite")
+
+        assert created is False
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["main"]["redmine_url"] == "https://original"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,10 +6,9 @@ from redi import config
 class TestCreateProfile:
     """create_profile()はconfig.tomlに新しいプロファイルセクションを追加する"""
 
-    def test_creates_new_profile_section(self, tmp_path, monkeypatch):
+    def test_creates_new_profile_section(self, tmp_path):
         """指定したプロファイル名でセクションを作成し、指定した値が書き込まれる"""
         config_path = tmp_path / "config.toml"
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
         result = config.create_profile(
             "main",
@@ -18,6 +17,7 @@ class TestCreateProfile:
             default_project_id="1",
             wiki_project_id="2",
             editor="nvim",
+            config_path=config_path,
         )
 
         assert result.created is True
@@ -31,35 +31,34 @@ class TestCreateProfile:
             "editor": "nvim",
         }
 
-    def test_skips_unspecified_keys(self, tmp_path, monkeypatch):
+    def test_skips_unspecified_keys(self, tmp_path):
         """指定されなかった項目はセクションに書き込まない"""
         config_path = tmp_path / "config.toml"
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        config.create_profile("main", redmine_url="https://example.com")
+        config.create_profile(
+            "main", redmine_url="https://example.com", config_path=config_path
+        )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["main"] == {"redmine_url": "https://example.com"}
 
-    def test_creates_parent_directory(self, tmp_path, monkeypatch):
+    def test_creates_parent_directory(self, tmp_path):
         """親ディレクトリが存在しなくても自動作成する"""
         config_path = tmp_path / "nested" / "config.toml"
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        config.create_profile("main")
+        config.create_profile("main", config_path=config_path)
 
         assert config_path.exists()
 
-    def test_preserves_existing_profiles(self, tmp_path, monkeypatch):
+    def test_preserves_existing_profiles(self, tmp_path):
         """既存プロファイルを保持したまま新しいプロファイルを追記する"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
             'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n'
         )
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        config.create_profile("sub", redmine_url="https://sub")
+        config.create_profile("sub", redmine_url="https://sub", config_path=config_path)
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
@@ -67,15 +66,14 @@ class TestCreateProfile:
         assert doc["main"]["redmine_url"] == "https://main"
         assert doc["sub"]["redmine_url"] == "https://sub"
 
-    def test_returns_false_when_profile_already_exists(
-        self, tmp_path, monkeypatch, capsys
-    ):
+    def test_returns_false_when_profile_already_exists(self, tmp_path):
         """同名プロファイルが既に存在する場合はFalseを返し、内容を変更しない"""
         config_path = tmp_path / "config.toml"
         config_path.write_text('[main]\nredmine_url = "https://original"\n')
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        result = config.create_profile("main", redmine_url="https://overwrite")
+        result = config.create_profile(
+            "main", redmine_url="https://overwrite", config_path=config_path
+        )
 
         assert result.created is False
         assert result.set_as_default is False
@@ -83,29 +81,29 @@ class TestCreateProfile:
             doc = tomllib.load(f)
         assert doc["main"]["redmine_url"] == "https://original"
 
-    def test_sets_as_default_when_only_profile(self, tmp_path, monkeypatch):
+    def test_sets_as_default_when_only_profile(self, tmp_path):
         """作成したプロファイルが唯一のプロファイルであればdefault_profileに設定される"""
         config_path = tmp_path / "config.toml"
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        result = config.create_profile("main", redmine_url="https://example.com")
+        result = config.create_profile(
+            "main", redmine_url="https://example.com", config_path=config_path
+        )
 
         assert result.set_as_default is True
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["default_profile"] == "main"
 
-    def test_keeps_existing_default_when_other_profiles_exist(
-        self, tmp_path, monkeypatch
-    ):
+    def test_keeps_existing_default_when_other_profiles_exist(self, tmp_path):
         """既存プロファイルがある場合はdefault_profileを変更しない"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
             'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n'
         )
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        result = config.create_profile("sub", redmine_url="https://sub")
+        result = config.create_profile(
+            "sub", redmine_url="https://sub", config_path=config_path
+        )
 
         assert result.set_as_default is False
         with open(config_path, "rb") as f:


### PR DESCRIPTION
## Summary
- `redi config create <profile_name>` で新しいプロファイルセクションを `~/.config/redi/config.toml` に追加
- 初期値を `--url` / `--api_key` / `--project_id` / `--wiki_project_id` / `--editor` で指定可能
- `--set-default` で作成と同時に `default_profile` へ設定
- 同名プロファイルが既に存在する場合は作成を拒否（exit 1）
- `create_profile()` のユニットテストを `tests/unit/test_config.py` に追加

## Test plan
- [x] `task check` (format / lint / typecheck / test) がすべて通る
- [x] `redi config create main --url ... --api_key ... --set-default` で新規プロファイルを作成できる
- [x] 既存の `[main]` に対して同コマンドを実行するとエラーで終了する
- [x] 既存プロファイルを保持したまま `redi config create sub ...` で追記できる