### PR TITLE
[refactor] config.py の他関数にも config_path 引数で DI を適用

### DIFF
--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -15,9 +15,10 @@ _default_config = {
 }
 
 
-def load_toml() -> dict:
-    if CONFIG_PATH.exists():
-        with open(CONFIG_PATH, "rb") as f:
+def load_toml(config_path: Path | None = None) -> dict:
+    path = config_path or CONFIG_PATH
+    if path.exists():
+        with open(path, "rb") as f:
             return tomllib.load(f)
     else:
         return {}
@@ -62,10 +63,16 @@ def check_config() -> None:
         exit(1)
 
 
-def update_config(key: str, value: str, profile: str | None = None) -> None:
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if CONFIG_PATH.exists():
-        with open(CONFIG_PATH) as f:
+def update_config(
+    key: str,
+    value: str,
+    profile: str | None = None,
+    config_path: Path | None = None,
+) -> None:
+    path = config_path or CONFIG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        with open(path) as f:
             doc = tomlkit.load(f)
     else:
         doc = tomlkit.document()
@@ -76,11 +83,11 @@ def update_config(key: str, value: str, profile: str | None = None) -> None:
         exit(1)
     profile_table = doc.get(target_profile) if target_profile in doc else None
     if not isinstance(profile_table, Table):
-        print(f"profile '{target_profile}' not found in {CONFIG_PATH}")
+        print(f"profile '{target_profile}' not found in {path}")
         exit(1)
 
     profile_table[key] = value
-    with open(CONFIG_PATH, "w") as f:
+    with open(path, "w") as f:
         tomlkit.dump(doc, f)
 
 
@@ -133,20 +140,21 @@ def create_profile(
     return CreateProfileResult(created=True, set_as_default=set_as_default)
 
 
-def set_default_profile(profile_name: str) -> bool:
-    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if CONFIG_PATH.exists():
-        with open(CONFIG_PATH) as f:
+def set_default_profile(profile_name: str, config_path: Path | None = None) -> bool:
+    path = config_path or CONFIG_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        with open(path) as f:
             doc = tomlkit.load(f)
     else:
         doc = tomlkit.document()
 
     if profile_name not in doc or not isinstance(doc.get(profile_name), dict):
-        print(f"profile '{profile_name}' not found in {CONFIG_PATH}")
+        print(f"profile '{profile_name}' not found in {path}")
         return False
 
     doc["default_profile"] = profile_name
-    with open(CONFIG_PATH, "w") as f:
+    with open(path, "w") as f:
         tomlkit.dump(doc, f)
     return True
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,5 +1,7 @@
 import tomllib
 
+import pytest
+
 from redi import config
 
 
@@ -109,3 +111,108 @@ class TestCreateProfile:
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["default_profile"] == "main"
+
+
+class TestLoadToml:
+    """load_toml()はconfig_path指定時にそのファイルを読み込む"""
+
+    def test_loads_existing_file(self, tmp_path):
+        """指定したパスが存在すれば内容を辞書として返す"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'default_profile = "main"\n\n[main]\nredmine_url = "https://example.com"\n'
+        )
+
+        result = config.load_toml(config_path=config_path)
+
+        assert result["default_profile"] == "main"
+        assert result["main"]["redmine_url"] == "https://example.com"
+
+    def test_returns_empty_dict_when_missing(self, tmp_path):
+        """指定したパスが存在しない場合は空の辞書を返す"""
+        config_path = tmp_path / "missing.toml"
+
+        assert config.load_toml(config_path=config_path) == {}
+
+
+class TestUpdateConfig:
+    """update_config()はconfig_path指定時にそのファイルを更新する"""
+
+    def test_updates_default_profile_value(self, tmp_path):
+        """default_profileで指定されたプロファイルのキーを更新する"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'default_profile = "main"\n\n[main]\nredmine_url = "https://old"\n'
+        )
+
+        config.update_config("redmine_url", "https://new", config_path=config_path)
+
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["main"]["redmine_url"] == "https://new"
+
+    def test_updates_specified_profile(self, tmp_path):
+        """profile引数で指定したプロファイルを更新する"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'default_profile = "main"\n\n[main]\nredmine_url = "https://main"\n\n[sub]\nredmine_url = "https://sub"\n'
+        )
+
+        config.update_config(
+            "redmine_url", "https://sub-new", profile="sub", config_path=config_path
+        )
+
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["main"]["redmine_url"] == "https://main"
+        assert doc["sub"]["redmine_url"] == "https://sub-new"
+
+    def test_exits_when_default_profile_missing(self, tmp_path):
+        """default_profileもprofile引数もない場合はexit 1する"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[main]\nredmine_url = "https://main"\n')
+
+        with pytest.raises(SystemExit) as e:
+            config.update_config("redmine_url", "v", config_path=config_path)
+        assert e.value.code == 1
+
+    def test_exits_when_profile_not_found(self, tmp_path):
+        """指定したprofileが存在しない場合はexit 1する"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[main]\nredmine_url = "https://main"\n')
+
+        with pytest.raises(SystemExit) as e:
+            config.update_config(
+                "redmine_url", "v", profile="missing", config_path=config_path
+            )
+        assert e.value.code == 1
+
+
+class TestSetDefaultProfile:
+    """set_default_profile()はconfig_path指定時にそのファイルのdefault_profileを更新する"""
+
+    def test_sets_default_profile(self, tmp_path):
+        """既存プロファイルをdefault_profileに設定しTrueを返す"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            '[main]\nredmine_url = "https://main"\n\n[sub]\nredmine_url = "https://sub"\n'
+        )
+
+        result = config.set_default_profile("sub", config_path=config_path)
+
+        assert result is True
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["default_profile"] == "sub"
+
+    def test_returns_false_when_profile_not_found(self, tmp_path):
+        """指定したプロファイルが存在しない場合はFalseを返し、ファイルを変更しない"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('[main]\nredmine_url = "https://main"\n')
+
+        result = config.set_default_profile("missing", config_path=config_path)
+
+        assert result is False
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert "default_profile" not in doc


### PR DESCRIPTION
closes #62 

## Summary
- `load_toml` / `update_config` / `set_default_profile` に `config_path: Path | None = None` 引数を追加（未指定時は `CONFIG_PATH` を使う既存挙動を維持）
- 上記3関数に対して `tmp_path` を使ったユニットテストを追加（monkeypatch 不要）
- 呼び出し側（`src/redi/cli/config_command.py`）は引数を渡さず既存挙動を維持

## Test plan
- [x] `task check` (format / lint / typecheck / test) がすべて通る
- [x] `redi config update --url https://example.com` で既存 `default_profile` の値を更新できる
- [x] `redi config update <profile> --url https://example.com` で指定プロファイルの値を更新できる
- [x] `redi config update --default_profile <name>` で default_profile を切り替えられる