### PR TITLE
redi user に view/update/delete、redi me に update を追加

### DIFF
--- a/src/redi/api/me.py
+++ b/src/redi/api/me.py
@@ -1,5 +1,7 @@
 import json
 
+import requests
+
 from redi.client import client
 
 
@@ -29,3 +31,29 @@ def read_my_account(full: bool = False) -> None:
         for cf in custom_fields:
             lines.append(f"  {cf.get('name')}: {cf.get('value')}")
     print("\n".join(lines))
+
+
+def update_my_account(
+    firstname: str | None = None,
+    lastname: str | None = None,
+    mail: str | None = None,
+) -> None:
+    data: dict = {}
+    if firstname is not None:
+        data["firstname"] = firstname
+    if lastname is not None:
+        data["lastname"] = lastname
+    if mail is not None:
+        data["mail"] = mail
+    if not data:
+        print("更新内容がないので更新をキャンセルしました")
+        exit(1)
+    response = client.put("/my/account.json", json={"user": data})
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("アカウント情報の更新に失敗しました")
+        exit(1)
+    print("アカウント情報を更新しました")

--- a/src/redi/api/user.py
+++ b/src/redi/api/user.py
@@ -53,11 +53,19 @@ def create_user(
     )
 
 
+def pop_apikey(user: dict) -> dict:
+    user.pop("api_key", None)
+    return user
+
+
 def list_users(project_id: str | None = None, full: bool = False) -> None:
     if project_id:
         response = client.get(f"/projects/{project_id}/memberships.json")
         response.raise_for_status()
         memberships = response.json()["memberships"]
+        for m in memberships:
+            if "user" in m:
+                pop_apikey(m["user"])
         if full:
             print(json.dumps(memberships, ensure_ascii=False))
         else:
@@ -73,9 +81,130 @@ def list_users(project_id: str | None = None, full: bool = False) -> None:
             return
         # 未知のステータスコードに遭遇した際にエラーをraiseする(jsonのdecodeエラーよりは原因がわかりやすい)
         response.raise_for_status()
-        users = response.json()["users"]
+        users = [pop_apikey(u) for u in response.json()["users"]]
         if full:
             print(json.dumps(users, ensure_ascii=False))
         else:
             for user in users:
                 print(f"{user['id']} {user['login']}")
+
+
+def fetch_user(user_id: str, include: list[str] | None = None) -> dict:
+    params = {}
+    if include:
+        params["include"] = ",".join(include)
+    response = client.get(f"/users/{user_id}.json", params=params)
+    if response.status_code == 404:
+        print(f"ユーザーが見つかりません: {user_id}")
+        exit(1)
+    if response.status_code == 403:
+        print("ユーザー詳細の取得には権限が必要です")
+        exit(1)
+    response.raise_for_status()
+    return pop_apikey(response.json()["user"])
+
+
+def read_user(user_id: str, full: bool = False) -> None:
+    include = ["memberships", "groups"]
+    user = fetch_user(user_id, include=include)
+    if full:
+        print(json.dumps(user, ensure_ascii=False))
+        return
+    name = f"{user.get('firstname', '')} {user.get('lastname', '')}".strip()
+    lines = [
+        f"{user['id']} {user.get('login', '')} {name}".rstrip(),
+        f"  メール: {user.get('mail', '')}",
+    ]
+    if user.get("admin"):
+        lines.append("  管理者: yes")
+    created_on = user.get("created_on")
+    if created_on:
+        lines.append(f"  作成日時: {created_on}")
+    last_login_on = user.get("last_login_on")
+    if last_login_on:
+        lines.append(f"  最終ログイン: {last_login_on}")
+    memberships = user.get("memberships") or []
+    if memberships:
+        lines.append("  メンバーシップ:")
+        for m in memberships:
+            project = m.get("project") or {}
+            roles = m.get("roles") or []
+            role_str = ", ".join(r.get("name", "") for r in roles)
+            lines.append(
+                f"    {project.get('id', '?')} {project.get('name', '')} - {role_str}"
+            )
+    groups = user.get("groups") or []
+    if groups:
+        lines.append("  グループ:")
+        for g in groups:
+            lines.append(f"    {g.get('id', '?')} {g.get('name', '')}")
+    print("\n".join(lines))
+
+
+def update_user(
+    user_id: str,
+    login: str | None = None,
+    firstname: str | None = None,
+    lastname: str | None = None,
+    mail: str | None = None,
+    password: str | None = None,
+    auth_source_id: int | None = None,
+    mail_notification: str | None = None,
+    must_change_passwd: bool | None = None,
+    admin: bool | None = None,
+) -> None:
+    data: dict = {}
+    if login is not None:
+        data["login"] = login
+    if firstname is not None:
+        data["firstname"] = firstname
+    if lastname is not None:
+        data["lastname"] = lastname
+    if mail is not None:
+        data["mail"] = mail
+    if password is not None:
+        data["password"] = password
+    if auth_source_id is not None:
+        data["auth_source_id"] = auth_source_id
+    if mail_notification is not None:
+        data["mail_notification"] = mail_notification
+    if must_change_passwd is not None:
+        data["must_change_passwd"] = must_change_passwd
+    if admin is not None:
+        data["admin"] = admin
+    if not data:
+        print("更新内容がないので更新をキャンセルしました")
+        exit(1)
+    response = client.put(f"/users/{user_id}.json", json={"user": data})
+    if response.status_code == 404:
+        print(f"ユーザーが見つかりません: {user_id}")
+        exit(1)
+    if response.status_code == 403:
+        print("ユーザーの更新には管理者権限が必要です")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("ユーザーの更新に失敗しました")
+        exit(1)
+    print(f"ユーザーを更新しました: {user_id}")
+
+
+def delete_user(user_id: str) -> None:
+    response = client.delete(f"/users/{user_id}.json")
+    if response.status_code == 404:
+        print(f"ユーザーが見つかりません: {user_id}")
+        exit(1)
+    if response.status_code == 403:
+        print("ユーザーの削除には管理者権限が必要です")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("ユーザーの削除に失敗しました")
+        exit(1)
+    print(f"ユーザーを削除しました: {user_id}")

--- a/src/redi/api/user.py
+++ b/src/redi/api/user.py
@@ -58,35 +58,22 @@ def pop_apikey(user: dict) -> dict:
     return user
 
 
-def list_users(project_id: str | None = None, full: bool = False) -> None:
-    if project_id:
-        response = client.get(f"/projects/{project_id}/memberships.json")
-        response.raise_for_status()
-        memberships = response.json()["memberships"]
-        for m in memberships:
-            if "user" in m:
-                pop_apikey(m["user"])
-        if full:
-            print(json.dumps(memberships, ensure_ascii=False))
-        else:
-            for m in memberships:
-                if "user" in m:
-                    user = m["user"]
-                    print(f"{user['id']} {user['name']}")
+def list_users(full: bool = False) -> None:
+    response = client.get("/users.json")
+    if response.status_code == 403:
+        print("ユーザー一覧の取得には管理者権限が必要です")
+        print(
+            "プロジェクトメンバーの一覧は `redi membership -p <project_id>` を使ってください"
+        )
+        return
+    # 未知のステータスコードに遭遇した際にエラーをraiseする(jsonのdecodeエラーよりは原因がわかりやすい)
+    response.raise_for_status()
+    users = [pop_apikey(u) for u in response.json()["users"]]
+    if full:
+        print(json.dumps(users, ensure_ascii=False))
     else:
-        response = client.get("/users.json")
-        if response.status_code == 403:
-            print("ユーザー一覧の取得には管理者権限が必要です")
-            print("プロジェクトを指定してください: redi u -p <project_id>")
-            return
-        # 未知のステータスコードに遭遇した際にエラーをraiseする(jsonのdecodeエラーよりは原因がわかりやすい)
-        response.raise_for_status()
-        users = [pop_apikey(u) for u in response.json()["users"]]
-        if full:
-            print(json.dumps(users, ensure_ascii=False))
-        else:
-            for user in users:
-                print(f"{user['id']} {user['login']}")
+        for user in users:
+            print(f"{user['id']} {user['login']}")
 
 
 def fetch_user(user_id: str, include: list[str] | None = None) -> dict:
@@ -105,8 +92,7 @@ def fetch_user(user_id: str, include: list[str] | None = None) -> dict:
 
 
 def read_user(user_id: str, full: bool = False) -> None:
-    include = ["memberships", "groups"]
-    user = fetch_user(user_id, include=include)
+    user = fetch_user(user_id, include=["memberships", "groups"])
     if full:
         print(json.dumps(user, ensure_ascii=False))
         return

--- a/src/redi/cli/me_command.py
+++ b/src/redi/cli/me_command.py
@@ -1,12 +1,29 @@
 import argparse
 
-from redi.api.me import read_my_account
+from redi.cli._common import resolve_alias
+from redi.api.me import read_my_account, update_my_account
 
 
 def add_me_parser(subparsers: argparse._SubParsersAction) -> None:
     me_parser = subparsers.add_parser("me", help="自分のアカウント情報")
     me_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
+    me_subparsers = me_parser.add_subparsers(dest="me_command")
+
+    me_update_parser = me_subparsers.add_parser(
+        "update", aliases=["u"], help="自分のアカウント情報を更新"
+    )
+    me_update_parser.add_argument("--firstname", "-f", help="名")
+    me_update_parser.add_argument("--lastname", "-l", help="姓")
+    me_update_parser.add_argument("--mail", "-m", help="メールアドレス")
 
 
 def handle_me(args: argparse.Namespace) -> None:
+    cmd = resolve_alias(args.me_command)
+    if cmd == "update":
+        update_my_account(
+            firstname=args.firstname,
+            lastname=args.lastname,
+            mail=args.mail,
+        )
+        return
     read_my_account(full=args.full)

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -2,11 +2,29 @@ import argparse
 
 from redi.cli._common import resolve_alias
 from redi.config import default_project_id
-from redi.api.user import create_user, list_users
+from redi.api.user import (
+    create_user,
+    delete_user,
+    list_users,
+    read_user,
+    update_user,
+)
+
+
+MAIL_NOTIFICATION_CHOICES = [
+    "all",
+    "selected",
+    "only_my_events",
+    "only_assigned",
+    "only_owner",
+    "none",
+]
 
 
 def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
-    u_parser = subparsers.add_parser("user", aliases=["u"], help="ユーザー一覧/作成")
+    u_parser = subparsers.add_parser(
+        "user", aliases=["u"], help="ユーザー一覧/詳細/作成/更新/削除"
+    )
     u_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     u_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     u_subparsers = u_parser.add_subparsers(dest="user_command")
@@ -26,14 +44,7 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     u_create_parser.add_argument("--auth_source_id", type=int, help="認証ソースID")
     u_create_parser.add_argument(
         "--mail_notification",
-        choices=[
-            "all",
-            "selected",
-            "only_my_events",
-            "only_assigned",
-            "only_owner",
-            "none",
-        ],
+        choices=MAIL_NOTIFICATION_CHOICES,
         help="メール通知設定",
     )
     u_create_parser.add_argument(
@@ -44,6 +55,47 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     u_create_parser.add_argument(
         "--admin", action="store_true", help="管理者権限を付与"
     )
+
+    u_view_parser = u_subparsers.add_parser("view", aliases=["v"], help="ユーザー詳細")
+    u_view_parser.add_argument(
+        "user_id", help="ユーザーID（'current'で現在のユーザー）"
+    )
+    u_view_parser.add_argument(
+        "--full", action="store_true", help="JSON形式で全情報を出力"
+    )
+
+    u_update_parser = u_subparsers.add_parser(
+        "update", aliases=["u"], help="ユーザー更新（管理者権限が必要）"
+    )
+    u_update_parser.add_argument("user_id", help="ユーザーID")
+    u_update_parser.add_argument("--login", help="ログイン名")
+    u_update_parser.add_argument("--firstname", "-f", help="名")
+    u_update_parser.add_argument("--lastname", "-l", help="姓")
+    u_update_parser.add_argument("--mail", "-m", help="メールアドレス")
+    u_update_parser.add_argument("--password", help="パスワード")
+    u_update_parser.add_argument("--auth_source_id", type=int, help="認証ソースID")
+    u_update_parser.add_argument(
+        "--mail_notification",
+        choices=MAIL_NOTIFICATION_CHOICES,
+        help="メール通知設定",
+    )
+    u_update_parser.add_argument(
+        "--must_change_passwd",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="次回ログイン時にパスワード変更を要求 (--no-must_change_passwd で解除)",
+    )
+    u_update_parser.add_argument(
+        "--admin",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="管理者権限 (--no-admin で解除)",
+    )
+
+    u_delete_parser = u_subparsers.add_parser(
+        "delete", aliases=["d"], help="ユーザー削除（管理者権限が必要）"
+    )
+    u_delete_parser.add_argument("user_id", help="ユーザーID")
 
 
 def handle_user(args: argparse.Namespace) -> None:
@@ -61,6 +113,26 @@ def handle_user(args: argparse.Namespace) -> None:
             generate_password=args.generate_password or None,
             admin=args.admin or None,
         )
+        return
+    if cmd == "view":
+        read_user(args.user_id, full=args.full)
+        return
+    if cmd == "update":
+        update_user(
+            user_id=args.user_id,
+            login=args.login,
+            firstname=args.firstname,
+            lastname=args.lastname,
+            mail=args.mail,
+            password=args.password,
+            auth_source_id=args.auth_source_id,
+            mail_notification=args.mail_notification,
+            must_change_passwd=args.must_change_passwd,
+            admin=args.admin,
+        )
+        return
+    if cmd == "delete":
+        delete_user(args.user_id)
         return
     project_id = args.project_id or default_project_id
     list_users(project_id=project_id, full=args.full)

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -1,7 +1,6 @@
 import argparse
 
 from redi.cli._common import resolve_alias
-from redi.config import default_project_id
 from redi.api.user import (
     create_user,
     delete_user,
@@ -25,7 +24,6 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     u_parser = subparsers.add_parser(
         "user", aliases=["u"], help="ユーザー一覧/詳細/作成/更新/削除"
     )
-    u_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     u_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     u_subparsers = u_parser.add_subparsers(dest="user_command")
     u_create_parser = u_subparsers.add_parser(
@@ -134,5 +132,4 @@ def handle_user(args: argparse.Namespace) -> None:
     if cmd == "delete":
         delete_user(args.user_id)
         return
-    project_id = args.project_id or default_project_id
-    list_users(project_id=project_id, full=args.full)
+    list_users(full=args.full)


### PR DESCRIPTION
## Summary
- `redi user` に `view` / `update` / `delete` サブコマンド（エイリアス `v` / `u` / `d`）を追加
- `redi user` の一覧は `/users.json` のみを使い、`/projects/:id/memberships.json` を呼ばないよう変更（`--project_id` オプションは廃止。プロジェクトメンバー一覧は `redi membership -p <project_id>` に誘導）
- `redi me update` を追加（`PUT /my/account.json` で firstname / lastname / mail を更新）
- `redi user` 系レスポンス（一覧/詳細）出力から `api_key` を常に除去

## Test plan
- [x] `redi user` でユーザー一覧が `id login` 形式で表示される
- [x] `redi user view <id>` で詳細（memberships/groups 含む）が表示され、`current` も使える
- [x] `redi user update <id> --mail ...` / `--no-admin` などで部分更新できる
- [x] `redi user delete <id>` で削除できる
- [x] `redi user create ...` は従来通り動く
- [x] `redi me update --mail ...` で自分のメールが更新できる
- [x] `redi user --full` / `redi user view <id> --full` の JSON 出力に `api_key` が含まれない