### PR TITLE
[add] --profile オプションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ redi config create <profile_name> --url <url> --api_key <key> # create new profi
 redi config create <profile_name> --url <url> --api_key <key> --set_default
 redi config update --default_profile <profile_name> # switch profile
 redi config update <profile_name> --editor nvim # update profile
+redi --profile <profile_name> issue # 一時的にプロファイルを切り替えて実行
 
 # project (alias: p)
 redi project # list projects

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -52,6 +52,10 @@ def _build_parser() -> tuple[argparse.ArgumentParser, argparse.ArgumentParser]:
     )
     parser.add_argument("--tui", action="store_true", help="TUI")
     parser.add_argument("--debug", action="store_true", help="デバッグログを有効にする")
+    parser.add_argument(
+        "--profile",
+        help="使用するプロファイル名（config.tomlのdefault_profileを一時的に上書き）",
+    )
     subparsers = parser.add_subparsers(dest="command")
     add_project_parser(subparsers)
     add_issue_parser(subparsers)

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import tomllib
 from pathlib import Path
 from typing import NamedTuple
@@ -32,15 +33,35 @@ def load_env_config() -> dict:
     }
 
 
+def resolve_profile_name(toml: dict, argv: list[str]) -> tuple[str | None, bool]:
+    """argvに--profileがあればそれを、なければdefault_profileを返す。
+
+    第二要素はCLI(--profile)で明示指定されたかどうかを示す。
+    """
+    for i, arg in enumerate(argv):
+        if arg == "--profile" and i + 1 < len(argv):
+            return argv[i + 1], True
+        if arg.startswith("--profile="):
+            return arg.split("=", 1)[1], True
+    return toml.get("default_profile"), False
+
+
 # 設定値の上書き
 merged_config = _default_config
 toml = load_toml()
-default_profile_name = toml.get("default_profile")
-if default_profile_name:
-    toml_config = load_toml()[default_profile_name]
-    for k, v in toml_config.items():
-        if v:
-            merged_config[k] = v
+selected_profile_name, _profile_explicit = resolve_profile_name(toml, sys.argv)
+if selected_profile_name:
+    if selected_profile_name in toml and isinstance(toml[selected_profile_name], dict):
+        toml_config = toml[selected_profile_name]
+        for k, v in toml_config.items():
+            if v:
+                merged_config[k] = v
+    elif _profile_explicit:
+        print(
+            f"profile '{selected_profile_name}' not found in {CONFIG_PATH}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 env_config = load_env_config()
 for k, v in env_config.items():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -286,6 +286,59 @@ class TestSetDefaultProfile:
         assert "default_profile" not in doc
 
 
+class TestResolveProfileName:
+    """resolve_profile_name()はargvの--profileを優先しdefault_profileにfallbackする"""
+
+    def test_returns_default_profile_when_no_cli_flag(self):
+        """--profileが無ければdefault_profileを返し、明示フラグはFalse"""
+        toml = {"default_profile": "main"}
+
+        name, explicit = config.resolve_profile_name(toml, ["redi", "issue"])
+
+        assert name == "main"
+        assert explicit is False
+
+    def test_cli_flag_space_separated_overrides_default(self):
+        """`--profile sub`形式のargvがdefault_profileを上書きする"""
+        toml = {"default_profile": "main"}
+
+        name, explicit = config.resolve_profile_name(
+            toml, ["redi", "--profile", "sub", "issue"]
+        )
+
+        assert name == "sub"
+        assert explicit is True
+
+    def test_cli_flag_equals_form_overrides_default(self):
+        """`--profile=sub`形式のargvがdefault_profileを上書きする"""
+        toml = {"default_profile": "main"}
+
+        name, explicit = config.resolve_profile_name(
+            toml, ["redi", "--profile=sub", "issue"]
+        )
+
+        assert name == "sub"
+        assert explicit is True
+
+    def test_returns_none_when_no_default_and_no_flag(self):
+        """default_profileもargvも無い場合はNoneを返す"""
+        name, explicit = config.resolve_profile_name({}, ["redi", "issue"])
+
+        assert name is None
+        assert explicit is False
+
+    def test_does_not_match_default_profile_flag(self):
+        """--default_profileは--profileに誤マッチしない"""
+        toml = {"default_profile": "main"}
+
+        name, explicit = config.resolve_profile_name(
+            toml, ["redi", "config", "update", "--default_profile", "sub"]
+        )
+
+        assert name == "main"
+        assert explicit is False
+
+
 class TestShowAllProfiles:
     """show_all_profiles()はconfig_path指定時にそのファイルの全プロファイルを表示する"""
 


### PR DESCRIPTION
## Summary
- closes #69 
- 実行時に `--profile <name>` を指定して config.toml の `default_profile` を一時的に上書きできるようにした
- `--profile=sub` / `--profile sub` の両形式に対応
- 存在しないプロファイル名を指定した場合は stderr にメッセージを出して exit 1

## Test plan
- [x] `redi --profile sub config` で `sub` プロファイルの内容が表示される
- [x] `redi --profile=main config` (`=` 形式) でも同様に動作する
- [x] `--profile` を付けない場合は従来通り `default_profile` が使われる
- [x] 存在しないプロファイルを指定したらエラーで終了する
- [x] `redi config update --default_profile xxx` が `--profile` に誤マッチしない
- [x] `task check` (`ruff format/check`, `ty`, `pytest`) が通る