### PR TITLE
[add] --debug-tui で TUI スクリーン内容を YAML 形式でログ出力

### DIFF
--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -53,6 +53,11 @@ def _build_parser() -> tuple[argparse.ArgumentParser, argparse.ArgumentParser]:
     parser.add_argument("--tui", action="store_true", help="TUI")
     parser.add_argument("--debug", action="store_true", help="デバッグログを有効にする")
     parser.add_argument(
+        "--debug-tui",
+        action="store_true",
+        help="TUI のスクリーン内容を YAML 形式でログ出力する",
+    )
+    parser.add_argument(
         "--profile",
         help="使用するプロファイル名（config.tomlのdefault_profileを一時的に上書き）",
     )
@@ -102,8 +107,13 @@ def main() -> None:
 
     if args.tui and args.command is None:
         tui_state = TuiState()
+        debug_log_path = None
+        if args.debug_tui:
+            debug_log_path = CONFIG_PATH.parent / "redi-debug-tui.yaml"
+            debug_log_path.parent.mkdir(parents=True, exist_ok=True)
+            debug_log_path.write_text("", encoding="utf-8")
         while True:
-            tui_result = run_issue_tui(state=tui_state)
+            tui_result = run_issue_tui(state=tui_state, debug_log_path=debug_log_path)
             if tui_result is None:
                 return
             tui_state = TuiState(last_result=tui_result)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -1,6 +1,7 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
 import logging
+from datetime import datetime
 from importlib.metadata import version
 
 import argcomplete
@@ -109,9 +110,9 @@ def main() -> None:
         tui_state = TuiState()
         debug_log_path = None
         if args.debug_tui:
-            debug_log_path = CONFIG_PATH.parent / "redi-debug-tui.yaml"
+            timestamp = datetime.now().strftime("%Y-%m-%dT%H-%M-%S")
+            debug_log_path = CONFIG_PATH.parent / f"redi-debug-tui-{timestamp}.yaml"
             debug_log_path.parent.mkdir(parents=True, exist_ok=True)
-            debug_log_path.write_text("", encoding="utf-8")
         while True:
             tui_result = run_issue_tui(state=tui_state, debug_log_path=debug_log_path)
             if tui_result is None:

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -89,6 +89,9 @@ def main() -> None:
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
+    if args.debug_tui:
+        args.tui = True
+
     if args.debug:
         log_path = CONFIG_PATH.parent / "redi-debug.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/redi/tui.py
+++ b/src/redi/tui.py
@@ -1,6 +1,8 @@
 import shutil
 import webbrowser
 from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
 from typing import Literal
 
 from prompt_toolkit import Application
@@ -12,6 +14,39 @@ from wcwidth import wcswidth
 
 from redi.config import default_project_id, redmine_url
 from redi.api.issue import fetch_issue, fetch_issues
+
+
+def dump_rendered_screen(app: Application) -> dict:
+    """
+    最後にレンダリングした画面 (`_last_screen`) の内容を
+    `{"width": int, "height": int, "lines": [str, ...]}` 形式で返す。
+    """
+    screen = app.renderer._last_screen
+    if screen is None:
+        return {"width": 0, "height": 0, "lines": []}
+    size = app.output.get_size()
+    width, height = size.columns, size.rows
+    lines = []
+    for y in range(height):
+        row = screen.data_buffer[y]
+        line = "".join(row[x].char for x in range(width)).rstrip()
+        lines.append(line)
+    return {"width": width, "height": height, "lines": lines}
+
+
+def _append_screen_yaml(path: Path, dumped: dict, key: str) -> None:
+    timestamp = datetime.now().isoformat(timespec="microseconds")
+    lines = dumped["lines"]
+    indented = "\n".join(f"    {line}" for line in lines) if lines else "    "
+    entry = (
+        f"- timestamp: {timestamp}\n"
+        f"  key: {key}\n"
+        f"  width: {dumped['width']}\n"
+        f"  height: {dumped['height']}\n"
+        f"  screen: |\n{indented}\n"
+    )
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(entry)
 
 
 def _pad_display(text: str, width: int) -> str:
@@ -49,7 +84,10 @@ class TuiState:
     issues: list[dict] = field(default_factory=list)
 
 
-def run_issue_tui(state: TuiState | None = None) -> TuiResult | None:
+def run_issue_tui(
+    state: TuiState | None = None,
+    debug_log_path: Path | None = None,
+) -> TuiResult | None:
     if state is None:
         state = TuiState()
     last = state.last_result
@@ -241,4 +279,14 @@ def run_issue_tui(state: TuiState | None = None) -> TuiResult | None:
         key_bindings=kb,
         full_screen=True,
     )
+
+    if debug_log_path is not None:
+
+        def _on_after_render(sender: Application) -> None:
+            seq = sender.key_processor._previous_key_sequence
+            key = " ".join(getattr(kp.key, "value", str(kp.key)) for kp in seq)
+            _append_screen_yaml(debug_log_path, dump_rendered_screen(sender), key=key)
+
+        app.after_render += _on_after_render
+
     return app.run()


### PR DESCRIPTION
resolve #74

## 対応内容

`redi --tui --debug-tui`で起動した画面をレンダリング後にそのレンダリング内容をyaml形式でログに書き込むようにした。


## 動作確認

- `redi ---tui --debug-tui`で起動してカーソルを下に2個移動させた後に終了 (`j j q`)
- `~/.config/redi/redi-debug-tui.yaml`に以下の内容が書き込まれている
- 画面右側のプレビューペインの内容が切り替わっている


```yaml
- timestamp: 2026-04-19T16:49:59.409442
  key: 
  width: 105
  height: 17
  screen: |
    #42 feature3                              │#42 feature3
    #41 feature2                              │
    #40 feature1                              │[ステータス] 新規
    #39 after tui                             │[優先度    ] 通常
    #38 a                                     │[トラッカー] 機能
    #37 a                                     │[担当者    ] -
    #36 title                                 │[作成者    ] first created
    #35 aa                                    │[開始日    ] 2026-04-19
    #34 aaa                                   │[期日      ] -
    #33 aaa                                   │[進捗      ] 0%
    #32 aaa                                   │[作成      ] 2026-04-19T07:49:19Z
    #31 ho                                    │[更新      ] 2026-04-19T07:49:19Z
    #30 ho                                    │
    #29 i                                     │----
    #28 bug1                                  │desc3
    #27 ok                                    │
     Page 1 (offset=0)  ↑↓/jk:移動 ←→/hl:ページ Enter:コメント読込 c:作成 u:更新 n:コメント v:web q:終了
- timestamp: 2026-04-19T16:50:02.409935
  key: j
  width: 105
  height: 17
  screen: |
    #42 feature3                              │#41 feature2
    #41 feature2                              │
    #40 feature1                              │[ステータス] 新規
    #39 after tui                             │[優先度    ] 通常
    #38 a                                     │[トラッカー] 機能
    #37 a                                     │[担当者    ] -
    #36 title                                 │[作成者    ] first created
    #35 aa                                    │[開始日    ] 2026-04-19
    #34 aaa                                   │[期日      ] -
    #33 aaa                                   │[進捗      ] 0%
    #32 aaa                                   │[作成      ] 2026-04-19T07:49:13Z
    #31 ho                                    │[更新      ] 2026-04-19T07:49:13Z
    #30 ho                                    │
    #29 i                                     │----
    #28 bug1                                  │desc2
    #27 ok                                    │
     Page 1 (offset=0)  ↑↓/jk:移動 ←→/hl:ページ Enter:コメント読込 c:作成 u:更新 n:コメント v:web q:終了
- timestamp: 2026-04-19T16:50:03.074311
  key: j
  width: 105
  height: 17
  screen: |
    #42 feature3                              │#40 feature1
    #41 feature2                              │
    #40 feature1                              │[ステータス] 新規
    #39 after tui                             │[優先度    ] 通常
    #38 a                                     │[トラッカー] 機能
    #37 a                                     │[担当者    ] -
    #36 title                                 │[作成者    ] first created
    #35 aa                                    │[開始日    ] 2026-04-19
    #34 aaa                                   │[期日      ] -
    #33 aaa                                   │[進捗      ] 0%
    #32 aaa                                   │[作成      ] 2026-04-19T07:48:55Z
    #31 ho                                    │[更新      ] 2026-04-19T07:48:55Z
    #30 ho                                    │
    #29 i                                     │----
    #28 bug1                                  │description1
    #27 ok                                    │
     Page 1 (offset=0)  ↑↓/jk:移動 ←→/hl:ページ Enter:コメント読込 c:作成 u:更新 n:コメント v:web q:終了
- timestamp: 2026-04-19T16:50:05.945155
  key: q
  width: 0
  height: 0
  screen: |
```
