### PR TITLE
[add] membership (list)/create/view/update/delete command

### DIFF
--- a/src/redi/api/membership.py
+++ b/src/redi/api/membership.py
@@ -1,0 +1,113 @@
+import json
+
+import requests
+
+from redi.client import client
+
+
+def list_memberships(project_id: str, full: bool = False) -> None:
+    response = client.get(f"/projects/{project_id}/memberships.json")
+    response.raise_for_status()
+    memberships = response.json()["memberships"]
+    if full:
+        print(json.dumps(memberships, ensure_ascii=False))
+        return
+    for m in memberships:
+        print(_format_membership_line(m))
+
+
+def fetch_membership(membership_id: str) -> dict:
+    response = client.get(f"/memberships/{membership_id}.json")
+    if response.status_code == 404:
+        print(f"メンバーシップが見つかりません: {membership_id}")
+        exit(1)
+    response.raise_for_status()
+    return response.json()["membership"]
+
+
+def read_membership(membership_id: str, full: bool = False) -> None:
+    membership = fetch_membership(membership_id)
+    if full:
+        print(json.dumps(membership, ensure_ascii=False))
+        return
+    lines = [_format_membership_line(membership)]
+    project = membership.get("project")
+    if project:
+        lines.append(f"プロジェクト: {project.get('id')} {project.get('name', '')}")
+    roles = membership.get("roles") or []
+    if roles:
+        lines.append("ロール:")
+        for r in roles:
+            inherited = " (継承)" if r.get("inherited") else ""
+            lines.append(f"  {r.get('id')} {r.get('name', '')}{inherited}")
+    print("\n".join(lines))
+
+
+def create_membership(
+    project_id: str,
+    role_ids: list[int],
+    user_id: int | None = None,
+    group_id: int | None = None,
+) -> None:
+    data: dict = {"role_ids": role_ids}
+    if user_id is not None:
+        data["user_id"] = user_id
+    elif group_id is not None:
+        data["user_id"] = group_id
+    else:
+        print("user_id または group_id を指定してください")
+        exit(1)
+    response = client.post(
+        f"/projects/{project_id}/memberships.json", json={"membership": data}
+    )
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("メンバーシップの作成に失敗しました")
+        exit(1)
+    created = response.json()["membership"]
+    print(f"メンバーシップを作成しました: {_format_membership_line(created)}")
+
+
+def update_membership(membership_id: str, role_ids: list[int]) -> None:
+    if not role_ids:
+        print("更新をキャンセルしました")
+        exit()
+    response = client.put(
+        f"/memberships/{membership_id}.json",
+        json={"membership": {"role_ids": role_ids}},
+    )
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("メンバーシップの更新に失敗しました")
+        exit(1)
+    print(f"メンバーシップを更新しました: {membership_id}")
+
+
+def delete_membership(membership_id: str) -> None:
+    response = client.delete(f"/memberships/{membership_id}.json")
+    if response.status_code == 404:
+        print(f"メンバーシップが見つかりません: {membership_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("メンバーシップの削除に失敗しました")
+        exit(1)
+    print(f"メンバーシップを削除しました: {membership_id}")
+
+
+def _format_membership_line(membership: dict) -> str:
+    principal = membership.get("user") or membership.get("group") or {}
+    principal_kind = "user" if "user" in membership else "group"
+    principal_str = f"{principal.get('id', '?')} {principal.get('name', '')}".strip()
+    roles = membership.get("roles") or []
+    role_str = ", ".join(r.get("name", "") for r in roles)
+    return f"{membership['id']} [{principal_kind}] {principal_str} - {role_str}"

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -30,6 +30,7 @@ from redi.cli.issue_command import (
     handle_issue_update,
 )
 from redi.cli.me_command import add_me_parser, handle_me
+from redi.cli.membership_command import add_membership_parser, handle_membership
 from redi.cli.news_command import add_news_parser, handle_news
 from redi.cli.project_command import add_project_parser, handle_project
 from redi.cli.role_command import add_role_parser, handle_role
@@ -76,6 +77,7 @@ def _build_parser() -> tuple[argparse.ArgumentParser, argparse.ArgumentParser]:
     add_config_parser(subparsers)
     add_user_parser(subparsers)
     add_me_parser(subparsers)
+    add_membership_parser(subparsers)
     add_news_parser(subparsers)
     add_tracker_parser(subparsers)
     add_issue_status_parser(subparsers)
@@ -183,6 +185,8 @@ def main() -> None:
         handle_user(args)
     elif args.command == "me":
         handle_me(args)
+    elif args.command in ("membership", "m"):
+        handle_membership(args)
     elif args.command == "news":
         handle_news(args)
     elif args.command == "tracker":

--- a/src/redi/cli/membership_command.py
+++ b/src/redi/cli/membership_command.py
@@ -1,0 +1,98 @@
+import argparse
+
+from redi.cli._common import resolve_alias
+from redi.config import default_project_id
+from redi.api.membership import (
+    create_membership,
+    delete_membership,
+    list_memberships,
+    read_membership,
+    update_membership,
+)
+
+
+def _parse_role_ids(value: str) -> list[int]:
+    return [int(v) for v in value.split(",") if v.strip()]
+
+
+def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
+    m_parser = subparsers.add_parser(
+        "membership", aliases=["m"], help="メンバーシップ一覧/詳細/作成/更新/削除"
+    )
+    m_parser.add_argument("--project_id", "-p", help="プロジェクトID")
+    m_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
+    m_subparsers = m_parser.add_subparsers(dest="membership_command")
+
+    m_view_parser = m_subparsers.add_parser(
+        "view", aliases=["v"], help="メンバーシップ詳細"
+    )
+    m_view_parser.add_argument("membership_id", help="メンバーシップID")
+    m_view_parser.add_argument(
+        "--full", action="store_true", help="JSON形式で全情報を出力"
+    )
+
+    m_create_parser = m_subparsers.add_parser(
+        "create", aliases=["c"], help="メンバーシップ作成"
+    )
+    m_create_parser.add_argument("--project_id", "-p", help="プロジェクトID")
+    m_create_parser.add_argument("--user_id", "-u", type=int, help="ユーザーID")
+    m_create_parser.add_argument("--group_id", "-g", type=int, help="グループID")
+    m_create_parser.add_argument(
+        "--role_ids",
+        "-r",
+        required=True,
+        help="ロールID（カンマ区切り。例: 3,4）",
+    )
+
+    m_update_parser = m_subparsers.add_parser(
+        "update", aliases=["u"], help="メンバーシップ更新（ロールのみ変更可能）"
+    )
+    m_update_parser.add_argument("membership_id", help="メンバーシップID")
+    m_update_parser.add_argument(
+        "--role_ids",
+        "-r",
+        required=True,
+        help="ロールID（カンマ区切り。例: 3,4）",
+    )
+
+    m_delete_parser = m_subparsers.add_parser(
+        "delete", aliases=["d"], help="メンバーシップ削除"
+    )
+    m_delete_parser.add_argument("membership_id", help="メンバーシップID")
+
+
+def handle_membership(args: argparse.Namespace) -> None:
+    cmd = resolve_alias(args.membership_command)
+    if cmd == "view":
+        read_membership(args.membership_id, full=args.full)
+        return
+    if cmd == "create":
+        project_id = args.project_id or default_project_id
+        if not project_id:
+            print("project_idを指定するか、default_project_idを設定してください")
+            exit(1)
+        if args.user_id is None and args.group_id is None:
+            print("--user_id または --group_id を指定してください")
+            exit(1)
+        create_membership(
+            project_id=project_id,
+            role_ids=_parse_role_ids(args.role_ids),
+            user_id=args.user_id,
+            group_id=args.group_id,
+        )
+        return
+    if cmd == "update":
+        update_membership(
+            membership_id=args.membership_id,
+            role_ids=_parse_role_ids(args.role_ids),
+        )
+        return
+    if cmd == "delete":
+        delete_membership(args.membership_id)
+        return
+
+    project_id = args.project_id or default_project_id
+    if not project_id:
+        print("project_idを指定するか、default_project_idを設定してください")
+        exit(1)
+    list_memberships(project_id, full=args.full)


### PR DESCRIPTION
## Summary
- `redi membership` (alias `m`) コマンドを追加し、Redmine Memberships API の LCRUD (list/create/read/update/delete) に対応
- `redi m` / `redi m view <id>` / `redi m create --user_id|--group_id --role_ids` / `redi m update <id> --role_ids` / `redi m delete <id>`
- サブコマンド alias に `d` (delete) を追加

## Test plan
- [x] `redi m -p <project_id>` でメンバーシップ一覧が表示される
- [x] `redi m view <id>` でメンバーシップ詳細が表示される
- [x] `redi m create --user_id <uid> --role_ids 3,4` でメンバーを追加できる
- [ ] `redi m create --group_id <gid> --role_ids 3` でグループを追加できる
- [x] `redi m update <id> --role_ids 3,4` でロールを更新できる
- [x] `redi m delete <id>` でメンバーシップを削除できる
- [x] `--full` で JSON 形式の全情報が出力される