### PR TITLE
削除系コマンドに確認プロンプトと -y/--yes フラグを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ redi file create ./foo.zip -p <project_id> -d "description"
 # attachment
 redi attachment view <attachment_id>
 redi attachment update <attachment_id> -f new_name.png -d "desc"
-redi attachment delete <attachment_id>
+redi attachment delete <attachment_id> # confirm before delete (-y to skip)
 
 # relation (イシュー関係性詳細)
 redi relation view <relation_id>
@@ -124,7 +124,7 @@ redi relation view <relation_id>
 redi time_entry -p <project_id> -u me
 redi time_entry create 1.5 -i <issue_id> -a <activity_id> -c "comment"
 redi time_entry update <time_entry_id> --hours 2.0
-redi time_entry delete <time_entry_id>
+redi time_entry delete <time_entry_id> # confirm before delete (-y to skip)
 
 # me (自分のアカウント)
 redi me

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ redi issue update <issue_id> --status_id <status_id> -n "notes"
 redi issue update <issue_id> --relate relates --to <other_issue_id>
 redi issue update <issue_id> --attach ./foo.png --attach ./bar.log
 redi issue comment <issue_id> "hello~"
+redi issue delete <issue_id> # (confirm before delete)
+redi issue delete <issue_id> -y # skip confirmation
 
 # version (alias: v)
 redi version # list versions(fixed_versions)

--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -17,6 +17,18 @@ def list_projects(full: bool = False) -> None:
             print(f"{project['id']} {project['name']}")
 
 
+def fetch_project(project_id: str, include: str = "") -> dict:
+    params: dict = {}
+    if include:
+        params["include"] = include
+    response = client.get(f"/projects/{project_id}.json", params=params)
+    if response.status_code == 404:
+        print(f"プロジェクトが見つかりません: {project_id}")
+        exit(1)
+    response.raise_for_status()
+    return response.json()["project"]
+
+
 def create_project(
     name: str,
     identifier: str,

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -22,6 +22,22 @@ def confirm_delete(summary: str) -> None:
         exit(1)
 
 
+def confirm_delete_with_identifier(
+    summary: str, expected: str, field_label: str
+) -> None:
+    print(summary)
+    try:
+        entered = prompt(
+            f'削除するには{field_label} "{expected}" を入力してください: '
+        ).strip()
+    except (KeyboardInterrupt, EOFError):
+        print("キャンセルしました")
+        exit(1)
+    if entered != expected:
+        print(f"{field_label}が一致しません。キャンセルしました")
+        exit(1)
+
+
 SUBCOMMAND_ALIASES: dict[str, str] = {
     "v": "view",
     "c": "create",

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -2,12 +2,24 @@ import os
 import subprocess
 import tempfile
 
-from prompt_toolkit import Application
+from prompt_toolkit import Application, prompt
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import HSplit, Layout, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 from redi.config import editor
+
+
+def confirm_delete(summary: str) -> None:
+    print(summary)
+    try:
+        confirm = prompt("削除してもよろしいですか? (yes/No): ").strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        print("キャンセルしました")
+        exit(1)
+    if confirm != "yes":
+        print("キャンセルしました")
+        exit(1)
 
 
 SUBCOMMAND_ALIASES: dict[str, str] = {

--- a/src/redi/cli/attachment_command.py
+++ b/src/redi/cli/attachment_command.py
@@ -1,7 +1,12 @@
 import argparse
 
-from redi.api.attachment import delete_attachment, read_attachment, update_attachment
-from redi.cli._common import resolve_alias
+from redi.api.attachment import (
+    delete_attachment,
+    fetch_attachment,
+    read_attachment,
+    update_attachment,
+)
+from redi.cli._common import confirm_delete, resolve_alias
 
 
 def add_attachment_parser(
@@ -26,6 +31,9 @@ def add_attachment_parser(
         "delete", aliases=["d"], help="添付ファイル削除"
     )
     a_delete_parser.add_argument("attachment_id", help="添付ファイルID")
+    a_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
     return a_parser
 
 
@@ -42,6 +50,11 @@ def handle_attachment(
             description=args.description,
         )
     elif cmd == "delete":
+        if not args.yes:
+            attachment = fetch_attachment(args.attachment_id)
+            confirm_delete(
+                f"削除する添付ファイル: {attachment['id']} {attachment['filename']}"
+            )
         delete_attachment(args.attachment_id)
     else:
         a_parser.print_help()

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -1,10 +1,11 @@
 import argparse
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import confirm_delete, resolve_alias
 from redi.api.group import (
     add_group_user,
     create_group,
     delete_group,
+    fetch_group,
     list_groups,
     read_group,
     remove_group_user,
@@ -68,6 +69,9 @@ def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="グループ削除（管理者権限が必要）"
     )
     g_delete_parser.add_argument("group_id", help="グループID")
+    g_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
 
 
 def handle_group(args: argparse.Namespace) -> None:
@@ -95,6 +99,9 @@ def handle_group(args: argparse.Namespace) -> None:
             exit()
         return
     if cmd == "delete":
+        if not args.yes:
+            group = fetch_group(args.group_id)
+            confirm_delete(f"削除するグループ: {group['id']} {group['name']}")
         delete_group(args.group_id)
         return
     list_groups(full=args.full)

--- a/src/redi/cli/issue_category_command.py
+++ b/src/redi/cli/issue_category_command.py
@@ -1,10 +1,11 @@
 import argparse
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import confirm_delete, resolve_alias
 from redi.config import default_project_id
 from redi.api.issue_category import (
     create_issue_category,
     delete_issue_category,
+    fetch_issue_category,
     list_issue_categories,
     read_issue_category,
     update_issue_category,
@@ -54,6 +55,9 @@ def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
         type=int,
         help="削除に伴い既存チケットを再割り当てするカテゴリID",
     )
+    ic_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
 
 
 def handle_issue_category(args: argparse.Namespace) -> None:
@@ -80,6 +84,11 @@ def handle_issue_category(args: argparse.Namespace) -> None:
         )
         return
     if cmd == "delete":
+        if not args.yes:
+            category = fetch_issue_category(args.category_id)
+            confirm_delete(
+                f"削除するイシューカテゴリ: {category['id']} {category['name']}"
+            )
         delete_issue_category(
             category_id=args.category_id,
             reassign_to_id=args.reassign_to_id,

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -168,6 +168,9 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="イシュー削除"
     )
     i_delete_parser.add_argument("issue_id", help="イシューID")
+    i_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
 
 
 def _interactive_select_issue_id() -> str:
@@ -517,16 +520,17 @@ def handle_issue(args: argparse.Namespace) -> None:
             else:
                 print("コメントが空のためキャンセルしました")
     elif cmd == "delete":
-        issue = fetch_issue(args.issue_id)
-        print(f"削除するイシュー: #{issue['id']} {issue['subject']}")
-        try:
-            confirm = prompt("削除してもよろしいですか? (yes/No): ").strip().lower()
-        except (KeyboardInterrupt, EOFError):
-            print("キャンセルしました")
-            exit(1)
-        if confirm != "yes":
-            print("キャンセルしました")
-            exit(1)
+        if not args.yes:
+            issue = fetch_issue(args.issue_id)
+            print(f"削除するイシュー: #{issue['id']} {issue['subject']}")
+            try:
+                confirm = prompt("削除してもよろしいですか? (yes/No): ").strip().lower()
+            except (KeyboardInterrupt, EOFError):
+                print("キャンセルしました")
+                exit(1)
+            if confirm != "yes":
+                print("キャンセルしました")
+                exit(1)
         delete_issue(args.issue_id)
     else:
         list_issues(

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -517,6 +517,16 @@ def handle_issue(args: argparse.Namespace) -> None:
             else:
                 print("コメントが空のためキャンセルしました")
     elif cmd == "delete":
+        issue = fetch_issue(args.issue_id)
+        print(f"削除するイシュー: #{issue['id']} {issue['subject']}")
+        try:
+            confirm = prompt("削除してもよろしいですか? (y/N): ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print("キャンセルしました")
+            exit(1)
+        if confirm not in ("y", "yes"):
+            print("キャンセルしました")
+            exit(1)
         delete_issue(args.issue_id)
     else:
         list_issues(

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -3,7 +3,13 @@ import argparse
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
 
-from redi.cli._common import inline_checkbox, inline_choice, open_editor, resolve_alias
+from redi.cli._common import (
+    confirm_delete,
+    inline_checkbox,
+    inline_choice,
+    open_editor,
+    resolve_alias,
+)
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
@@ -522,15 +528,7 @@ def handle_issue(args: argparse.Namespace) -> None:
     elif cmd == "delete":
         if not args.yes:
             issue = fetch_issue(args.issue_id)
-            print(f"削除するイシュー: #{issue['id']} {issue['subject']}")
-            try:
-                confirm = prompt("削除してもよろしいですか? (yes/No): ").strip().lower()
-            except (KeyboardInterrupt, EOFError):
-                print("キャンセルしました")
-                exit(1)
-            if confirm != "yes":
-                print("キャンセルしました")
-                exit(1)
+            confirm_delete(f"削除するイシュー: #{issue['id']} {issue['subject']}")
         delete_issue(args.issue_id)
     else:
         list_issues(

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -520,11 +520,11 @@ def handle_issue(args: argparse.Namespace) -> None:
         issue = fetch_issue(args.issue_id)
         print(f"削除するイシュー: #{issue['id']} {issue['subject']}")
         try:
-            confirm = prompt("削除してもよろしいですか? (y/N): ").strip().lower()
+            confirm = prompt("削除してもよろしいですか? (yes/No): ").strip().lower()
         except (KeyboardInterrupt, EOFError):
             print("キャンセルしました")
             exit(1)
-        if confirm not in ("y", "yes"):
+        if confirm != "yes":
             print("キャンセルしました")
             exit(1)
         delete_issue(args.issue_id)

--- a/src/redi/cli/membership_command.py
+++ b/src/redi/cli/membership_command.py
@@ -1,10 +1,11 @@
 import argparse
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import confirm_delete, resolve_alias
 from redi.config import default_project_id
 from redi.api.membership import (
     create_membership,
     delete_membership,
+    fetch_membership,
     list_memberships,
     read_membership,
     update_membership,
@@ -59,6 +60,9 @@ def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="メンバーシップ削除"
     )
     m_delete_parser.add_argument("membership_id", help="メンバーシップID")
+    m_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
 
 
 def handle_membership(args: argparse.Namespace) -> None:
@@ -88,6 +92,15 @@ def handle_membership(args: argparse.Namespace) -> None:
         )
         return
     if cmd == "delete":
+        if not args.yes:
+            m = fetch_membership(args.membership_id)
+            principal = m.get("user") or m.get("group") or {}
+            kind = "user" if "user" in m else "group"
+            roles = ", ".join(r.get("name", "") for r in (m.get("roles") or []))
+            confirm_delete(
+                f"削除するメンバーシップ: {m['id']} [{kind}] "
+                f"{principal.get('id', '?')} {principal.get('name', '')} - {roles}"
+            )
         delete_membership(args.membership_id)
         return
 

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -1,10 +1,11 @@
 import argparse
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import confirm_delete_with_identifier, resolve_alias
 from redi.api.project import (
     archive_project,
     create_project,
     delete_project,
+    fetch_project,
     list_projects,
     read_project,
     unarchive_project,
@@ -53,6 +54,9 @@ def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="プロジェクト削除"
     )
     p_delete_parser.add_argument("project_id", help="プロジェクトID")
+    p_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
     p_update_parser = p_subparsers.add_parser(
         "update", aliases=["u"], help="プロジェクト更新"
     )
@@ -101,6 +105,16 @@ def handle_project(args: argparse.Namespace) -> None:
             tracker_ids=tracker_ids,
         )
     elif cmd == "delete":
+        if not args.yes:
+            project = fetch_project(args.project_id)
+            summary = (
+                f"削除するプロジェクト: {project['id']} {project['name']} "
+                f"(identifier: {project['identifier']})\n"
+                "**この操作は配下のイシュー等を含めて削除します**"
+            )
+            confirm_delete_with_identifier(
+                summary, project["identifier"], "プロジェクト識別子"
+            )
         delete_project(args.project_id)
     elif cmd == "update":
         is_public = None

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -1,10 +1,11 @@
 import argparse
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import confirm_delete, resolve_alias
 from redi.config import default_project_id
 from redi.api.time_entry import (
     create_time_entry,
     delete_time_entry,
+    fetch_time_entry,
     list_time_entries,
     read_time_entry,
     update_time_entry,
@@ -53,6 +54,9 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="作業時間削除"
     )
     te_delete_parser.add_argument("time_entry_id", help="作業時間ID")
+    te_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
 
 
 def handle_time_entry(args: argparse.Namespace) -> None:
@@ -80,6 +84,13 @@ def handle_time_entry(args: argparse.Namespace) -> None:
             comments=args.comments,
         )
     elif cmd == "delete":
+        if not args.yes:
+            te = fetch_time_entry(args.time_entry_id)
+            activity = (te.get("activity") or {}).get("name", "")
+            confirm_delete(
+                f"削除する作業時間: {te['id']} {te['hours']}h {activity} "
+                f"({te['spent_on']})"
+            )
         delete_time_entry(args.time_entry_id)
     else:
         project_id = args.project_id or default_project_id

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -1,9 +1,10 @@
 import argparse
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import confirm_delete_with_identifier, resolve_alias
 from redi.api.user import (
     create_user,
     delete_user,
+    fetch_user,
     list_users,
     read_user,
     update_user,
@@ -94,6 +95,9 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="ユーザー削除（管理者権限が必要）"
     )
     u_delete_parser.add_argument("user_id", help="ユーザーID")
+    u_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
 
 
 def handle_user(args: argparse.Namespace) -> None:
@@ -130,6 +134,11 @@ def handle_user(args: argparse.Namespace) -> None:
         )
         return
     if cmd == "delete":
+        if not args.yes:
+            user = fetch_user(args.user_id)
+            name = f"{user.get('firstname', '')} {user.get('lastname', '')}".strip()
+            summary = f"削除するユーザー: {user['id']} {user.get('login', '')} {name}".rstrip()
+            confirm_delete_with_identifier(summary, user.get("login", ""), "ログイン名")
         delete_user(args.user_id)
         return
     list_users(full=args.full)

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -7,7 +7,12 @@ from prompt_toolkit.keys import Keys
 from prompt_toolkit.shortcuts import choice
 from prompt_toolkit.validation import Validator
 
-from redi.cli._common import inline_checkbox, inline_choice, resolve_alias
+from redi.cli._common import (
+    confirm_delete,
+    inline_checkbox,
+    inline_choice,
+    resolve_alias,
+)
 from redi.config import default_project_id
 from redi.api.version import (
     create_version,
@@ -56,6 +61,9 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="バージョン削除"
     )
     v_delete_parser.add_argument("version_id", help="バージョンID")
+    v_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
     v_update_parser = v_subparsers.add_parser(
         "update", aliases=["u"], help="バージョン更新"
     )
@@ -242,6 +250,9 @@ def handle_version(args: argparse.Namespace) -> None:
                 sharing=args.sharing,
             )
     elif cmd == "delete":
+        if not args.yes:
+            version = fetch_version(args.version_id)
+            confirm_delete(f"削除するバージョン: {version['id']} {version['name']}")
         delete_version(args.version_id)
     elif cmd == "update":
         if not args.version_id:

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -3,7 +3,7 @@ import argparse
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import ValidationError, Validator
 
-from redi.cli._common import inline_choice, open_editor, resolve_alias
+from redi.cli._common import confirm_delete, inline_choice, open_editor, resolve_alias
 from redi.config import default_project_id, wiki_project_id
 from redi.api.wiki import (
     build_children_map,
@@ -70,6 +70,9 @@ def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
         "delete", aliases=["d"], help="Wikiページ削除"
     )
     w_delete_parser.add_argument("page_title", help="Wikiページタイトル")
+    w_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help="確認プロンプトをスキップ"
+    )
     w_update_parser = w_subparsers.add_parser(
         "update", aliases=["u"], help="Wikiページ更新"
     )
@@ -153,7 +156,11 @@ def handle_wiki(args: argparse.Namespace) -> None:
         else:
             print("テキストが空のためキャンセルしました")
     elif cmd == "delete":
-        delete_wiki(project_id, normalize_title(args.page_title))
+        title = normalize_title(args.page_title)
+        if not args.yes:
+            page = fetch_wiki(project_id, title)
+            confirm_delete(f"削除するWikiページ: {page.get('title', title)}")
+        delete_wiki(project_id, title)
     elif cmd == "update":
         page_title = args.page_title
         if page_title is None:

--- a/tests/unit/test_confirm_delete.py
+++ b/tests/unit/test_confirm_delete.py
@@ -1,0 +1,143 @@
+import pytest
+
+from redi.cli import _common
+
+
+class TestConfirmDelete:
+    """confirm_delete()はyes/Noプロンプトで削除可否を確認する"""
+
+    def test_accepts_yes(self, monkeypatch, capsys):
+        """'yes'の入力なら例外なく処理が続行する"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "yes")
+        _common.confirm_delete("削除するX: 1")
+        out = capsys.readouterr().out
+        assert "削除するX: 1" in out
+
+    def test_accepts_yes_case_insensitive(self, monkeypatch):
+        """大文字小文字と前後空白を許容する"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "  YES  ")
+        _common.confirm_delete("summary")
+
+    def test_rejects_no(self, monkeypatch, capsys):
+        """'no'ならexit(1)してキャンセルメッセージを出力する"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "no")
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete("summary")
+        assert exc.value.code == 1
+        assert "キャンセルしました" in capsys.readouterr().out
+
+    def test_rejects_empty_input(self, monkeypatch):
+        """空入力はキャンセル扱い（デフォルトNoの挙動）"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "")
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete("summary")
+        assert exc.value.code == 1
+
+    def test_rejects_other_inputs(self, monkeypatch):
+        """'y'単体や関係ない文字列はキャンセル扱い"""
+        for value in ["y", "ye", "n", "abc"]:
+            monkeypatch.setattr(_common, "prompt", lambda _msg, v=value: v)
+            with pytest.raises(SystemExit) as exc:
+                _common.confirm_delete("summary")
+            assert exc.value.code == 1
+
+    def test_keyboard_interrupt_cancels(self, monkeypatch, capsys):
+        """Ctrl-Cはキャンセル扱い"""
+
+        def raise_interrupt(_msg):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(_common, "prompt", raise_interrupt)
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete("summary")
+        assert exc.value.code == 1
+        assert "キャンセルしました" in capsys.readouterr().out
+
+    def test_eof_error_cancels(self, monkeypatch):
+        """EOF(Ctrl-D)もキャンセル扱い"""
+
+        def raise_eof(_msg):
+            raise EOFError
+
+        monkeypatch.setattr(_common, "prompt", raise_eof)
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete("summary")
+        assert exc.value.code == 1
+
+
+class TestConfirmDeleteWithIdentifier:
+    """confirm_delete_with_identifier()は識別子の再入力で削除可否を確認する"""
+
+    def test_accepts_matching_identifier(self, monkeypatch, capsys):
+        """識別子が一致すれば例外なく処理が続行する"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "my-project")
+        _common.confirm_delete_with_identifier(
+            "削除するプロジェクト: 1 My Project", "my-project", "プロジェクト識別子"
+        )
+        assert "削除するプロジェクト: 1 My Project" in capsys.readouterr().out
+
+    def test_trims_whitespace(self, monkeypatch):
+        """前後空白は無視する"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "  my-project  ")
+        _common.confirm_delete_with_identifier(
+            "summary", "my-project", "プロジェクト識別子"
+        )
+
+    def test_is_case_sensitive(self, monkeypatch):
+        """識別子の比較は大文字小文字を区別する"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "MY-PROJECT")
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete_with_identifier(
+                "summary", "my-project", "プロジェクト識別子"
+            )
+        assert exc.value.code == 1
+
+    def test_rejects_mismatched_identifier(self, monkeypatch, capsys):
+        """識別子が一致しなければexit(1)してメッセージを出力する"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "wrong-id")
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete_with_identifier(
+                "summary", "my-project", "プロジェクト識別子"
+            )
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "プロジェクト識別子が一致しません" in out
+        assert "キャンセルしました" in out
+
+    def test_rejects_empty_input(self, monkeypatch):
+        """空入力は不一致扱い"""
+        monkeypatch.setattr(_common, "prompt", lambda _msg: "")
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete_with_identifier(
+                "summary", "my-project", "プロジェクト識別子"
+            )
+        assert exc.value.code == 1
+
+    def test_keyboard_interrupt_cancels(self, monkeypatch, capsys):
+        """Ctrl-Cはキャンセル扱い"""
+
+        def raise_interrupt(_msg):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(_common, "prompt", raise_interrupt)
+        with pytest.raises(SystemExit) as exc:
+            _common.confirm_delete_with_identifier(
+                "summary", "my-project", "プロジェクト識別子"
+            )
+        assert exc.value.code == 1
+        assert "キャンセルしました" in capsys.readouterr().out
+
+    def test_prompt_message_includes_identifier_and_label(self, monkeypatch):
+        """プロンプト文字列に識別子とフィールドラベルが含まれる"""
+        captured: dict[str, str] = {}
+
+        def capture_prompt(msg: str) -> str:
+            captured["msg"] = msg
+            return "my-project"
+
+        monkeypatch.setattr(_common, "prompt", capture_prompt)
+        _common.confirm_delete_with_identifier(
+            "summary", "my-project", "プロジェクト識別子"
+        )
+        assert "プロジェクト識別子" in captured["msg"]
+        assert "my-project" in captured["msg"]


### PR DESCRIPTION
## Summary
closes #84 

- `redi <resource> delete` 系コマンドに削除前の確認プロンプトを追加（yes/No 形式）
- `-y` / `--yes` フラグで確認をスキップ可能
- プロジェクト / ユーザーの削除は影響が大きいため、通常の yes/No ではなく **識別子（プロジェクト識別子 / ログイン名）の再入力** で確認する強めのプロンプトに
- 確認処理は `redi.cli._common.confirm_delete` / `confirm_delete_with_identifier` に切り出して共通化
- `confirm_delete*` 系のユニットテストを追加 (`tests/unit/test_confirm_delete.py`)

### 対象コマンド
- 通常の yes/No 確認: `issue` / `wiki` / `version` / `group` / `membership` / `issue_category` / `time_entry` / `attachment`
- 識別子再入力による確認: `project` / `user`

## Test plan
- [x] `task check` がパスする
- [x] `redi issue delete <id>` で対象イシュー情報表示 + yes/No プロンプトが出る
- [x] `redi issue delete <id> -y` で確認がスキップされ即削除される
- [x] `no` や空入力、Ctrl-C でキャンセルされる
- [x] `redi project delete <project_id>` でプロジェクト識別子の再入力を求められる
- [x] 入力した識別子が一致しない場合に削除されずキャンセルされる
- [x] `redi user delete <user_id>` でログイン名の再入力を求められる