### PR TITLE
対話フローを prompt_toolkit に統一し questionary 依存を削除

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires-python = ">=3.13"
 dependencies = [
     "argcomplete>=3.6.3",
     "prompt-toolkit>=3.0.52",
-    "questionary>=2.1.1",
     "requests>=2.33.1",
     "tomlkit>=0.14.0",
     "wcwidth>=0.2.13",

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -32,8 +32,10 @@ def resolve_alias(command: str | None) -> str | None:
 def inline_checkbox(
     message: str,
     values: list[tuple[str, str]],
+    initial_value: str | None = None,
 ) -> list[str]:
-    cursor = 0
+    keys = [v for v, _ in values]
+    cursor = keys.index(initial_value) if initial_value in keys else 0
     checked: set[str] = set()
 
     def render():

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -2,17 +2,12 @@ import os
 import subprocess
 import tempfile
 
-import questionary
-import questionary.prompts.common
 from prompt_toolkit import Application
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import HSplit, Layout, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from redi.config import editor
-
-questionary.prompts.common.INDICATOR_SELECTED = "[x]"  # ty: ignore[invalid-assignment]  # pyright: ignore[reportPrivateImportUsage]
-questionary.prompts.common.INDICATOR_UNSELECTED = "[ ]"  # ty: ignore[invalid-assignment]  # pyright: ignore[reportPrivateImportUsage]
 
 
 SUBCOMMAND_ALIASES: dict[str, str] = {

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -1,7 +1,7 @@
 import argparse
 
-import questionary
 from prompt_toolkit import prompt
+from prompt_toolkit.validation import Validator
 
 from redi.cli._common import inline_checkbox, inline_choice, open_editor, resolve_alias
 from redi.config import default_project_id
@@ -154,16 +154,16 @@ def _interactive_select_issue_id() -> str:
     if not issues:
         print("選択可能なイシューがありません")
         exit(1)
-    issue_id = questionary.select(
-        "更新するイシューを選択",
-        choices=[
-            questionary.Choice(f"#{i['id']} {i['subject']}", value=str(i["id"]))
-            for i in issues
-        ],
-    ).ask(kbi_msg="")
-    if not issue_id:
-        print("イシューが選択されていないためキャンセルしました")
+    options: list[tuple[str, str]] = [
+        (str(i["id"]), f"#{i['id']} {i['subject']}") for i in issues
+    ]
+    labels = dict(options)
+    try:
+        issue_id = inline_choice("更新するイシューを選択", options)
+    except KeyboardInterrupt:
+        print("キャンセルしました")
         exit(1)
+    print(f"更新するイシュー: {labels[issue_id]}")
     return issue_id
 
 
@@ -193,76 +193,73 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         exit(1)
     labels = dict(field_values)
     print(f"更新する項目: {', '.join(labels[v] for v in selected)}")
-    if "tracker" in selected:
-        trackers = fetch_trackers()
-        args.tracker_id = questionary.select(
-            "トラッカー",
-            choices=[
-                questionary.Choice(t["name"], value=str(t["id"])) for t in trackers
-            ],
-        ).ask(kbi_msg="")
-    if "subject" in selected:
-        args.subject = questionary.text(
-            "題名", default=current.get("subject") or ""
-        ).ask(kbi_msg="")
-    if "description" in selected:
-        args.description = ""
-    if "status" in selected:
-        statuses = fetch_issue_statuses()
-        args.status_id = questionary.select(
-            "ステータス",
-            choices=[
-                questionary.Choice(s["name"], value=str(s["id"])) for s in statuses
-            ],
-        ).ask(kbi_msg="")
-    if "priority" in selected:
-        priorities = fetch_issue_priorities()
-        args.priority_id = questionary.select(
-            "優先度",
-            choices=[
-                questionary.Choice(p["name"], value=str(p["id"])) for p in priorities
-            ],
-        ).ask(kbi_msg="")
-    if "fixed_version" in selected:
-        project_id = (current.get("project") or {}).get("id")
-        if not project_id:
-            print("プロジェクトが特定できないためキャンセルしました")
-            exit(1)
-        versions = fetch_versions(str(project_id))
-        args.fixed_version_id = questionary.select(
-            "対象バージョン",
-            choices=[
-                questionary.Choice(f"{v['name']} ({v['status']})", value=str(v["id"]))
-                for v in versions
-            ],
-        ).ask(kbi_msg="")
-    if "notes" in selected:
-        args.notes = questionary.text("コメント").ask(kbi_msg="")
-    if "time_entry" in selected:
-        hours_str = questionary.text(
-            "作業時間（例: 1.5 (h)）",
-            validate=lambda v: (
-                v.replace(".", "", 1).isdigit() or "数値を入力してください"
-            ),
-        ).ask(kbi_msg="")
-        if hours_str:
-            args.hours = float(hours_str)
-        activities = fetch_time_entry_activities()
-        args.activity_id = questionary.select(
-            "作業分類",
-            choices=[
-                questionary.Choice(a["name"], value=str(a["id"])) for a in activities
-            ],
-        ).ask(kbi_msg="")
-        args.spent_on = (
-            questionary.text("作業日（YYYY-MM-DD、省略で今日）", default="").ask(
-                kbi_msg=""
+    try:
+        if "tracker" in selected:
+            trackers = fetch_trackers()
+            tracker_options: list[tuple[str, str]] = [
+                (str(t["id"]), t["name"]) for t in trackers
+            ]
+            tracker_labels = dict(tracker_options)
+            args.tracker_id = inline_choice("トラッカー", tracker_options)
+            print(f"トラッカー: {tracker_labels[args.tracker_id]}")
+        if "subject" in selected:
+            args.subject = prompt(
+                "題名: ", default=current.get("subject") or ""
+            ).strip()
+        if "description" in selected:
+            args.description = ""
+        if "status" in selected:
+            statuses = fetch_issue_statuses()
+            status_options: list[tuple[str, str]] = [
+                (str(s["id"]), s["name"]) for s in statuses
+            ]
+            status_labels = dict(status_options)
+            args.status_id = inline_choice("ステータス", status_options)
+            print(f"ステータス: {status_labels[args.status_id]}")
+        if "priority" in selected:
+            priorities = fetch_issue_priorities()
+            priority_options: list[tuple[str, str]] = [
+                (str(p["id"]), p["name"]) for p in priorities
+            ]
+            priority_labels = dict(priority_options)
+            args.priority_id = inline_choice("優先度", priority_options)
+            print(f"優先度: {priority_labels[args.priority_id]}")
+        if "fixed_version" in selected:
+            project_id = (current.get("project") or {}).get("id")
+            if not project_id:
+                print("プロジェクトが特定できないためキャンセルしました")
+                exit(1)
+            versions = fetch_versions(str(project_id))
+            version_options: list[tuple[str, str]] = [
+                (str(v["id"]), f"{v['name']} ({v['status']})") for v in versions
+            ]
+            version_labels = dict(version_options)
+            args.fixed_version_id = inline_choice("対象バージョン", version_options)
+            print(f"対象バージョン: {version_labels[args.fixed_version_id]}")
+        if "notes" in selected:
+            args.notes = prompt("コメント: ").strip()
+        if "time_entry" in selected:
+            hours_validator = Validator.from_callable(
+                lambda v: v.replace(".", "", 1).isdigit(),
+                error_message="数値を入力してください",
             )
-            or None
-        )
-        args.time_comments = (
-            questionary.text("作業時間のコメント", default="").ask(kbi_msg="") or None
-        )
+            hours_str = prompt(
+                "作業時間（例: 1.5 (h)）: ", validator=hours_validator
+            ).strip()
+            if hours_str:
+                args.hours = float(hours_str)
+            activities = fetch_time_entry_activities()
+            activity_options: list[tuple[str, str]] = [
+                (str(a["id"]), a["name"]) for a in activities
+            ]
+            activity_labels = dict(activity_options)
+            args.activity_id = inline_choice("作業分類", activity_options)
+            print(f"作業分類: {activity_labels[args.activity_id]}")
+            args.spent_on = prompt("作業日（YYYY-MM-DD、省略で今日）: ").strip() or None
+            args.time_comments = prompt("作業時間のコメント: ").strip() or None
+    except (KeyboardInterrupt, EOFError):
+        print("キャンセルしました")
+        exit(1)
 
 
 def _prompt_custom_field_value(cf: dict) -> str | None:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -1,8 +1,9 @@
 import argparse
 
 import questionary
+from prompt_toolkit import prompt
 
-from redi.cli._common import inline_checkbox, open_editor, resolve_alias
+from redi.cli._common import inline_checkbox, inline_choice, open_editor, resolve_alias
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
@@ -271,16 +272,20 @@ def _prompt_custom_field_value(cf: dict) -> str | None:
     # not support All formats
     if fmt == "list":
         possible = cf.get("possible_values") or []
-        choices = [
-            questionary.Choice(
-                title=str(pv.get("value", "")), value=str(pv.get("value", ""))
-            )
+        options: list[tuple[str, str]] = [
+            (str(pv.get("value", "")), str(pv.get("value", "")))
             for pv in possible
             if pv.get("value", "") != ""
         ]
-        if choices:
-            return questionary.select(label, choices=choices).ask(kbi_msg="")
-    return questionary.text(label).ask(kbi_msg="")
+        if options:
+            try:
+                return inline_choice(label, options)
+            except KeyboardInterrupt:
+                return None
+    try:
+        return prompt(f"{label}: ").strip() or None
+    except (KeyboardInterrupt, EOFError):
+        return None
 
 
 def _interactive_fill_required_custom_fields(
@@ -330,21 +335,22 @@ def handle_issue_create(args: argparse.Namespace) -> None:
     if subject is None:
         if tracker_id is None:
             trackers = fetch_trackers()
-            choices = [
-                questionary.Choice(title=t["name"], value=str(t["id"]))
-                for t in trackers
+            tracker_options: list[tuple[str, str]] = [
+                (str(t["id"]), t["name"]) for t in trackers
             ]
-            tracker_id = questionary.select("トラッカーを選択", choices=choices).ask(
-                kbi_msg=""
-            )
-            if tracker_id is None:
+            try:
+                tracker_id = inline_choice("トラッカーを選択", tracker_options)
+            except KeyboardInterrupt:
                 print("キャンセルしました")
                 exit(1)
-        subject = questionary.text("題名").ask(kbi_msg="")
+        try:
+            subject = prompt("題名: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("キャンセルしました")
+            exit(1)
         if not subject:
             print("題名が空のためキャンセルしました")
             exit(1)
-        subject = subject.strip()
         # 必要なカスタムフィールドを対話的に入力
         custom_fields = _interactive_fill_required_custom_fields(
             project_id=project_id,

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -279,9 +279,11 @@ def _prompt_custom_field_value(cf: dict) -> str | None:
         ]
         if options:
             try:
-                return inline_choice(label, options)
+                value = inline_choice(label, options)
             except KeyboardInterrupt:
                 return None
+            print(f"{name}: {value}")
+            return value
     try:
         return prompt(f"{label}: ").strip() or None
     except (KeyboardInterrupt, EOFError):
@@ -338,11 +340,13 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             tracker_options: list[tuple[str, str]] = [
                 (str(t["id"]), t["name"]) for t in trackers
             ]
+            labels = dict(tracker_options)
             try:
                 tracker_id = inline_choice("トラッカーを選択", tracker_options)
             except KeyboardInterrupt:
                 print("キャンセルしました")
                 exit(1)
+            print(f"トラッカー: {labels[tracker_id]}")
         try:
             subject = prompt("題名: ").strip()
         except (KeyboardInterrupt, EOFError):

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -2,7 +2,7 @@ import argparse
 
 import questionary
 
-from redi.cli._common import open_editor, resolve_alias
+from redi.cli._common import inline_checkbox, open_editor, resolve_alias
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
@@ -168,26 +168,30 @@ def _interactive_select_issue_id() -> str:
 
 def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
     current = fetch_issue(args.issue_id)
-    field_choices = [
-        questionary.Choice("トラッカー (tracker)", value="tracker"),
-        questionary.Choice("題名 (subject)", value="subject"),
-        questionary.Choice("説明 (description)", value="description"),
-        questionary.Choice("ステータス (status)", value="status"),
-        questionary.Choice("優先度 (priority)", value="priority"),
-        questionary.Choice("対象バージョン (fixed_version)", value="fixed_version"),
-        questionary.Choice("コメント (notes)", value="notes"),
-        questionary.Choice("作業時間 (time_entry)", value="time_entry"),
+    field_values: list[tuple[str, str]] = [
+        ("tracker", "トラッカー (tracker)"),
+        ("subject", "題名 (subject)"),
+        ("description", "説明 (description)"),
+        ("status", "ステータス (status)"),
+        ("priority", "優先度 (priority)"),
+        ("fixed_version", "対象バージョン (fixed_version)"),
+        ("notes", "コメント (notes)"),
+        ("time_entry", "作業時間 (time_entry)"),
     ]
-    description_choice = next(c for c in field_choices if c.value == "description")
-    selected = questionary.checkbox(
-        "更新する項目を選択",
-        choices=field_choices,
-        style=questionary.Style([("selected", "noreverse")]),
-        initial_choice=description_choice,
-    ).ask(kbi_msg="")
+    try:
+        selected = inline_checkbox(
+            "更新する項目を選択 (Spaceで選択、Enterで確定)",
+            field_values,
+            initial_value="description",
+        )
+    except KeyboardInterrupt:
+        print("キャンセルしました")
+        exit(1)
     if not selected:
         print("更新する項目が選択されていないためキャンセルしました")
         exit(1)
+    labels = dict(field_values)
+    print(f"更新する項目: {', '.join(labels[v] for v in selected)}")
     if "tracker" in selected:
         trackers = fetch_trackers()
         args.tracker_id = questionary.select(

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -1,8 +1,9 @@
 import argparse
 
-import questionary
+from prompt_toolkit import prompt
+from prompt_toolkit.validation import ValidationError, Validator
 
-from redi.cli._common import open_editor, resolve_alias
+from redi.cli._common import inline_choice, open_editor, resolve_alias
 from redi.config import default_project_id, wiki_project_id
 from redi.api.wiki import (
     build_children_map,
@@ -16,17 +17,17 @@ from redi.api.wiki import (
 )
 
 
-def build_wiki_tree_choices(pages: list[dict]) -> list[questionary.Choice]:
+def build_wiki_tree_choices(pages: list[dict]) -> list[tuple[str, str]]:
     children_map = build_children_map(pages)
-    choices: list[questionary.Choice] = []
+    options: list[tuple[str, str]] = []
 
     def walk(parent: str | None, depth: int) -> None:
         for title in children_map.get(parent, []):
-            choices.append(questionary.Choice("  " * depth + title, value=title))
+            options.append((title, "  " * depth + title))
             walk(title, depth + 1)
 
     walk(None, 0)
-    return choices
+    return options
 
 
 def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -92,26 +93,38 @@ def handle_wiki(args: argparse.Namespace) -> None:
             pages = fetch_wikis(project_id)
             existing_titles = {normalize_title(p["title"]) for p in pages}
 
-            def validate_page_title(value: str) -> bool | str:
-                stripped = value.strip()
-                if not stripped:
-                    return "ページタイトルを入力してください"
-                if normalize_title(stripped) in existing_titles:
-                    return "既存のページタイトルと重複しています"
-                return True
+            class _PageTitleValidator(Validator):
+                def validate(self, document) -> None:
+                    stripped = document.text.strip()
+                    if not stripped:
+                        raise ValidationError(
+                            message="ページタイトルを入力してください"
+                        )
+                    if normalize_title(stripped) in existing_titles:
+                        raise ValidationError(
+                            message="既存のページタイトルと重複しています"
+                        )
 
-            page_title = questionary.text(
-                "ページタイトル",
-                validate=validate_page_title,
-            ).ask(kbi_msg="")
+            try:
+                page_title = prompt(
+                    "ページタイトル: ", validator=_PageTitleValidator()
+                ).strip()
+            except (KeyboardInterrupt, EOFError):
+                print("キャンセルしました")
+                exit(1)
             if not page_title:
                 print("ページタイトルが空のためキャンセルしました")
                 exit(1)
             if parent_title is None:
-                parent_title = questionary.select(
-                    "親ページ",
-                    choices=build_wiki_tree_choices(pages),
-                ).ask(kbi_msg="")
+                parent_options = build_wiki_tree_choices(pages)
+                if parent_options:
+                    parent_labels = dict(parent_options)
+                    try:
+                        parent_title = inline_choice("親ページ", parent_options)
+                    except KeyboardInterrupt:
+                        print("キャンセルしました")
+                        exit(1)
+                    print(f"親ページ: {parent_labels[parent_title].strip()}")
         if args.description and args.description != "":
             text = args.description
         else:
@@ -130,13 +143,14 @@ def handle_wiki(args: argparse.Namespace) -> None:
             if not pages:
                 print("Wikiページが存在しません")
                 exit(1)
-            page_title = questionary.select(
-                "編集するページ",
-                choices=build_wiki_tree_choices(pages),
-            ).ask(kbi_msg="")
-            if not page_title:
+            page_options = build_wiki_tree_choices(pages)
+            page_labels = dict(page_options)
+            try:
+                page_title = inline_choice("編集するページ", page_options)
+            except KeyboardInterrupt:
                 print("キャンセルしました")
                 exit(1)
+            print(f"編集するページ: {page_labels[page_title].strip()}")
         if args.description and args.description != "":
             text = args.description
         else:

--- a/uv.lock
+++ b/uv.lock
@@ -160,25 +160,12 @@ wheels = [
 ]
 
 [[package]]
-name = "questionary"
-version = "2.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prompt-toolkit" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
-]
-
-[[package]]
 name = "redi"
 version = "0.0.13"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },
     { name = "prompt-toolkit" },
-    { name = "questionary" },
     { name = "requests" },
     { name = "tomlkit" },
     { name = "wcwidth" },
@@ -195,7 +182,6 @@ dev = [
 requires-dist = [
     { name = "argcomplete", specifier = ">=3.6.3" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
-    { name = "questionary", specifier = ">=2.1.1" },
     { name = "requests", specifier = ">=2.33.1" },
     { name = "tomlkit", specifier = ">=0.14.0" },
     { name = "wcwidth", specifier = ">=0.2.13" },


### PR DESCRIPTION
## Summary
- `issue` / `wiki` / `version` の対話フローで使っていた `questionary` を `_common.inline_choice` / `inline_checkbox` / `prompt_toolkit.prompt` に置き換え
- 各 choice / checkbox の後に選択したラベルを表示するように統一(`done (N selections)` 等の自動サマリを自前表示に)
- `questionary` への依存を `pyproject.toml` / `uv.lock` から削除

refs #72 

## Test plan
- [x] `redi issue create` で対話的にトラッカー選択 → 題名 → 必須カスタムフィールド入力 → 説明エディタ起動 まで動作する
- [x] `redi issue update` (id 省略) で対話的にイシュー選択 → 更新項目選択 → 各項目入力 まで動作する (description / notes / time_entry 含む)
- [x] `redi wiki create` で対話的にページタイトル入力 (バリデーション含む) → 親ページ選択 → 説明エディタ起動 まで動作する
- [x] `redi wiki update` で対話的にページ選択 → 既存 text 編集 まで動作する
- [x] `redi version update` (既存機能) のフローに影響がないこと
- [x] `task check` (format / lint / typecheck / pytest) が通る