### PR TITLE
[update] issue create でformat:text,format:list の必須なカスタムフィールドに対して対応出来るようにした

### DIFF
--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -6,7 +6,7 @@ from redi.client import client
 CACHE_KEY = "custom_fields"
 
 
-def fetch_custom_fields() -> list[dict]:
+def fetch_custom_fields() -> list[dict] | None:
     cached = cache.load(CACHE_KEY)
     if cached is not None:
         return cached
@@ -15,7 +15,7 @@ def fetch_custom_fields() -> list[dict]:
         # https://www.redmine.org/projects/redmine/wiki/Rest_CustomFields
         # https://www.redmine.org/issues/18875
         print("カスタムフィールドの取得には管理者権限が必要です")
-        exit()
+        return
     response.raise_for_status()
     data = response.json()["custom_fields"]
     cache.save(CACHE_KEY, data)
@@ -27,8 +27,9 @@ def list_custom_fields(full: bool = False) -> None:
     if full:
         print(json.dumps(custom_fields, ensure_ascii=False))
     else:
-        for cf in custom_fields:
-            print(f"{cf['id']} {cf['name']}")
+        if custom_fields:
+            for cf in custom_fields:
+                print(f"{cf['id']} {cf['name']}")
 
 
 def fetch_project_issue_custom_field_ids(project_id: str) -> set[int]:

--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -29,3 +29,42 @@ def list_custom_fields(full: bool = False) -> None:
     else:
         for cf in custom_fields:
             print(f"{cf['id']} {cf['name']}")
+
+
+def fetch_project_issue_custom_field_ids(project_id: str) -> set[int]:
+    """プロジェクトで有効なイシュー用カスタムフィールドのIDを取得する。"""
+    response = client.get(
+        f"/projects/{project_id}.json", params={"include": "issue_custom_fields"}
+    )
+    response.raise_for_status()
+    project = response.json()["project"]
+
+    return {cf["id"] for cf in project.get("issue_custom_fields") or []}
+
+
+def filter_required_issue_custom_fields(
+    custom_fields: list[dict],
+    project_cf_ids: set[int],
+    tracker_id: str | None,
+) -> list[dict]:
+    """
+    入力必須・初期値なし・プロジェクト/トラッカーに該当する
+    イシュー用カスタムフィールドを抽出する。
+    """
+    result = []
+    for cf in custom_fields:
+        if cf.get("customized_type") != "issue":
+            continue
+        if not cf.get("is_required"):
+            continue
+        if cf.get("default_value"):
+            continue
+        if cf["id"] not in project_cf_ids:
+            continue
+        trackers = cf.get("trackers") or []
+        if trackers and tracker_id is not None:
+            tracker_ids = {str(t["id"]) for t in trackers}
+            if str(tracker_id) not in tracker_ids:
+                continue
+        result.append(cf)
+    return result

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -20,6 +20,12 @@ from redi.api.time_entry import create_time_entry
 from redi.api.tracker import fetch_trackers
 from redi.api.version import fetch_versions
 
+from redi.api.custom_field import (
+    fetch_custom_fields,
+    fetch_project_issue_custom_field_ids,
+    filter_required_issue_custom_fields,
+)
+
 
 def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     i_parser = subparsers.add_parser(
@@ -254,6 +260,63 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         )
 
 
+def _prompt_custom_field_value(cf: dict) -> str | None:
+    name = cf.get("name", "")
+    fmt = cf.get("field_format", "string")
+    label = f"{name}（必須）"
+    # not support All formats
+    if fmt == "list":
+        possible = cf.get("possible_values") or []
+        choices = [
+            questionary.Choice(
+                title=str(pv.get("value", "")), value=str(pv.get("value", ""))
+            )
+            for pv in possible
+            if pv.get("value", "") != ""
+        ]
+        if choices:
+            return questionary.select(label, choices=choices).ask(kbi_msg="")
+    return questionary.text(label).ask(kbi_msg="")
+
+
+def _interactive_fill_required_custom_fields(
+    project_id: str, tracker_id: str | None, existing: str | None
+) -> str | None:
+    custom_fields = fetch_custom_fields()
+    if custom_fields is None:
+        print(
+            "カスタムフィールドの取得には管理者権限が必要なため、必須カスタムフィールドの対話入力をスキップしました"
+        )
+        return existing
+    project_cf_ids = fetch_project_issue_custom_field_ids(project_id)
+    required = filter_required_issue_custom_fields(
+        custom_fields, project_cf_ids, tracker_id
+    )
+    if not required:
+        return existing
+
+    existing_ids: set[int] = set()
+    if existing:
+        for pair in existing.split(","):
+            key = pair.split("=")[0]
+            existing_ids.add(int(key))
+
+    added: list[str] = []
+    for cf in required:
+        if cf["id"] in existing_ids:
+            continue
+        value = _prompt_custom_field_value(cf)
+        if value is None:
+            print("キャンセルしました")
+            exit(1)
+        added.append(f"{cf['id']}={value}")
+    if not added:
+        return existing
+    if existing:
+        return existing + "," + ",".join(added)
+    return ",".join(added)
+
+
 def handle_issue_create(args: argparse.Namespace) -> None:
     project_id = args.project_id or default_project_id
     if not project_id:
@@ -261,6 +324,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
         exit(1)
     subject = args.subject
     tracker_id = args.tracker_id
+    custom_fields = args.custom_fields
     if subject is None:
         if tracker_id is None:
             trackers = fetch_trackers()
@@ -279,6 +343,12 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             print("題名が空のためキャンセルしました")
             exit(1)
         subject = subject.strip()
+        # 必要なカスタムフィールドを対話的に入力
+        custom_fields = _interactive_fill_required_custom_fields(
+            project_id=project_id,
+            tracker_id=tracker_id,
+            existing=args.custom_fields,
+        )
     if args.description is None:
         description = open_editor()
     else:
@@ -290,7 +360,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
         tracker_id=tracker_id,
         priority_id=args.priority_id,
         assigned_to_id=args.assigned_to_id,
-        custom_fields=args.custom_fields,
+        custom_fields=custom_fields,
     )
 
 


### PR DESCRIPTION
resolve #18 

- https://github.com/kawagh/redi/pull/39 を再作成したもの

## 動作確認

### 非管理者

- 以下のようにしてcustom_fileldを求められた際に作成出来ること　　　　

```
redi i c --custom_fields 1=0.0.12,2=optionB
```

### custom_fields を取得できる管理者
- `redi i c`でテキストとリスト形式で必須のものを入力してissueが作成できること
- 全プロジェクト向けやプロジェクトを指定しなかった場合に入力を求められないこと
- 該当しないトラッカーのイシュー作成では入力を求められないこと

`redi custom_field --full | jq`

```json
[
  {
    "id": 1,
    "name": "バージョン",
    "description": "redi --version の出力",
    "customized_type": "issue",
    "field_format": "string",
    "regexp": "",
    "min_length": null,
    "max_length": null,
    "is_required": true,
    "is_filter": false,
    "searchable": false,
    "multiple": false,
    "default_value": null,
    "visible": true,
    "editable": true,
    "trackers": [
      {
        "id": 1,
        "name": "バグ"
      }
    ],
    "roles": []
  },
  {
    "id": 2,
    "name": "ドロップダウン",
    "description": "",
    "customized_type": "issue",
    "field_format": "list",
    "regexp": "",
    "min_length": null,
    "max_length": null,
    "is_required": true,
    "is_filter": false,
    "searchable": false,
    "multiple": false,
    "default_value": "",
    "visible": true,
    "editable": true,
    "possible_values": [
      {
        "value": "optionA",
        "label": "optionA"
      },
      {
        "value": "optionB",
        "label": "optionB"
      },
      {
        "value": "optionC",
        "label": "optionC"
      }
    ],
    "trackers": [
      {
        "id": 1,
        "name": "バグ"
      }
    ],
    "roles": []
  }
]
```