### PR TITLE
issue #77 残りの未実装API 12件を追加

### DIFF
--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -66,6 +66,21 @@ def read_attachment(attachment_id: str, full: bool = False) -> None:
     print("\n".join(lines))
 
 
+def delete_attachment(attachment_id: str) -> None:
+    response = client.delete(f"/attachments/{attachment_id}.json")
+    if response.status_code == 404:
+        print(f"添付ファイルが見つかりません: #{attachment_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("添付ファイルの削除に失敗しました")
+        exit(1)
+    print(f"添付ファイルを削除しました: #{attachment_id}")
+
+
 def update_attachment(
     attachment_id: str,
     filename: str | None = None,

--- a/src/redi/api/file.py
+++ b/src/redi/api/file.py
@@ -1,0 +1,55 @@
+import json
+
+import requests
+
+from redi.api.attachment import upload_file
+from redi.client import client
+
+
+def list_files(project_id: str, full: bool = False) -> None:
+    response = client.get(f"/projects/{project_id}/files.json")
+    if response.status_code == 404:
+        print(f"プロジェクトが見つかりません: {project_id}")
+        exit(1)
+    response.raise_for_status()
+    files = response.json()["files"]
+    if full:
+        print(json.dumps(files, ensure_ascii=False))
+        return
+    for f in files:
+        version = f.get("version") or {}
+        version_label = f" [{version.get('name')}]" if version else ""
+        size = f.get("filesize", "")
+        print(f"{f['id']} {f['filename']} ({size}B){version_label}")
+
+
+def create_file(
+    project_id: str,
+    file_path: str,
+    version_id: int | None = None,
+    description: str | None = None,
+) -> None:
+    upload = upload_file(file_path)
+    file_data: dict = {
+        "token": upload["token"],
+        "filename": upload["filename"],
+        "content_type": upload["content_type"],
+    }
+    if version_id is not None:
+        file_data["version_id"] = version_id
+    if description is not None:
+        file_data["description"] = description
+    response = client.post(
+        f"/projects/{project_id}/files.json", json={"file": file_data}
+    )
+    if response.status_code == 404:
+        print(f"プロジェクトが見つかりません: {project_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("ファイルのアップロードに失敗しました")
+        exit(1)
+    print(f"ファイルをアップロードしました: {upload['filename']}")

--- a/src/redi/api/group.py
+++ b/src/redi/api/group.py
@@ -88,6 +88,45 @@ def update_group(
     print(f"グループを更新しました: {group_id}")
 
 
+def add_group_user(group_id: str, user_id: int) -> None:
+    response = client.post(
+        f"/groups/{group_id}/users.json",
+        json={"user_id": user_id},
+    )
+    if response.status_code == 404:
+        print(f"グループが見つかりません: #{group_id}")
+        exit(1)
+    if response.status_code == 403:
+        print("グループへのユーザー追加には管理者権限が必要です")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("グループへのユーザー追加に失敗しました")
+        exit(1)
+    print(f"グループ {group_id} にユーザー {user_id} を追加しました")
+
+
+def remove_group_user(group_id: str, user_id: int) -> None:
+    response = client.delete(f"/groups/{group_id}/users/{user_id}.json")
+    if response.status_code == 404:
+        print(f"グループまたはユーザーが見つかりません: #{group_id} / #{user_id}")
+        exit(1)
+    if response.status_code == 403:
+        print("グループからのユーザー削除には管理者権限が必要です")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("グループからのユーザー削除に失敗しました")
+        exit(1)
+    print(f"グループ {group_id} からユーザー {user_id} を削除しました")
+
+
 def delete_group(group_id: str) -> None:
     response = client.delete(f"/groups/{group_id}.json")
     if response.status_code == 404:

--- a/src/redi/api/group.py
+++ b/src/redi/api/group.py
@@ -88,6 +88,24 @@ def update_group(
     print(f"グループを更新しました: {group_id}")
 
 
+def delete_group(group_id: str) -> None:
+    response = client.delete(f"/groups/{group_id}.json")
+    if response.status_code == 404:
+        print(f"グループが見つかりません: #{group_id}")
+        exit(1)
+    if response.status_code == 403:
+        print("グループの削除には管理者権限が必要です")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("グループの削除に失敗しました")
+        exit(1)
+    print(f"グループを削除しました: {group_id}")
+
+
 def create_group(name: str, user_ids: list[int] | None = None) -> None:
     group_data: dict = {"name": name}
     if user_ids:

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -304,6 +304,39 @@ def update_issue(
     print(f"イシューを更新しました: {url}")
 
 
+def add_watcher(issue_id: str, user_id: int) -> None:
+    response = client.post(
+        f"/issues/{issue_id}/watchers.json",
+        json={"user_id": user_id},
+    )
+    if response.status_code == 404:
+        print(f"イシューが見つかりません: #{issue_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("ウォッチャーの追加に失敗しました")
+        exit(1)
+    print(f"#{issue_id} にウォッチャー {user_id} を追加しました")
+
+
+def remove_watcher(issue_id: str, user_id: int) -> None:
+    response = client.delete(f"/issues/{issue_id}/watchers/{user_id}.json")
+    if response.status_code == 404:
+        print(f"イシューまたはユーザーが見つかりません: #{issue_id} / #{user_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("ウォッチャーの削除に失敗しました")
+        exit(1)
+    print(f"#{issue_id} からウォッチャー {user_id} を削除しました")
+
+
 def delete_issue(issue_id: str) -> None:
     response = client.delete(f"/issues/{issue_id}.json")
     if response.status_code == 404:

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -304,6 +304,21 @@ def update_issue(
     print(f"イシューを更新しました: {url}")
 
 
+def delete_issue(issue_id: str) -> None:
+    response = client.delete(f"/issues/{issue_id}.json")
+    if response.status_code == 404:
+        print(f"イシューが見つかりません: #{issue_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("イシューの削除に失敗しました")
+        exit(1)
+    print(f"イシューを削除しました: #{issue_id}")
+
+
 def add_note(issue_id: str, notes: str) -> None:
     response = client.put(f"/issues/{issue_id}.json", json={"issue": {"notes": notes}})
     response.raise_for_status()

--- a/src/redi/api/issue_relation.py
+++ b/src/redi/api/issue_relation.py
@@ -1,6 +1,34 @@
+import json
+
 import requests
 
 from redi.client import client
+from redi.config import redmine_url
+
+
+def fetch_relation(relation_id: str) -> dict:
+    response = client.get(f"/relations/{relation_id}.json")
+    if response.status_code == 404:
+        print(f"関係性が見つかりません: #{relation_id}")
+        exit(1)
+    response.raise_for_status()
+    return response.json()["relation"]
+
+
+def read_relation(relation_id: str, full: bool = False) -> None:
+    relation = fetch_relation(relation_id)
+    if full:
+        print(json.dumps(relation, ensure_ascii=False))
+        return
+    issue_url = f"{redmine_url}/issues/{relation['issue_id']}"
+    issue_to_url = f"{redmine_url}/issues/{relation['issue_to_id']}"
+    print(
+        f"{relation['id']} #{relation['issue_id']} --[{relation['relation_type']}]--> #{relation['issue_to_id']}"
+    )
+    print(f"  {issue_url}")
+    print(f"  {issue_to_url}")
+    if relation.get("delay") is not None:
+        print(f"  delay: {relation['delay']}")
 
 
 def create_relation(

--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -81,6 +81,36 @@ def update_project(
     print(f"プロジェクトを更新しました: {project_id}")
 
 
+def archive_project(project_id: str) -> None:
+    response = client.put(f"/projects/{project_id}/archive.json")
+    if response.status_code == 404:
+        print(f"プロジェクトが見つかりません: {project_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("プロジェクトのアーカイブに失敗しました")
+        exit(1)
+    print(f"プロジェクトをアーカイブしました: {project_id}")
+
+
+def unarchive_project(project_id: str) -> None:
+    response = client.put(f"/projects/{project_id}/unarchive.json")
+    if response.status_code == 404:
+        print(f"プロジェクトが見つかりません: {project_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("プロジェクトのアーカイブ解除に失敗しました")
+        exit(1)
+    print(f"プロジェクトのアーカイブを解除しました: {project_id}")
+
+
 def delete_project(project_id: str) -> None:
     response = client.delete(f"/projects/{project_id}.json")
     if response.status_code == 404:

--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -81,6 +81,21 @@ def update_project(
     print(f"プロジェクトを更新しました: {project_id}")
 
 
+def delete_project(project_id: str) -> None:
+    response = client.delete(f"/projects/{project_id}.json")
+    if response.status_code == 404:
+        print(f"プロジェクトが見つかりません: {project_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("プロジェクトの削除に失敗しました")
+        exit(1)
+    print(f"プロジェクトを削除しました: {project_id}")
+
+
 def read_project(
     project_id: str, include: str = "", full: bool = False, web: bool = False
 ) -> None:

--- a/src/redi/api/version.py
+++ b/src/redi/api/version.py
@@ -112,6 +112,21 @@ def read_version(version_id: str, full: bool = False, web: bool = False) -> None
     print("\n".join(lines))
 
 
+def delete_version(version_id: str) -> None:
+    response = client.delete(f"/versions/{version_id}.json")
+    if response.status_code == 404:
+        print(f"バージョンが見つかりません: {version_id}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("バージョンの削除に失敗しました")
+        exit(1)
+    print(f"バージョンを削除しました: {version_id}")
+
+
 def fetch_versions(project_id: str) -> list[dict]:
     response = client.get(f"/projects/{project_id}/versions.json")
     response.raise_for_status()

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -2,6 +2,8 @@ import json
 import webbrowser
 from collections import defaultdict
 
+import requests
+
 from redi.client import client
 from redi.config import redmine_url
 
@@ -83,6 +85,21 @@ def update_wiki(project_id: str, page_title: str, text: str) -> None:
     response.raise_for_status()
     url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
     print(f"Wikiページを更新しました: {url}")
+
+
+def delete_wiki(project_id: str, page_title: str) -> None:
+    response = client.delete(f"/projects/{project_id}/wiki/{page_title}.json")
+    if response.status_code == 404:
+        print(f"Wikiページが見つかりません: {page_title}")
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print("Wikiページの削除に失敗しました")
+        exit(1)
+    print(f"Wikiページを削除しました: {page_title}")
 
 
 def create_wiki(

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -53,24 +53,36 @@ def list_wikis(project_id: str, full: bool = False) -> None:
     print_tree(None)
 
 
-def fetch_wiki(project_id: str, page_title: str) -> dict:
-    response = client.get(f"/projects/{project_id}/wiki/{page_title}.json")
+def fetch_wiki(project_id: str, page_title: str, version: int | None = None) -> dict:
+    path = f"/projects/{project_id}/wiki/{page_title}.json"
+    if version is not None:
+        path = f"/projects/{project_id}/wiki/{page_title}/{version}.json"
+    response = client.get(path)
     if response.status_code == 404:
-        print(f"Wikiページが見つかりません: {page_title}")
+        if version is not None:
+            print(f"Wikiページが見つかりません: {page_title} (version={version})")
+        else:
+            print(f"Wikiページが見つかりません: {page_title}")
         exit(1)
     response.raise_for_status()
     return response.json()["wiki_page"]
 
 
 def read_wiki(
-    project_id: str, page_title: str, full: bool = False, web: bool = False
+    project_id: str,
+    page_title: str,
+    full: bool = False,
+    web: bool = False,
+    version: int | None = None,
 ) -> None:
     if web:
         url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
+        if version is not None:
+            url = f"{url}/{version}"
         print(url)
         webbrowser.open(url)
         return
-    wiki = fetch_wiki(project_id, page_title)
+    wiki = fetch_wiki(project_id, page_title, version=version)
     if full:
         print(json.dumps(wiki, ensure_ascii=False, indent=2))
     else:

--- a/src/redi/cli/attachment_command.py
+++ b/src/redi/cli/attachment_command.py
@@ -1,6 +1,6 @@
 import argparse
 
-from redi.api.attachment import read_attachment, update_attachment
+from redi.api.attachment import delete_attachment, read_attachment, update_attachment
 from redi.cli._common import resolve_alias
 
 
@@ -22,6 +22,10 @@ def add_attachment_parser(
     a_update_parser.add_argument("attachment_id", help="添付ファイルID")
     a_update_parser.add_argument("--filename", "-f", help="ファイル名")
     a_update_parser.add_argument("--description", "-d", help="説明")
+    a_delete_parser = a_subparsers.add_parser(
+        "delete", aliases=["d"], help="添付ファイル削除"
+    )
+    a_delete_parser.add_argument("attachment_id", help="添付ファイルID")
     return a_parser
 
 
@@ -37,5 +41,7 @@ def handle_attachment(
             filename=args.filename,
             description=args.description,
         )
+    elif cmd == "delete":
+        delete_attachment(args.attachment_id)
     else:
         a_parser.print_help()

--- a/src/redi/cli/file_command.py
+++ b/src/redi/cli/file_command.py
@@ -1,0 +1,38 @@
+import argparse
+
+from redi.api.file import create_file, list_files
+from redi.cli._common import resolve_alias
+from redi.config import default_project_id
+
+
+def add_file_parser(subparsers: argparse._SubParsersAction) -> None:
+    f_parser = subparsers.add_parser(
+        "file", help="プロジェクトファイル 一覧/アップロード"
+    )
+    f_parser.add_argument("--project_id", "-p", help="プロジェクトID")
+    f_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
+    f_subparsers = f_parser.add_subparsers(dest="file_command")
+    f_create_parser = f_subparsers.add_parser(
+        "create", aliases=["c"], help="ファイルアップロード"
+    )
+    f_create_parser.add_argument("file_path", help="アップロードするファイルのパス")
+    f_create_parser.add_argument("--project_id", "-p", help="プロジェクトID")
+    f_create_parser.add_argument("--version_id", type=int, help="バージョンID")
+    f_create_parser.add_argument("--description", "-d", help="説明")
+
+
+def handle_file(args: argparse.Namespace) -> None:
+    project_id = args.project_id or default_project_id
+    if not project_id:
+        print("project_idを指定するか、default_project_idを設定してください")
+        exit(1)
+    cmd = resolve_alias(args.file_command)
+    if cmd == "create":
+        create_file(
+            project_id=project_id,
+            file_path=args.file_path,
+            version_id=args.version_id,
+            description=args.description,
+        )
+        return
+    list_files(project_id, full=args.full)

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -2,10 +2,12 @@ import argparse
 
 from redi.cli._common import resolve_alias
 from redi.api.group import (
+    add_group_user,
     create_group,
     delete_group,
     list_groups,
     read_group,
+    remove_group_user,
     update_group,
 )
 
@@ -46,6 +48,20 @@ def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
         dest="user_ids",
         help="所属ユーザーIDを指定（複数指定可、既存の所属ユーザーを置き換え）",
     )
+    g_update_parser.add_argument(
+        "--add-user",
+        type=int,
+        action="append",
+        dest="add_user_ids",
+        help="グループに追加するユーザーID（複数指定可）",
+    )
+    g_update_parser.add_argument(
+        "--remove-user",
+        type=int,
+        action="append",
+        dest="remove_user_ids",
+        help="グループから削除するユーザーID（複数指定可）",
+    )
     g_delete_parser = group_subparsers.add_parser(
         "delete", aliases=["d"], help="グループ削除（管理者権限が必要）"
     )
@@ -61,11 +77,20 @@ def handle_group(args: argparse.Namespace) -> None:
         create_group(name=args.name, user_ids=args.user_ids)
         return
     if cmd == "update":
-        update_group(
-            group_id=args.group_id,
-            name=args.name,
-            user_ids=args.user_ids,
-        )
+        should_update = args.name is not None or args.user_ids is not None
+        if should_update:
+            update_group(
+                group_id=args.group_id,
+                name=args.name,
+                user_ids=args.user_ids,
+            )
+        for user_id in args.add_user_ids or []:
+            add_group_user(args.group_id, user_id)
+        for user_id in args.remove_user_ids or []:
+            remove_group_user(args.group_id, user_id)
+        if not should_update and not args.add_user_ids and not args.remove_user_ids:
+            print("更新をキャンセルしました")
+            exit()
         return
     if cmd == "delete":
         delete_group(args.group_id)

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -1,7 +1,13 @@
 import argparse
 
 from redi.cli._common import resolve_alias
-from redi.api.group import create_group, list_groups, read_group, update_group
+from redi.api.group import (
+    create_group,
+    delete_group,
+    list_groups,
+    read_group,
+    update_group,
+)
 
 
 def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -40,6 +46,10 @@ def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
         dest="user_ids",
         help="所属ユーザーIDを指定（複数指定可、既存の所属ユーザーを置き換え）",
     )
+    g_delete_parser = group_subparsers.add_parser(
+        "delete", aliases=["d"], help="グループ削除（管理者権限が必要）"
+    )
+    g_delete_parser.add_argument("group_id", help="グループID")
 
 
 def handle_group(args: argparse.Namespace) -> None:
@@ -56,5 +66,8 @@ def handle_group(args: argparse.Namespace) -> None:
             name=args.name,
             user_ids=args.user_ids,
         )
+        return
+    if cmd == "delete":
+        delete_group(args.group_id)
         return
     list_groups(full=args.full)

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -8,12 +8,14 @@ from redi.config import default_project_id
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
     add_note,
+    add_watcher,
     create_issue,
     delete_issue,
     fetch_issue,
     fetch_issues,
     list_issues,
     read_issue,
+    remove_watcher,
     update_issue,
 )
 from redi.api.issue_relation import create_relation, delete_relation
@@ -141,6 +143,20 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     i_update_parser.add_argument("--activity_id", help="作業分類ID")
     i_update_parser.add_argument("--spent_on", help="作業日（YYYY-MM-DD、省略で今日）")
     i_update_parser.add_argument("--time_comments", help="作業時間のコメント")
+    i_update_parser.add_argument(
+        "--add-watcher",
+        type=int,
+        action="append",
+        dest="add_watcher_ids",
+        help="ウォッチャーに追加するユーザーID（複数指定可）",
+    )
+    i_update_parser.add_argument(
+        "--remove-watcher",
+        type=int,
+        action="append",
+        dest="remove_watcher_ids",
+        help="ウォッチャーから削除するユーザーID（複数指定可）",
+    )
     i_comment_parser = i_subparsers.add_parser(
         "comment", aliases=["co"], help="イシューにコメント追加"
     )
@@ -397,6 +413,8 @@ def handle_issue_update(args: argparse.Namespace) -> None:
         or args.delete_relation
         or args.attach
         or args.hours is not None
+        or args.add_watcher_ids
+        or args.remove_watcher_ids
     )
     if no_args_provided:
         _interactive_fill_issue_update_args(args)
@@ -461,10 +479,16 @@ def handle_issue_update(args: argparse.Namespace) -> None:
             spent_on=args.spent_on,
             comments=args.time_comments,
         )
+    for user_id in args.add_watcher_ids or []:
+        add_watcher(args.issue_id, user_id)
+    for user_id in args.remove_watcher_ids or []:
+        remove_watcher(args.issue_id, user_id)
+    should_update_watchers = bool(args.add_watcher_ids or args.remove_watcher_ids)
     if (
         not should_update_issue
         and not should_update_issue_relation
         and not should_create_time_entry
+        and not should_update_watchers
     ):
         print("更新内容がないので更新をキャンセルしました")
         exit(1)

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -9,6 +9,7 @@ from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activi
 from redi.api.issue import (
     add_note,
     create_issue,
+    delete_issue,
     fetch_issue,
     fetch_issues,
     list_issues,
@@ -147,6 +148,10 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     i_comment_parser.add_argument(
         "notes", nargs="?", default="", help="コメント（省略でエディタ起動）"
     )
+    i_delete_parser = i_subparsers.add_parser(
+        "delete", aliases=["d"], help="イシュー削除"
+    )
+    i_delete_parser.add_argument("issue_id", help="イシューID")
 
 
 def _interactive_select_issue_id() -> str:
@@ -487,6 +492,8 @@ def handle_issue(args: argparse.Namespace) -> None:
                 add_note(args.issue_id, notes)
             else:
                 print("コメントが空のためキャンセルしました")
+    elif cmd == "delete":
+        delete_issue(args.issue_id)
     else:
         list_issues(
             project_id=args.project_id or default_project_id,

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -8,6 +8,7 @@ import argcomplete
 
 from redi.cli.attachment_command import add_attachment_parser, handle_attachment
 from redi.cli.config_command import add_config_parser, handle_config
+from redi.cli.file_command import add_file_parser, handle_file
 from redi.cli.enumerations_command import (
     add_custom_field_parser,
     add_document_category_parser,
@@ -96,6 +97,7 @@ def _build_parser() -> tuple[
     a_parser = add_attachment_parser(subparsers)
     r_parser = add_relation_parser(subparsers)
     add_time_entry_parser(subparsers)
+    add_file_parser(subparsers)
     return parser, a_parser, r_parser
 
 
@@ -223,5 +225,7 @@ def main() -> None:
         handle_relation(args, r_parser)
     elif args.command == "time_entry":
         handle_time_entry(args)
+    elif args.command == "file":
+        handle_file(args)
     else:
         parser.print_help()

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -33,6 +33,7 @@ from redi.cli.me_command import add_me_parser, handle_me
 from redi.cli.membership_command import add_membership_parser, handle_membership
 from redi.cli.news_command import add_news_parser, handle_news
 from redi.cli.project_command import add_project_parser, handle_project
+from redi.cli.relation_command import add_relation_parser, handle_relation
 from redi.cli.role_command import add_role_parser, handle_role
 from redi.cli.search_command import add_search_parser, handle_search
 from redi.cli.time_entry_command import add_time_entry_parser, handle_time_entry
@@ -53,7 +54,9 @@ from redi.api.tracker import list_trackers
 from redi.tui import TuiState, run_issue_tui
 
 
-def _build_parser() -> tuple[argparse.ArgumentParser, argparse.ArgumentParser]:
+def _build_parser() -> tuple[
+    argparse.ArgumentParser, argparse.ArgumentParser, argparse.ArgumentParser
+]:
     parser = argparse.ArgumentParser(description="Redmine CLI")
     parser.add_argument(
         "-V", "--version", action="version", version=f"redi {version('redi')}"
@@ -91,12 +94,13 @@ def _build_parser() -> tuple[argparse.ArgumentParser, argparse.ArgumentParser]:
     add_issue_category_parser(subparsers)
     add_search_parser(subparsers)
     a_parser = add_attachment_parser(subparsers)
+    r_parser = add_relation_parser(subparsers)
     add_time_entry_parser(subparsers)
-    return parser, a_parser
+    return parser, a_parser, r_parser
 
 
 def main() -> None:
-    parser, a_parser = _build_parser()
+    parser, a_parser, r_parser = _build_parser()
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
@@ -215,6 +219,8 @@ def main() -> None:
         handle_search(args)
     elif args.command == "attachment":
         handle_attachment(args, a_parser)
+    elif args.command == "relation":
+        handle_relation(args, r_parser)
     elif args.command == "time_entry":
         handle_time_entry(args)
     else:

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -153,6 +153,8 @@ def main() -> None:
                     activity_id=None,
                     spent_on=None,
                     time_comments=None,
+                    add_watcher_ids=None,
+                    remove_watcher_ids=None,
                 )
                 handle_issue_update(update_args)
             elif tui_result.action == "create":

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -2,10 +2,12 @@ import argparse
 
 from redi.cli._common import resolve_alias
 from redi.api.project import (
+    archive_project,
     create_project,
     delete_project,
     list_projects,
     read_project,
+    unarchive_project,
     update_project,
 )
 
@@ -66,6 +68,12 @@ def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
     p_update_parser.add_argument(
         "--tracker_ids", help="トラッカーID（カンマ区切り。例: 1,2,3）"
     )
+    p_update_parser.add_argument(
+        "--archive",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="アーカイブ (--no-archive で解除)",
+    )
 
 
 def handle_project(args: argparse.Namespace) -> None:
@@ -101,13 +109,28 @@ def handle_project(args: argparse.Namespace) -> None:
         tracker_ids = None
         if args.tracker_ids:
             tracker_ids = [int(x) for x in args.tracker_ids.split(",")]
-        update_project(
-            project_id=args.project_id,
-            name=args.name,
-            description=args.description,
-            is_public=is_public,
-            parent_id=args.parent_id,
-            tracker_ids=tracker_ids,
+        should_update = (
+            args.name is not None
+            or args.description is not None
+            or is_public is not None
+            or args.parent_id is not None
+            or tracker_ids is not None
         )
+        if should_update:
+            update_project(
+                project_id=args.project_id,
+                name=args.name,
+                description=args.description,
+                is_public=is_public,
+                parent_id=args.parent_id,
+                tracker_ids=tracker_ids,
+            )
+        if args.archive is True:
+            archive_project(args.project_id)
+        elif args.archive is False:
+            unarchive_project(args.project_id)
+        elif not should_update:
+            print("更新をキャンセルしました")
+            exit()
     else:
         list_projects(full=args.full)

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -1,7 +1,13 @@
 import argparse
 
 from redi.cli._common import resolve_alias
-from redi.api.project import create_project, list_projects, read_project, update_project
+from redi.api.project import (
+    create_project,
+    delete_project,
+    list_projects,
+    read_project,
+    update_project,
+)
 
 
 def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -41,6 +47,10 @@ def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
     p_create_parser.add_argument(
         "--tracker_ids", help="トラッカーID（カンマ区切り。例: 1,2,3）"
     )
+    p_delete_parser = p_subparsers.add_parser(
+        "delete", aliases=["d"], help="プロジェクト削除"
+    )
+    p_delete_parser.add_argument("project_id", help="プロジェクトID")
     p_update_parser = p_subparsers.add_parser(
         "update", aliases=["u"], help="プロジェクト更新"
     )
@@ -82,6 +92,8 @@ def handle_project(args: argparse.Namespace) -> None:
             parent_id=args.parent_id,
             tracker_ids=tracker_ids,
         )
+    elif cmd == "delete":
+        delete_project(args.project_id)
     elif cmd == "update":
         is_public = None
         if args.is_public is not None:

--- a/src/redi/cli/relation_command.py
+++ b/src/redi/cli/relation_command.py
@@ -1,0 +1,28 @@
+import argparse
+
+from redi.api.issue_relation import read_relation
+from redi.cli._common import resolve_alias
+
+
+def add_relation_parser(
+    subparsers: argparse._SubParsersAction,
+) -> argparse.ArgumentParser:
+    r_parser = subparsers.add_parser("relation", help="イシュー関係性 詳細")
+    r_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
+    r_subparsers = r_parser.add_subparsers(dest="relation_command")
+    r_view_parser = r_subparsers.add_parser("view", aliases=["v"], help="関係性詳細")
+    r_view_parser.add_argument("relation_id", help="関係性ID")
+    r_view_parser.add_argument(
+        "--full", action="store_true", help="JSON形式で全情報を出力"
+    )
+    return r_parser
+
+
+def handle_relation(
+    args: argparse.Namespace, r_parser: argparse.ArgumentParser
+) -> None:
+    cmd = resolve_alias(args.relation_command)
+    if cmd == "view":
+        read_relation(args.relation_id, full=args.full)
+        return
+    r_parser.print_help()

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -11,6 +11,7 @@ from redi.cli._common import inline_checkbox, inline_choice, resolve_alias
 from redi.config import default_project_id
 from redi.api.version import (
     create_version,
+    delete_version,
     fetch_version,
     fetch_versions,
     list_versions,
@@ -49,6 +50,10 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
         choices=["none", "descendants", "hierarchy", "tree", "system"],
         help="共有設定",
     )
+    v_delete_parser = v_subparsers.add_parser(
+        "delete", aliases=["d"], help="バージョン削除"
+    )
+    v_delete_parser.add_argument("version_id", help="バージョンID")
     v_update_parser = v_subparsers.add_parser(
         "update", aliases=["u"], help="バージョン更新"
     )
@@ -234,6 +239,8 @@ def handle_version(args: argparse.Namespace) -> None:
                 description=args.description,
                 sharing=args.sharing,
             )
+    elif cmd == "delete":
+        delete_version(args.version_id)
     elif cmd == "update":
         if not args.version_id:
             project_id = args.project_id or default_project_id

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -8,6 +8,7 @@ from redi.config import default_project_id, wiki_project_id
 from redi.api.wiki import (
     build_children_map,
     create_wiki,
+    delete_wiki,
     fetch_wiki,
     fetch_wikis,
     list_wikis,
@@ -60,6 +61,10 @@ def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
         default=None,
         help="説明（値省略でエディタ起動）",
     )
+    w_delete_parser = w_subparsers.add_parser(
+        "delete", aliases=["d"], help="Wikiページ削除"
+    )
+    w_delete_parser.add_argument("page_title", help="Wikiページタイトル")
     w_update_parser = w_subparsers.add_parser(
         "update", aliases=["u"], help="Wikiページ更新"
     )
@@ -136,6 +141,8 @@ def handle_wiki(args: argparse.Namespace) -> None:
             create_wiki(project_id, page_title, text, parent_title=parent_title)
         else:
             print("テキストが空のためキャンセルしました")
+    elif cmd == "delete":
+        delete_wiki(project_id, normalize_title(args.page_title))
     elif cmd == "update":
         page_title = args.page_title
         if page_title is None:

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -46,6 +46,9 @@ def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
     w_view_parser.add_argument(
         "--web", "-w", action="store_true", help="ブラウザでRedmineのページを開く"
     )
+    w_view_parser.add_argument(
+        "--version", type=int, help="特定バージョンのページを取得"
+    )
     w_create_parser = w_subparsers.add_parser(
         "create", aliases=["c"], help="Wikiページ作成"
     )
@@ -90,7 +93,13 @@ def handle_wiki(args: argparse.Namespace) -> None:
         exit(1)
     cmd = resolve_alias(args.wiki_command)
     if cmd == "view":
-        read_wiki(project_id, args.page_title, full=args.full, web=args.web)
+        read_wiki(
+            project_id,
+            args.page_title,
+            full=args.full,
+            web=args.web,
+            version=args.version,
+        )
     elif cmd == "create":
         page_title = args.page_title
         parent_title = args.parent_title


### PR DESCRIPTION
## Summary
- issue #77 で未実装だった Redmine REST API 12件にコマンドを追加
- delete 系 6件 (issue / version / wiki / attachment / group / project)
- その他 6件 (project archive, wiki version, group user add/remove, issue watcher, relation view, file list/create)

## 追加コマンド一覧
| API | コマンド |
| --- | --- |
| DELETE /issues/[id] | \`redi issue delete <id>\` |
| DELETE /versions/[id] | \`redi version delete <id>\` |
| DELETE /projects/[id]/wiki/[title] | \`redi wiki delete <title>\` |
| DELETE /attachments/[id] | \`redi attachment delete <id>\` |
| DELETE /groups/[id] | \`redi group delete <id>\` |
| DELETE /projects/[id] | \`redi project delete <id>\` |
| PUT /projects/[id]/(un)archive | \`redi project update <id> --archive / --no-archive\` |
| GET /projects/[id]/wiki/[title]/[version] | \`redi wiki view <title> --version <n>\` |
| POST/DELETE /groups/[id]/users | \`redi group update <id> --add-user <uid> / --remove-user <uid>\` |
| POST/DELETE /issues/[id]/watchers | \`redi issue update <id> --add-watcher <uid> / --remove-watcher <uid>\` |
| GET /relations/[id] | \`redi relation view <id>\` |
| GET/POST /projects/[id]/files | \`redi file -p <project_id>\` / \`redi file create <path> -p <project_id>\` |

## Test plan
- [x] \`task check\` (format / lint / typecheck / test) が通る
- [x] 各 delete コマンドがローカル Redmine で対象リソースを削除できる
- [x] \`redi project update --archive / --no-archive\` でアーカイブ状態が変化する
- [x] \`redi wiki view --version\` で旧版テキストが取得できる
- [x] \`redi group update --add-user / --remove-user\` でユーザー所属が変化する
- [x] \`redi issue update --add-watcher / --remove-watcher\` でウォッチャーが変化する
- [x] \`redi relation view\` で関係性の詳細が表示される
- [x] \`redi file\` で一覧取得、\`redi file create\` でアップロードが成功する

refs #77