### PR TITLE
[add] redi config --full で全プロファイルを表示 #63 

### DIFF
--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -11,6 +11,7 @@ from redi.config import (
 
 def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
     c_parser = subparsers.add_parser("config", aliases=["c"], help="設定表示/更新")
+    c_parser.add_argument("--full", action="store_true", help="全プロファイルを表示")
     c_subparsers = c_parser.add_subparsers(dest="config_command")
     c_update_parser = c_subparsers.add_parser("update", aliases=["u"], help="設定更新")
     c_update_parser.add_argument(
@@ -62,7 +63,7 @@ def handle_config(args: argparse.Namespace) -> None:
             print(f"default_profileを {args.profile_name} に設定しました")
         return
     if cmd != "update":
-        show_config()
+        show_config(full=args.full)
         return
     updated = False
     profile = args.profile_name

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -159,9 +159,9 @@ def set_default_profile(profile_name: str, config_path: Path | None = None) -> b
     return True
 
 
-def show_config(full: bool = False) -> None:
+def show_config(full: bool = False, config_path: Path | None = None) -> None:
     if full:
-        show_all_profiles()
+        show_all_profiles(config_path=config_path)
         return
     doc = tomlkit.document()
     doc["redmine_url"] = redmine_url
@@ -171,11 +171,12 @@ def show_config(full: bool = False) -> None:
     print(tomlkit.dumps(doc).rstrip())
 
 
-def show_all_profiles() -> None:
-    if not CONFIG_PATH.exists():
-        print(f"config file not found: {CONFIG_PATH}")
+def show_all_profiles(config_path: Path | None = None) -> None:
+    path = config_path or CONFIG_PATH
+    if not path.exists():
+        print(f"config file not found: {path}")
         return
-    with open(CONFIG_PATH) as f:
+    with open(path) as f:
         doc = tomlkit.load(f)
     for key in list(doc.keys()):
         value = doc[key]

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -159,10 +159,26 @@ def set_default_profile(profile_name: str, config_path: Path | None = None) -> b
     return True
 
 
-def show_config() -> None:
+def show_config(full: bool = False) -> None:
+    if full:
+        show_all_profiles()
+        return
     doc = tomlkit.document()
     doc["redmine_url"] = redmine_url
     doc["default_project_id"] = default_project_id or ""
     doc["wiki_project_id"] = wiki_project_id or ""
     doc["editor"] = editor
+    print(tomlkit.dumps(doc).rstrip())
+
+
+def show_all_profiles() -> None:
+    if not CONFIG_PATH.exists():
+        print(f"config file not found: {CONFIG_PATH}")
+        return
+    with open(CONFIG_PATH) as f:
+        doc = tomlkit.load(f)
+    for key in list(doc.keys()):
+        value = doc[key]
+        if isinstance(value, Table) and "redmine_api_key" in value:
+            del value["redmine_api_key"]
     print(tomlkit.dumps(doc).rstrip())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -62,17 +62,19 @@ class TestCreateProfile:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
         """)
         )
 
-        config.create_profile("sub", redmine_url="https://sub", config_path=config_path)
+        config.create_profile(
+            "sub", redmine_url="https://example.com/sub", config_path=config_path
+        )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["default_profile"] == "main"
-        assert doc["main"]["redmine_url"] == "https://main"
-        assert doc["sub"]["redmine_url"] == "https://sub"
+        assert doc["main"]["redmine_url"] == "https://example.com/main"
+        assert doc["sub"]["redmine_url"] == "https://example.com/sub"
 
     def test_returns_false_when_profile_already_exists(self, tmp_path):
         """同名プロファイルが既に存在する場合はFalseを返し、内容を変更しない"""
@@ -80,19 +82,19 @@ class TestCreateProfile:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://original"
+            redmine_url = "https://example.com/original"
         """)
         )
 
         result = config.create_profile(
-            "main", redmine_url="https://overwrite", config_path=config_path
+            "main", redmine_url="https://example.com/overwrite", config_path=config_path
         )
 
         assert result.created is False
         assert result.set_as_default is False
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
-        assert doc["main"]["redmine_url"] == "https://original"
+        assert doc["main"]["redmine_url"] == "https://example.com/original"
 
     def test_sets_as_default_when_only_profile(self, tmp_path):
         """作成したプロファイルが唯一のプロファイルであればdefault_profileに設定される"""
@@ -115,12 +117,12 @@ class TestCreateProfile:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
         """)
         )
 
         result = config.create_profile(
-            "sub", redmine_url="https://sub", config_path=config_path
+            "sub", redmine_url="https://example.com/sub", config_path=config_path
         )
 
         assert result.set_as_default is False
@@ -167,15 +169,17 @@ class TestUpdateConfig:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://old"
+            redmine_url = "https://example.com/old"
         """)
         )
 
-        config.update_config("redmine_url", "https://new", config_path=config_path)
+        config.update_config(
+            "redmine_url", "https://example.com/new", config_path=config_path
+        )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
-        assert doc["main"]["redmine_url"] == "https://new"
+        assert doc["main"]["redmine_url"] == "https://example.com/new"
 
     def test_updates_specified_profile(self, tmp_path):
         """profile引数で指定したプロファイルを更新する"""
@@ -185,21 +189,24 @@ class TestUpdateConfig:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
 
             [sub]
-            redmine_url = "https://sub"
+            redmine_url = "https://example.com/sub"
         """)
         )
 
         config.update_config(
-            "redmine_url", "https://sub-new", profile="sub", config_path=config_path
+            "redmine_url",
+            "https://example.com/sub-new",
+            profile="sub",
+            config_path=config_path,
         )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
-        assert doc["main"]["redmine_url"] == "https://main"
-        assert doc["sub"]["redmine_url"] == "https://sub-new"
+        assert doc["main"]["redmine_url"] == "https://example.com/main"
+        assert doc["sub"]["redmine_url"] == "https://example.com/sub-new"
 
     def test_exits_when_default_profile_missing(self, tmp_path):
         """default_profileもprofile引数もない場合はexit 1する"""
@@ -207,7 +214,7 @@ class TestUpdateConfig:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
         """)
         )
 
@@ -221,7 +228,7 @@ class TestUpdateConfig:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
         """)
         )
 
@@ -241,10 +248,10 @@ class TestSetDefaultProfile:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
 
             [sub]
-            redmine_url = "https://sub"
+            redmine_url = "https://example.com/sub"
         """)
         )
 
@@ -261,7 +268,7 @@ class TestSetDefaultProfile:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
         """)
         )
 
@@ -284,11 +291,11 @@ class TestShowAllProfiles:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
             default_project_id = "1"
 
             [sub]
-            redmine_url = "https://sub"
+            redmine_url = "https://example.com/sub"
             default_project_id = "2"
         """)
         )
@@ -298,8 +305,8 @@ class TestShowAllProfiles:
         out = capsys.readouterr().out
         doc = tomllib.loads(out)
         assert doc["default_profile"] == "main"
-        assert doc["main"]["redmine_url"] == "https://main"
-        assert doc["sub"]["redmine_url"] == "https://sub"
+        assert doc["main"]["redmine_url"] == "https://example.com/main"
+        assert doc["sub"]["redmine_url"] == "https://example.com/sub"
 
     def test_hides_api_key(self, tmp_path, capsys):
         """APIキーは出力に含まれない"""
@@ -307,11 +314,11 @@ class TestShowAllProfiles:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://main"
+            redmine_url = "https://example.com/main"
             redmine_api_key = "secret-main"
 
             [sub]
-            redmine_url = "https://sub"
+            redmine_url = "https://example.com/sub"
             redmine_api_key = "secret-sub"
         """)
         )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,3 +1,4 @@
+import textwrap
 import tomllib
 
 import pytest
@@ -57,7 +58,12 @@ class TestCreateProfile:
         """既存プロファイルを保持したまま新しいプロファイルを追記する"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n'
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://main"
+        """)
         )
 
         config.create_profile("sub", redmine_url="https://sub", config_path=config_path)
@@ -71,7 +77,12 @@ class TestCreateProfile:
     def test_returns_false_when_profile_already_exists(self, tmp_path):
         """同名プロファイルが既に存在する場合はFalseを返し、内容を変更しない"""
         config_path = tmp_path / "config.toml"
-        config_path.write_text('[main]\nredmine_url = "https://original"\n')
+        config_path.write_text(
+            textwrap.dedent("""\
+            [main]
+            redmine_url = "https://original"
+        """)
+        )
 
         result = config.create_profile(
             "main", redmine_url="https://overwrite", config_path=config_path
@@ -100,7 +111,12 @@ class TestCreateProfile:
         """既存プロファイルがある場合はdefault_profileを変更しない"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n'
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://main"
+        """)
         )
 
         result = config.create_profile(
@@ -120,7 +136,12 @@ class TestLoadToml:
         """指定したパスが存在すれば内容を辞書として返す"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            'default_profile = "main"\n\n[main]\nredmine_url = "https://example.com"\n'
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://example.com"
+        """)
         )
 
         result = config.load_toml(config_path=config_path)
@@ -142,7 +163,12 @@ class TestUpdateConfig:
         """default_profileで指定されたプロファイルのキーを更新する"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            'default_profile = "main"\n\n[main]\nredmine_url = "https://old"\n'
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://old"
+        """)
         )
 
         config.update_config("redmine_url", "https://new", config_path=config_path)
@@ -155,7 +181,15 @@ class TestUpdateConfig:
         """profile引数で指定したプロファイルを更新する"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n\n[sub]\nredmine_url = "https://sub"\n'
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://main"
+
+            [sub]
+            redmine_url = "https://sub"
+        """)
         )
 
         config.update_config(
@@ -170,7 +204,12 @@ class TestUpdateConfig:
     def test_exits_when_default_profile_missing(self, tmp_path):
         """default_profileもprofile引数もない場合はexit 1する"""
         config_path = tmp_path / "config.toml"
-        config_path.write_text('[main]\nredmine_url = "https://main"\n')
+        config_path.write_text(
+            textwrap.dedent("""\
+            [main]
+            redmine_url = "https://main"
+        """)
+        )
 
         with pytest.raises(SystemExit) as e:
             config.update_config("redmine_url", "v", config_path=config_path)
@@ -179,7 +218,12 @@ class TestUpdateConfig:
     def test_exits_when_profile_not_found(self, tmp_path):
         """指定したprofileが存在しない場合はexit 1する"""
         config_path = tmp_path / "config.toml"
-        config_path.write_text('[main]\nredmine_url = "https://main"\n')
+        config_path.write_text(
+            textwrap.dedent("""\
+            [main]
+            redmine_url = "https://main"
+        """)
+        )
 
         with pytest.raises(SystemExit) as e:
             config.update_config(
@@ -195,7 +239,13 @@ class TestSetDefaultProfile:
         """既存プロファイルをdefault_profileに設定しTrueを返す"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            '[main]\nredmine_url = "https://main"\n\n[sub]\nredmine_url = "https://sub"\n'
+            textwrap.dedent("""\
+            [main]
+            redmine_url = "https://main"
+
+            [sub]
+            redmine_url = "https://sub"
+        """)
         )
 
         result = config.set_default_profile("sub", config_path=config_path)
@@ -208,7 +258,12 @@ class TestSetDefaultProfile:
     def test_returns_false_when_profile_not_found(self, tmp_path):
         """指定したプロファイルが存在しない場合はFalseを返し、ファイルを変更しない"""
         config_path = tmp_path / "config.toml"
-        config_path.write_text('[main]\nredmine_url = "https://main"\n')
+        config_path.write_text(
+            textwrap.dedent("""\
+            [main]
+            redmine_url = "https://main"
+        """)
+        )
 
         result = config.set_default_profile("missing", config_path=config_path)
 
@@ -225,13 +280,17 @@ class TestShowAllProfiles:
         """複数プロファイルがdefault_profileと共にTOML形式で出力される"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            'default_profile = "main"\n\n'
-            "[main]\n"
-            'redmine_url = "https://main"\n'
-            'default_project_id = "1"\n\n'
-            "[sub]\n"
-            'redmine_url = "https://sub"\n'
-            'default_project_id = "2"\n'
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://main"
+            default_project_id = "1"
+
+            [sub]
+            redmine_url = "https://sub"
+            default_project_id = "2"
+        """)
         )
 
         config.show_all_profiles(config_path=config_path)
@@ -246,12 +305,15 @@ class TestShowAllProfiles:
         """APIキーは出力に含まれない"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
-            "[main]\n"
-            'redmine_url = "https://main"\n'
-            'redmine_api_key = "secret-main"\n\n'
-            "[sub]\n"
-            'redmine_url = "https://sub"\n'
-            'redmine_api_key = "secret-sub"\n'
+            textwrap.dedent("""\
+            [main]
+            redmine_url = "https://main"
+            redmine_api_key = "secret-main"
+
+            [sub]
+            redmine_url = "https://sub"
+            redmine_api_key = "secret-sub"
+        """)
         )
 
         config.show_all_profiles(config_path=config_path)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -219,9 +219,9 @@ class TestSetDefaultProfile:
 
 
 class TestShowAllProfiles:
-    """show_all_profiles()はconfig.tomlの全プロファイルをTOML形式で表示する"""
+    """show_all_profiles()はconfig_path指定時にそのファイルの全プロファイルを表示する"""
 
-    def test_outputs_all_profiles(self, tmp_path, monkeypatch, capsys):
+    def test_outputs_all_profiles(self, tmp_path, capsys):
         """複数プロファイルがdefault_profileと共にTOML形式で出力される"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
@@ -233,9 +233,8 @@ class TestShowAllProfiles:
             'redmine_url = "https://sub"\n'
             'default_project_id = "2"\n'
         )
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        config.show_all_profiles()
+        config.show_all_profiles(config_path=config_path)
 
         out = capsys.readouterr().out
         doc = tomllib.loads(out)
@@ -243,7 +242,7 @@ class TestShowAllProfiles:
         assert doc["main"]["redmine_url"] == "https://main"
         assert doc["sub"]["redmine_url"] == "https://sub"
 
-    def test_hides_api_key(self, tmp_path, monkeypatch, capsys):
+    def test_hides_api_key(self, tmp_path, capsys):
         """APIキーは出力に含まれない"""
         config_path = tmp_path / "config.toml"
         config_path.write_text(
@@ -254,21 +253,19 @@ class TestShowAllProfiles:
             'redmine_url = "https://sub"\n'
             'redmine_api_key = "secret-sub"\n'
         )
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        config.show_all_profiles()
+        config.show_all_profiles(config_path=config_path)
 
         out = capsys.readouterr().out
         assert "secret-main" not in out
         assert "secret-sub" not in out
         assert "redmine_api_key" not in out
 
-    def test_prints_message_when_config_missing(self, tmp_path, monkeypatch, capsys):
+    def test_prints_message_when_config_missing(self, tmp_path, capsys):
         """config.tomlが存在しない場合はメッセージを出力する"""
         config_path = tmp_path / "missing.toml"
-        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
 
-        config.show_all_profiles()
+        config.show_all_profiles(config_path=config_path)
 
         out = capsys.readouterr().out
         assert "not found" in out

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -216,3 +216,59 @@ class TestSetDefaultProfile:
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert "default_profile" not in doc
+
+
+class TestShowAllProfiles:
+    """show_all_profiles()はconfig.tomlの全プロファイルをTOML形式で表示する"""
+
+    def test_outputs_all_profiles(self, tmp_path, monkeypatch, capsys):
+        """複数プロファイルがdefault_profileと共にTOML形式で出力される"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'default_profile = "main"\n\n'
+            "[main]\n"
+            'redmine_url = "https://main"\n'
+            'default_project_id = "1"\n\n'
+            "[sub]\n"
+            'redmine_url = "https://sub"\n'
+            'default_project_id = "2"\n'
+        )
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        config.show_all_profiles()
+
+        out = capsys.readouterr().out
+        doc = tomllib.loads(out)
+        assert doc["default_profile"] == "main"
+        assert doc["main"]["redmine_url"] == "https://main"
+        assert doc["sub"]["redmine_url"] == "https://sub"
+
+    def test_hides_api_key(self, tmp_path, monkeypatch, capsys):
+        """APIキーは出力に含まれない"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            "[main]\n"
+            'redmine_url = "https://main"\n'
+            'redmine_api_key = "secret-main"\n\n'
+            "[sub]\n"
+            'redmine_url = "https://sub"\n'
+            'redmine_api_key = "secret-sub"\n'
+        )
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        config.show_all_profiles()
+
+        out = capsys.readouterr().out
+        assert "secret-main" not in out
+        assert "secret-sub" not in out
+        assert "redmine_api_key" not in out
+
+    def test_prints_message_when_config_missing(self, tmp_path, monkeypatch, capsys):
+        """config.tomlが存在しない場合はメッセージを出力する"""
+        config_path = tmp_path / "missing.toml"
+        monkeypatch.setattr(config, "CONFIG_PATH", config_path)
+
+        config.show_all_profiles()
+
+        out = capsys.readouterr().out
+        assert "not found" in out

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,7 +15,7 @@ class TestCreateProfile:
 
         result = config.create_profile(
             "main",
-            redmine_url="https://example.com",
+            redmine_url="https://redmine.example.com",
             redmine_api_key="secret",
             default_project_id="1",
             wiki_project_id="2",
@@ -27,7 +27,7 @@ class TestCreateProfile:
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["main"] == {
-            "redmine_url": "https://example.com",
+            "redmine_url": "https://redmine.example.com",
             "redmine_api_key": "secret",
             "default_project_id": "1",
             "wiki_project_id": "2",
@@ -39,12 +39,12 @@ class TestCreateProfile:
         config_path = tmp_path / "config.toml"
 
         config.create_profile(
-            "main", redmine_url="https://example.com", config_path=config_path
+            "main", redmine_url="https://redmine.example.com", config_path=config_path
         )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
-        assert doc["main"] == {"redmine_url": "https://example.com"}
+        assert doc["main"] == {"redmine_url": "https://redmine.example.com"}
 
     def test_creates_parent_directory(self, tmp_path):
         """親ディレクトリが存在しなくても自動作成する"""
@@ -62,19 +62,21 @@ class TestCreateProfile:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
         """)
         )
 
         config.create_profile(
-            "sub", redmine_url="https://example.com/sub", config_path=config_path
+            "sub",
+            redmine_url="https://redmine.example.com/sub",
+            config_path=config_path,
         )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["default_profile"] == "main"
-        assert doc["main"]["redmine_url"] == "https://example.com/main"
-        assert doc["sub"]["redmine_url"] == "https://example.com/sub"
+        assert doc["main"]["redmine_url"] == "https://redmine.example.com/main"
+        assert doc["sub"]["redmine_url"] == "https://redmine.example.com/sub"
 
     def test_returns_false_when_profile_already_exists(self, tmp_path):
         """同名プロファイルが既に存在する場合はFalseを返し、内容を変更しない"""
@@ -82,26 +84,28 @@ class TestCreateProfile:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://example.com/original"
+            redmine_url = "https://redmine.example.com/original"
         """)
         )
 
         result = config.create_profile(
-            "main", redmine_url="https://example.com/overwrite", config_path=config_path
+            "main",
+            redmine_url="https://redmine.example.com/overwrite",
+            config_path=config_path,
         )
 
         assert result.created is False
         assert result.set_as_default is False
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
-        assert doc["main"]["redmine_url"] == "https://example.com/original"
+        assert doc["main"]["redmine_url"] == "https://redmine.example.com/original"
 
     def test_sets_as_default_when_only_profile(self, tmp_path):
         """作成したプロファイルが唯一のプロファイルであればdefault_profileに設定される"""
         config_path = tmp_path / "config.toml"
 
         result = config.create_profile(
-            "main", redmine_url="https://example.com", config_path=config_path
+            "main", redmine_url="https://redmine.example.com", config_path=config_path
         )
 
         assert result.set_as_default is True
@@ -117,12 +121,14 @@ class TestCreateProfile:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
         """)
         )
 
         result = config.create_profile(
-            "sub", redmine_url="https://example.com/sub", config_path=config_path
+            "sub",
+            redmine_url="https://redmine.example.com/sub",
+            config_path=config_path,
         )
 
         assert result.set_as_default is False
@@ -142,14 +148,14 @@ class TestLoadToml:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://example.com"
+            redmine_url = "https://redmine.example.com"
         """)
         )
 
         result = config.load_toml(config_path=config_path)
 
         assert result["default_profile"] == "main"
-        assert result["main"]["redmine_url"] == "https://example.com"
+        assert result["main"]["redmine_url"] == "https://redmine.example.com"
 
     def test_returns_empty_dict_when_missing(self, tmp_path):
         """指定したパスが存在しない場合は空の辞書を返す"""
@@ -169,17 +175,17 @@ class TestUpdateConfig:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://example.com/old"
+            redmine_url = "https://redmine.example.com/old"
         """)
         )
 
         config.update_config(
-            "redmine_url", "https://example.com/new", config_path=config_path
+            "redmine_url", "https://redmine.example.com/new", config_path=config_path
         )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
-        assert doc["main"]["redmine_url"] == "https://example.com/new"
+        assert doc["main"]["redmine_url"] == "https://redmine.example.com/new"
 
     def test_updates_specified_profile(self, tmp_path):
         """profile引数で指定したプロファイルを更新する"""
@@ -189,24 +195,24 @@ class TestUpdateConfig:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
 
             [sub]
-            redmine_url = "https://example.com/sub"
+            redmine_url = "https://redmine.example.com/sub"
         """)
         )
 
         config.update_config(
             "redmine_url",
-            "https://example.com/sub-new",
+            "https://redmine.example.com/sub-new",
             profile="sub",
             config_path=config_path,
         )
 
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
-        assert doc["main"]["redmine_url"] == "https://example.com/main"
-        assert doc["sub"]["redmine_url"] == "https://example.com/sub-new"
+        assert doc["main"]["redmine_url"] == "https://redmine.example.com/main"
+        assert doc["sub"]["redmine_url"] == "https://redmine.example.com/sub-new"
 
     def test_exits_when_default_profile_missing(self, tmp_path):
         """default_profileもprofile引数もない場合はexit 1する"""
@@ -214,7 +220,7 @@ class TestUpdateConfig:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
         """)
         )
 
@@ -228,7 +234,7 @@ class TestUpdateConfig:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
         """)
         )
 
@@ -248,10 +254,10 @@ class TestSetDefaultProfile:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
 
             [sub]
-            redmine_url = "https://example.com/sub"
+            redmine_url = "https://redmine.example.com/sub"
         """)
         )
 
@@ -268,7 +274,7 @@ class TestSetDefaultProfile:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
         """)
         )
 
@@ -291,11 +297,11 @@ class TestShowAllProfiles:
             default_profile = "main"
 
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
             default_project_id = "1"
 
             [sub]
-            redmine_url = "https://example.com/sub"
+            redmine_url = "https://redmine.example.com/sub"
             default_project_id = "2"
         """)
         )
@@ -305,8 +311,8 @@ class TestShowAllProfiles:
         out = capsys.readouterr().out
         doc = tomllib.loads(out)
         assert doc["default_profile"] == "main"
-        assert doc["main"]["redmine_url"] == "https://example.com/main"
-        assert doc["sub"]["redmine_url"] == "https://example.com/sub"
+        assert doc["main"]["redmine_url"] == "https://redmine.example.com/main"
+        assert doc["sub"]["redmine_url"] == "https://redmine.example.com/sub"
 
     def test_hides_api_key(self, tmp_path, capsys):
         """APIキーは出力に含まれない"""
@@ -314,11 +320,11 @@ class TestShowAllProfiles:
         config_path.write_text(
             textwrap.dedent("""\
             [main]
-            redmine_url = "https://example.com/main"
+            redmine_url = "https://redmine.example.com/main"
             redmine_api_key = "secret-main"
 
             [sub]
-            redmine_url = "https://example.com/sub"
+            redmine_url = "https://redmine.example.com/sub"
             redmine_api_key = "secret-sub"
         """)
         )


### PR DESCRIPTION
## Summary
- `redi config` はデフォルトプロファイルを表示（既存動作）
- `redi config --full` は config.toml の全プロファイルを TOML 形式で出力
- いずれも `redmine_api_key` は出力に含めない

closes #63

## Test plan
- [x] `redi config` でデフォルトプロファイルが表示される（APIキー非表示）
- [x] `redi config --full` で全プロファイルが TOML 形式で表示される（APIキー非表示）
- [x] `task check` がすべて通る