### PR TITLE
[add] time_entry に view/update/delete サブコマンドを追加

### DIFF
--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -63,3 +63,81 @@ def list_time_entries(
             print(
                 f"{te['id']} {te['hours']}h {te['activity']['name']} ({te['spent_on']})"
             )
+
+
+def fetch_time_entry(time_entry_id: str) -> dict:
+    response = client.get(f"/time_entries/{time_entry_id}.json")
+    if response.status_code == 404:
+        print(f"作業時間が見つかりません: {time_entry_id}")
+        exit(1)
+    response.raise_for_status()
+    return response.json()["time_entry"]
+
+
+def read_time_entry(time_entry_id: str, full: bool = False) -> None:
+    te = fetch_time_entry(time_entry_id)
+    if full:
+        print(json.dumps(te, ensure_ascii=False))
+        return
+    lines = [
+        f"{te['id']} {te['hours']}h {te['activity']['name']} ({te['spent_on']})",
+        f"  プロジェクト: {te['project']['name']} (id={te['project']['id']})",
+        f"  ユーザー: {te['user']['name']} (id={te['user']['id']})",
+    ]
+    issue = te.get("issue")
+    if issue:
+        lines.append(f"  イシュー: #{issue['id']}")
+    comments = te.get("comments")
+    if comments:
+        lines.append(f"  コメント: {comments}")
+    print("\n".join(lines))
+
+
+def update_time_entry(
+    time_entry_id: str,
+    hours: float | None = None,
+    issue_id: str | None = None,
+    project_id: str | None = None,
+    activity_id: str | None = None,
+    spent_on: str | None = None,
+    comments: str | None = None,
+) -> None:
+    data: dict = {}
+    if hours is not None:
+        data["hours"] = hours
+    if issue_id:
+        data["issue_id"] = issue_id
+    if project_id:
+        data["project_id"] = project_id
+    if activity_id:
+        data["activity_id"] = activity_id
+    if spent_on:
+        data["spent_on"] = spent_on
+    if comments is not None:
+        data["comments"] = comments
+    if not data:
+        print("更新内容がないので更新をキャンセルしました")
+        exit(1)
+    response = client.put(
+        f"/time_entries/{time_entry_id}.json", json={"time_entry": data}
+    )
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("作業時間の更新に失敗しました")
+        exit(1)
+    print(f"作業時間を更新しました: {time_entry_id}")
+
+
+def delete_time_entry(time_entry_id: str) -> None:
+    response = client.delete(f"/time_entries/{time_entry_id}.json")
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("作業時間の削除に失敗しました")
+        exit(1)
+    print(f"作業時間を削除しました: {time_entry_id}")

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -15,6 +15,7 @@ SUBCOMMAND_ALIASES: dict[str, str] = {
     "c": "create",
     "u": "update",
     "co": "comment",
+    "d": "delete",
 }
 
 

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -2,7 +2,13 @@ import argparse
 
 from redi.cli._common import resolve_alias
 from redi.config import default_project_id
-from redi.api.time_entry import create_time_entry, list_time_entries
+from redi.api.time_entry import (
+    create_time_entry,
+    delete_time_entry,
+    list_time_entries,
+    read_time_entry,
+    update_time_entry,
+)
 
 
 def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -24,10 +30,32 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     te_create_parser.add_argument("--activity_id", "-a", help="作業分類ID")
     te_create_parser.add_argument("--spent_on", help="日付（YYYY-MM-DD、省略で今日）")
     te_create_parser.add_argument("--comments", "-c", help="コメント")
+    te_view_parser = te_subparsers.add_parser(
+        "view", aliases=["v"], help="作業時間詳細"
+    )
+    te_view_parser.add_argument("time_entry_id", help="作業時間ID")
+    te_view_parser.add_argument(
+        "--full", action="store_true", help="JSON形式で全情報を出力"
+    )
+    te_update_parser = te_subparsers.add_parser(
+        "update", aliases=["u"], help="作業時間更新"
+    )
+    te_update_parser.add_argument("time_entry_id", help="作業時間ID")
+    te_update_parser.add_argument("--hours", type=float, help="時間（例: 1.5）")
+    te_update_parser.add_argument("--issue_id", "-i", help="イシューID")
+    te_update_parser.add_argument("--project_id", "-p", help="プロジェクトID")
+    te_update_parser.add_argument("--activity_id", "-a", help="作業分類ID")
+    te_update_parser.add_argument("--spent_on", help="日付（YYYY-MM-DD）")
+    te_update_parser.add_argument("--comments", "-c", help="コメント")
+    te_delete_parser = te_subparsers.add_parser(
+        "delete", aliases=["d"], help="作業時間削除"
+    )
+    te_delete_parser.add_argument("time_entry_id", help="作業時間ID")
 
 
 def handle_time_entry(args: argparse.Namespace) -> None:
-    if resolve_alias(args.time_entry_command) == "create":
+    cmd = resolve_alias(args.time_entry_command)
+    if cmd == "create":
         project_id = args.project_id or default_project_id
         create_time_entry(
             issue_id=args.issue_id,
@@ -37,6 +65,20 @@ def handle_time_entry(args: argparse.Namespace) -> None:
             spent_on=args.spent_on,
             comments=args.comments,
         )
+    elif cmd == "view":
+        read_time_entry(args.time_entry_id, full=args.full)
+    elif cmd == "update":
+        update_time_entry(
+            time_entry_id=args.time_entry_id,
+            hours=args.hours,
+            issue_id=args.issue_id,
+            project_id=args.project_id,
+            activity_id=args.activity_id,
+            spent_on=args.spent_on,
+            comments=args.comments,
+        )
+    elif cmd == "delete":
+        delete_time_entry(args.time_entry_id)
     else:
         project_id = args.project_id or default_project_id
         list_time_entries(project_id=project_id, user_id=args.user_id, full=args.full)


### PR DESCRIPTION
## Summary
- `redi time_entry` に `view` / `update` / `delete` サブコマンド（エイリアス `v` / `u` / `d`）を追加
- 共通エイリアス辞書に `d` -> `delete` を追加
- API 層に `fetch_time_entry` / `read_time_entry` / `update_time_entry` / `delete_time_entry` を実装

## Test plan
- [x] \`uv run redi time_entry --help\` でサブコマンド一覧と \`view/v\`, \`update/u\`, \`delete/d\` が表示される
- [x] \`uv run redi time_entry create 1.5 -p <pid> -a <aid> -c "test"\` で作成し、出力 ID を控える
- [x] \`uv run redi time_entry view <id>\` で詳細が表示され、\`--full\` で JSON 出力できる
- [x] \`uv run redi time_entry update <id> --hours 2.0 -c "updated"\` で更新され、再度 view すると反映される
- [x] \`uv run redi time_entry update <id>\` （引数なし）が "更新内容がない" で exit 1 する
- [x] \`uv run redi time_entry delete <id>\` で削除され、一覧から消える
- [x] 存在しない ID への \`view\` が "作業時間が見つかりません" で exit 1 する