### PR TITLE
init-redmine.sh の整備 (resolve #50 )

### DIFF
--- a/script/init-redmine.sh
+++ b/script/init-redmine.sh
@@ -34,7 +34,7 @@ INSTANT_API_KEY=$(docker exec -i redi-redmine-for-test-1 rails runner - <<RUBY
       cf = IssueCustomField.find_or_initialize_by(name: attrs[:name])
       cf.assign_attributes(attrs)
       cf.is_for_all = true
-      cf.is_required = false
+      cf.is_required = true
       cf.tracker_ids = bug_tracker_ids
       cf.save!
     end

--- a/script/init-redmine.sh
+++ b/script/init-redmine.sh
@@ -20,6 +20,9 @@ RUBY
 )
 INSTANT_API_KEY=$(echo "$INSTANT_API_KEY" | tail -1)
 
-redi config --api_key "$INSTANT_API_KEY"
-redi config --url "http://localhost:3000"
+redi config create test
+redi config update --default_profile test
+redi config update test \
+    --url "http://localhost:3000" \
+    --api_key "$INSTANT_API_KEY"
 

--- a/script/init-redmine.sh
+++ b/script/init-redmine.sh
@@ -25,16 +25,17 @@ INSTANT_API_KEY=$(docker exec -i redi-redmine-for-test-1 rails runner - <<RUBY
     project.enabled_module_names = %w[issue_tracking time_tracking news wiki]
     project.save!
 
-    # カスタムフィールドを作成（全プロジェクト・全トラッカーに適用）
+    # カスタムフィールドを作成（全プロジェクト・バグトラッカーのみに適用）
     cf_defs = [
       { name: 'バージョン',               field_format: 'string' },
     ]
+    bug_tracker_ids = Tracker.where(name: 'バグ').pluck(:id)
     cf_defs.each do |attrs|
       cf = IssueCustomField.find_or_initialize_by(name: attrs[:name])
       cf.assign_attributes(attrs)
       cf.is_for_all = true
       cf.is_required = false
-      cf.tracker_ids = Tracker.pluck(:id)
+      cf.tracker_ids = bug_tracker_ids
       cf.save!
     end
 

--- a/script/init-redmine.sh
+++ b/script/init-redmine.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 docker compose down
 docker compose up -d
 sleep 5
@@ -20,7 +22,7 @@ RUBY
 )
 INSTANT_API_KEY=$(echo "$INSTANT_API_KEY" | tail -1)
 
-redi config create test
+redi config create test || true # profile作成がべき等でないので失敗するのを当座で防ぐ
 redi config update --default_profile test
 redi config update test \
     --url "http://localhost:3000" \

--- a/script/init-redmine.sh
+++ b/script/init-redmine.sh
@@ -17,6 +17,27 @@ INSTANT_API_KEY=$(docker exec -i redi-redmine-for-test-1 rails runner - <<RUBY
 
     Setting.rest_api_enabled = '1'
 
+    # テスト用プロジェクトを作成
+    project = Project.find_or_initialize_by(identifier: 'reditest')
+    project.name = 'reditestプロジェクト'
+    project.description = 'rediのtest用に作成されたプロジェクト'
+    project.is_public = true
+    project.enabled_module_names = %w[issue_tracking time_tracking news wiki]
+    project.save!
+
+    # カスタムフィールドを作成（全プロジェクト・全トラッカーに適用）
+    cf_defs = [
+      { name: 'バージョン',               field_format: 'string' },
+    ]
+    cf_defs.each do |attrs|
+      cf = IssueCustomField.find_or_initialize_by(name: attrs[:name])
+      cf.assign_attributes(attrs)
+      cf.is_for_all = true
+      cf.is_required = false
+      cf.tracker_ids = Tracker.pluck(:id)
+      cf.save!
+    end
+
     puts User.active[0].api_key
 RUBY
 )
@@ -26,5 +47,6 @@ redi config create test || true # profile作成がべき等でないので失敗
 redi config update --default_profile test
 redi config update test \
     --url "http://localhost:3000" \
-    --api_key "$INSTANT_API_KEY"
+    --api_key "$INSTANT_API_KEY" \
+    --project_id "reditest"
 

--- a/script/init-redmine.sh
+++ b/script/init-redmine.sh
@@ -27,7 +27,11 @@ INSTANT_API_KEY=$(docker exec -i redi-redmine-for-test-1 rails runner - <<RUBY
 
     # カスタムフィールドを作成（全プロジェクト・バグトラッカーのみに適用）
     cf_defs = [
-      { name: 'バージョン',               field_format: 'string' },
+      {
+        name: 'バージョン',
+        field_format: 'string',
+        description: 'redi --version の出力',
+      },
     ]
     bug_tracker_ids = Tracker.where(name: 'バグ').pluck(:id)
     cf_defs.each do |attrs|


### PR DESCRIPTION
## Summary
- `redi config create` / `update` コマンドを使う形にセットアップスクリプトを置き換え
- `set -e` を追加して早期失敗にし、API key 取得失敗時に壊れた profile が出来るのを防止
- テスト用プロジェクト `reditest` を rails runner 側で作成し、profile の default project にも設定
- REST API で作成出来ないカスタムフィールド「バージョン」(string / 必須 / バグトラッカーのみ / description「redi --version の出力」) を作成

## Test plan
- [x] `./script/init-redmine.sh` を空の状態から実行して最後まで成功する
- [x] 2 回目の実行でも `set -e` で落ちずに最後まで走る（`redi config create test || true` が効いている）
- [ ] ~~redi` config show` で `redmine_url` / `redmine_api_key` / `default_project_id=reditest` が設定されている~~
- [x] Redmine 管理画面で `reditest` プロジェクトと `バージョン` カスタムフィールドが作成されている
- [x] `バージョン` フィールドがバグトラッカーの issue でのみ入力欄として表示される