### PR TITLE
[add] user createコマンドを追加

### DIFF
--- a/src/redi/api/user.py
+++ b/src/redi/api/user.py
@@ -1,6 +1,56 @@
 import json
 
+import requests
+
 from redi.client import client
+from redi.config import redmine_url
+
+
+def create_user(
+    login: str,
+    firstname: str,
+    lastname: str,
+    mail: str,
+    password: str | None = None,
+    auth_source_id: int | None = None,
+    mail_notification: str | None = None,
+    must_change_passwd: bool | None = None,
+    generate_password: bool | None = None,
+    admin: bool | None = None,
+) -> None:
+    user_data: dict = {
+        "login": login,
+        "firstname": firstname,
+        "lastname": lastname,
+        "mail": mail,
+    }
+    if password is not None:
+        user_data["password"] = password
+    if auth_source_id is not None:
+        user_data["auth_source_id"] = auth_source_id
+    if mail_notification is not None:
+        user_data["mail_notification"] = mail_notification
+    if must_change_passwd is not None:
+        user_data["must_change_passwd"] = must_change_passwd
+    if generate_password is not None:
+        user_data["generate_password"] = generate_password
+    if admin is not None:
+        user_data["admin"] = admin
+    response = client.post("/users.json", json={"user": user_data})
+    if response.status_code == 403:
+        print("ユーザーの作成には管理者権限が必要です")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("ユーザーの作成に失敗しました")
+        exit(1)
+    created = response.json()["user"]
+    print(
+        f"ユーザーを作成しました: {created['id']} {created['login']} {redmine_url}/users/{created['id']}"
+    )
 
 
 def list_users(project_id: str | None = None, full: bool = False) -> None:

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -1,15 +1,66 @@
 import argparse
 
+from redi.cli._common import resolve_alias
 from redi.config import default_project_id
-from redi.api.user import list_users
+from redi.api.user import create_user, list_users
 
 
 def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
-    u_parser = subparsers.add_parser("user", aliases=["u"], help="ユーザー一覧")
+    u_parser = subparsers.add_parser("user", aliases=["u"], help="ユーザー一覧/作成")
     u_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     u_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
+    u_subparsers = u_parser.add_subparsers(dest="user_command")
+    u_create_parser = u_subparsers.add_parser(
+        "create", aliases=["c"], help="ユーザー作成（管理者権限が必要）"
+    )
+    u_create_parser.add_argument("login", help="ログイン名")
+    u_create_parser.add_argument("--firstname", "-f", required=True, help="名")
+    u_create_parser.add_argument("--lastname", "-l", required=True, help="姓")
+    u_create_parser.add_argument("--mail", "-m", required=True, help="メールアドレス")
+    u_create_parser.add_argument("--password", help="パスワード")
+    u_create_parser.add_argument(
+        "--generate_password",
+        action="store_true",
+        help="パスワードを自動生成",
+    )
+    u_create_parser.add_argument("--auth_source_id", type=int, help="認証ソースID")
+    u_create_parser.add_argument(
+        "--mail_notification",
+        choices=[
+            "all",
+            "selected",
+            "only_my_events",
+            "only_assigned",
+            "only_owner",
+            "none",
+        ],
+        help="メール通知設定",
+    )
+    u_create_parser.add_argument(
+        "--must_change_passwd",
+        action="store_true",
+        help="次回ログイン時にパスワード変更を要求",
+    )
+    u_create_parser.add_argument(
+        "--admin", action="store_true", help="管理者権限を付与"
+    )
 
 
 def handle_user(args: argparse.Namespace) -> None:
+    cmd = resolve_alias(args.user_command)
+    if cmd == "create":
+        create_user(
+            login=args.login,
+            firstname=args.firstname,
+            lastname=args.lastname,
+            mail=args.mail,
+            password=args.password,
+            auth_source_id=args.auth_source_id,
+            mail_notification=args.mail_notification,
+            must_change_passwd=args.must_change_passwd or None,
+            generate_password=args.generate_password or None,
+            admin=args.admin or None,
+        )
+        return
     project_id = args.project_id or default_project_id
     list_users(project_id=project_id, full=args.full)


### PR DESCRIPTION
## Summary
- closes #67 
- `redi user create <login> --firstname <name> --lastname <name> --mail <addr>` でユーザーを作成できるようにした（管理者権限が必要）
- 対話プロンプトは用意せず、ワンライナーでの実行のみ対応
- オプション: `--password` / `--generate_password` / `--auth_source_id` / `--mail_notification` / `--must_change_passwd` / `--admin`

## Test plan
- [x] `redi user create --help` でヘルプが表示される
- [x] `redi user create <login> -f <firstname> -l <lastname> -m <mail> --password <pass>` でユーザーが作成される
- [ ] 既存の `redi user` / `redi u -p <project_id>` の挙動が変わらない
- [x] 重複するログイン/メールで 422 エラーメッセージが表示される
- [x] 非管理者 API key で 403 の場合に案内が表示される