### PR TITLE
#90 各リソースに list サブコマンド (alias: l) を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ redi --profile <profile_name> issue # 一時的にプロファイルを切り替
 
 # project (alias: p)
 redi project # list projects
+redi project list # 同上 (`redi project l` / `redi p list` / `redi p l` / `redi p` も同じ)
 redi project view <project_id> # view project
 redi project view <project_id> --include trackers,issue_categories
 redi project create <name> <identifier>

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -44,6 +44,7 @@ SUBCOMMAND_ALIASES: dict[str, str] = {
     "u": "update",
     "co": "comment",
     "d": "delete",
+    "l": "list",
 }
 
 

--- a/src/redi/cli/file_command.py
+++ b/src/redi/cli/file_command.py
@@ -6,12 +6,11 @@ from redi.config import default_project_id
 
 
 def add_file_parser(subparsers: argparse._SubParsersAction) -> None:
-    f_parser = subparsers.add_parser(
-        "file", help="プロジェクトファイル 一覧/アップロード"
-    )
+    f_parser = subparsers.add_parser("file", help="list: 一覧, create: アップロード")
     f_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     f_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     f_subparsers = f_parser.add_subparsers(dest="file_command")
+    f_subparsers.add_parser("list", aliases=["l"], help="プロジェクトファイル一覧")
     f_create_parser = f_subparsers.add_parser(
         "create", aliases=["c"], help="ファイルアップロード"
     )
@@ -35,4 +34,5 @@ def handle_file(args: argparse.Namespace) -> None:
             description=args.description,
         )
         return
-    list_files(project_id, full=args.full)
+    if cmd == "list" or cmd is None:
+        list_files(project_id, full=args.full)

--- a/src/redi/cli/file_command.py
+++ b/src/redi/cli/file_command.py
@@ -6,7 +6,9 @@ from redi.config import default_project_id
 
 
 def add_file_parser(subparsers: argparse._SubParsersAction) -> None:
-    f_parser = subparsers.add_parser("file", help="list: 一覧, create: アップロード")
+    f_parser = subparsers.add_parser(
+        "file", help="list(l): 一覧, create(c): アップロード"
+    )
     f_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     f_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     f_subparsers = f_parser.add_subparsers(dest="file_command")

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -15,12 +15,14 @@ from redi.api.group import (
 
 def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
     group_parser = subparsers.add_parser(
-        "group", help="グループ一覧/詳細/作成/更新/削除"
+        "group",
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
     )
     group_parser.add_argument(
         "--full", action="store_true", help="JSON形式で全情報を出力"
     )
     group_subparsers = group_parser.add_subparsers(dest="group_command")
+    group_subparsers.add_parser("list", aliases=["l"], help="グループ一覧")
     g_view_parser = group_subparsers.add_parser(
         "view", aliases=["v"], help="グループ詳細"
     )
@@ -104,4 +106,5 @@ def handle_group(args: argparse.Namespace) -> None:
             confirm_delete(f"削除するグループ: {group['id']} {group['name']}")
         delete_group(args.group_id)
         return
-    list_groups(full=args.full)
+    if cmd == "list" or cmd is None:
+        list_groups(full=args.full)

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -16,7 +16,7 @@ from redi.api.group import (
 def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
     group_parser = subparsers.add_parser(
         "group",
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, delete(d): 削除",
     )
     group_parser.add_argument(
         "--full", action="store_true", help="JSON形式で全情報を出力"

--- a/src/redi/cli/issue_category_command.py
+++ b/src/redi/cli/issue_category_command.py
@@ -15,7 +15,7 @@ from redi.api.issue_category import (
 def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
     ic_parser = subparsers.add_parser(
         "issue_category",
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, delete(d): 削除",
     )
     ic_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     ic_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")

--- a/src/redi/cli/issue_category_command.py
+++ b/src/redi/cli/issue_category_command.py
@@ -14,11 +14,13 @@ from redi.api.issue_category import (
 
 def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
     ic_parser = subparsers.add_parser(
-        "issue_category", help="イシューカテゴリ 一覧/詳細/作成/更新/削除"
+        "issue_category",
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
     )
     ic_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     ic_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     ic_subparsers = ic_parser.add_subparsers(dest="issue_category_command")
+    ic_subparsers.add_parser("list", aliases=["l"], help="イシューカテゴリ一覧")
 
     ic_view_parser = ic_subparsers.add_parser(
         "view", aliases=["v"], help="カテゴリ詳細"
@@ -94,8 +96,9 @@ def handle_issue_category(args: argparse.Namespace) -> None:
             reassign_to_id=args.reassign_to_id,
         )
         return
-    project_id = args.project_id or default_project_id
-    if not project_id:
-        print("project_idを指定するか、default_project_idを設定してください")
-        exit(1)
-    list_issue_categories(project_id, full=args.full)
+    if cmd == "list" or cmd is None:
+        project_id = args.project_id or default_project_id
+        if not project_id:
+            print("project_idを指定するか、default_project_idを設定してください")
+            exit(1)
+        list_issue_categories(project_id, full=args.full)

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -39,7 +39,9 @@ from redi.api.custom_field import (
 
 def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     i_parser = subparsers.add_parser(
-        "issue", aliases=["i"], help="イシュー一覧/詳細/作成/更新/コメント/削除"
+        "issue",
+        aliases=["i"],
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, comment: コメント, delete: 削除",
     )
     i_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     i_parser.add_argument("--project_id", "-p", help="プロジェクトIDでフィルタリング")
@@ -68,6 +70,7 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     i_parser.add_argument("--limit", "-l", type=int, help="取得件数")
     i_parser.add_argument("--offset", "-o", type=int, help="オフセット")
     i_subparsers = i_parser.add_subparsers(dest="issue_command")
+    i_subparsers.add_parser("list", aliases=["l"], help="イシュー一覧")
     i_view_parser = i_subparsers.add_parser("view", aliases=["v"], help="イシュー詳細")
     i_view_parser.add_argument("issue_id", help="イシューID")
     i_view_parser.add_argument(
@@ -530,7 +533,7 @@ def handle_issue(args: argparse.Namespace) -> None:
             issue = fetch_issue(args.issue_id)
             confirm_delete(f"削除するイシュー: #{issue['id']} {issue['subject']}")
         delete_issue(args.issue_id)
-    else:
+    elif cmd == "list" or cmd is None:
         list_issues(
             project_id=args.project_id or default_project_id,
             fixed_version_id=args.version,

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -41,7 +41,7 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     i_parser = subparsers.add_parser(
         "issue",
         aliases=["i"],
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, comment: コメント, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, comment(co): コメント, delete(d): 削除",
     )
     i_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     i_parser.add_argument("--project_id", "-p", help="プロジェクトIDでフィルタリング")

--- a/src/redi/cli/membership_command.py
+++ b/src/redi/cli/membership_command.py
@@ -18,11 +18,14 @@ def _parse_role_ids(value: str) -> list[int]:
 
 def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
     m_parser = subparsers.add_parser(
-        "membership", aliases=["m"], help="メンバーシップ一覧/詳細/作成/更新/削除"
+        "membership",
+        aliases=["m"],
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
     )
     m_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     m_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     m_subparsers = m_parser.add_subparsers(dest="membership_command")
+    m_subparsers.add_parser("list", aliases=["l"], help="メンバーシップ一覧")
 
     m_view_parser = m_subparsers.add_parser(
         "view", aliases=["v"], help="メンバーシップ詳細"
@@ -104,8 +107,9 @@ def handle_membership(args: argparse.Namespace) -> None:
         delete_membership(args.membership_id)
         return
 
-    project_id = args.project_id or default_project_id
-    if not project_id:
-        print("project_idを指定するか、default_project_idを設定してください")
-        exit(1)
-    list_memberships(project_id, full=args.full)
+    if cmd == "list" or cmd is None:
+        project_id = args.project_id or default_project_id
+        if not project_id:
+            print("project_idを指定するか、default_project_idを設定してください")
+            exit(1)
+        list_memberships(project_id, full=args.full)

--- a/src/redi/cli/membership_command.py
+++ b/src/redi/cli/membership_command.py
@@ -20,7 +20,7 @@ def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
     m_parser = subparsers.add_parser(
         "membership",
         aliases=["m"],
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, delete(d): 削除",
     )
     m_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     m_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -17,7 +17,7 @@ def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
     p_parser = subparsers.add_parser(
         "project",
         aliases=["p"],
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, delete(d): 削除",
     )
     p_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     p_subparsers = p_parser.add_subparsers(dest="project_command")

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -15,10 +15,13 @@ from redi.api.project import (
 
 def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
     p_parser = subparsers.add_parser(
-        "project", aliases=["p"], help="プロジェクト一覧/詳細/作成/更新/削除"
+        "project",
+        aliases=["p"],
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
     )
     p_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     p_subparsers = p_parser.add_subparsers(dest="project_command")
+    p_subparsers.add_parser("list", aliases=["l"], help="プロジェクト一覧")
     p_view_parser = p_subparsers.add_parser(
         "view", aliases=["v"], help="プロジェクト詳細"
     )
@@ -146,5 +149,5 @@ def handle_project(args: argparse.Namespace) -> None:
         elif not should_update:
             print("更新をキャンセルしました")
             exit()
-    else:
+    elif cmd == "list" or cmd is None:
         list_projects(full=args.full)

--- a/src/redi/cli/role_command.py
+++ b/src/redi/cli/role_command.py
@@ -5,7 +5,7 @@ from redi.api.role import list_roles, read_role
 
 
 def add_role_parser(subparsers: argparse._SubParsersAction) -> None:
-    role_parser = subparsers.add_parser("role", help="list: 一覧, view: 詳細")
+    role_parser = subparsers.add_parser("role", help="list(l): 一覧, view(v): 詳細")
     role_parser.add_argument(
         "--full", action="store_true", help="JSON形式で全情報を出力"
     )

--- a/src/redi/cli/role_command.py
+++ b/src/redi/cli/role_command.py
@@ -5,11 +5,12 @@ from redi.api.role import list_roles, read_role
 
 
 def add_role_parser(subparsers: argparse._SubParsersAction) -> None:
-    role_parser = subparsers.add_parser("role", help="ロール一覧/詳細")
+    role_parser = subparsers.add_parser("role", help="list: 一覧, view: 詳細")
     role_parser.add_argument(
         "--full", action="store_true", help="JSON形式で全情報を出力"
     )
     role_subparsers = role_parser.add_subparsers(dest="role_command")
+    role_subparsers.add_parser("list", aliases=["l"], help="ロール一覧")
     role_view_parser = role_subparsers.add_parser(
         "view", aliases=["v"], help="ロール詳細"
     )
@@ -20,7 +21,8 @@ def add_role_parser(subparsers: argparse._SubParsersAction) -> None:
 
 
 def handle_role(args: argparse.Namespace) -> None:
-    if resolve_alias(args.role_command) == "view":
+    cmd = resolve_alias(args.role_command)
+    if cmd == "view":
         read_role(args.role_id, full=args.full)
-    else:
+    elif cmd == "list" or cmd is None:
         list_roles(full=args.full)

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -15,7 +15,7 @@ from redi.api.time_entry import (
 def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     time_entry_parser = subparsers.add_parser(
         "time_entry",
-        help="list: 一覧, view: 詳細, create: 登録, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 登録, update(u): 更新, delete(d): 削除",
     )
     time_entry_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     time_entry_parser.add_argument(

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -14,7 +14,8 @@ from redi.api.time_entry import (
 
 def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     time_entry_parser = subparsers.add_parser(
-        "time_entry", help="作業時間一覧/詳細/登録/更新/削除"
+        "time_entry",
+        help="list: 一覧, view: 詳細, create: 登録, update: 更新, delete: 削除",
     )
     time_entry_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     time_entry_parser.add_argument(
@@ -24,6 +25,7 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
         "--full", action="store_true", help="JSON形式で全情報を出力"
     )
     te_subparsers = time_entry_parser.add_subparsers(dest="time_entry_command")
+    te_subparsers.add_parser("list", aliases=["l"], help="作業時間一覧")
     te_create_parser = te_subparsers.add_parser(
         "create", aliases=["c"], help="作業時間登録"
     )
@@ -92,6 +94,6 @@ def handle_time_entry(args: argparse.Namespace) -> None:
                 f"({te['spent_on']})"
             )
         delete_time_entry(args.time_entry_id)
-    else:
+    elif cmd == "list" or cmd is None:
         project_id = args.project_id or default_project_id
         list_time_entries(project_id=project_id, user_id=args.user_id, full=args.full)

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -25,7 +25,7 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     u_parser = subparsers.add_parser(
         "user",
         aliases=["u"],
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, delete(d): 削除",
     )
     u_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     u_subparsers = u_parser.add_subparsers(dest="user_command")

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -23,10 +23,13 @@ MAIL_NOTIFICATION_CHOICES = [
 
 def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     u_parser = subparsers.add_parser(
-        "user", aliases=["u"], help="ユーザー一覧/詳細/作成/更新/削除"
+        "user",
+        aliases=["u"],
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
     )
     u_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     u_subparsers = u_parser.add_subparsers(dest="user_command")
+    u_subparsers.add_parser("list", aliases=["l"], help="ユーザー一覧")
     u_create_parser = u_subparsers.add_parser(
         "create", aliases=["c"], help="ユーザー作成（管理者権限が必要）"
     )
@@ -141,4 +144,5 @@ def handle_user(args: argparse.Namespace) -> None:
             confirm_delete_with_identifier(summary, user.get("login", ""), "ログイン名")
         delete_user(args.user_id)
         return
-    list_users(full=args.full)
+    if cmd == "list" or cmd is None:
+        list_users(full=args.full)

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -27,11 +27,14 @@ from redi.api.version import (
 
 def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
     v_parser = subparsers.add_parser(
-        "version", aliases=["v"], help="バージョン一覧/詳細/作成/更新/削除"
+        "version",
+        aliases=["v"],
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
     )
     v_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     v_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     v_subparsers = v_parser.add_subparsers(dest="version_command")
+    v_subparsers.add_parser("list", aliases=["l"], help="バージョン一覧")
     v_view_parser = v_subparsers.add_parser(
         "view", aliases=["v"], help="バージョン詳細"
     )
@@ -278,7 +281,7 @@ def handle_version(args: argparse.Namespace) -> None:
             description=args.description,
             sharing=args.sharing,
         )
-    else:
+    elif cmd == "list" or cmd is None:
         project_id = args.project_id or default_project_id
         if not project_id:
             print("project_idを指定するか、default_project_idを設定してください")

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -29,7 +29,7 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
     v_parser = subparsers.add_parser(
         "version",
         aliases=["v"],
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, delete(d): 削除",
     )
     v_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     v_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -35,7 +35,7 @@ def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
     w_parser = subparsers.add_parser(
         "wiki",
         aliases=["w"],
-        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
+        help="list(l): 一覧, view(v): 詳細, create(c): 作成, update(u): 更新, delete(d): 削除",
     )
     w_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     w_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -33,11 +33,14 @@ def build_wiki_tree_choices(pages: list[dict]) -> list[tuple[str, str]]:
 
 def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
     w_parser = subparsers.add_parser(
-        "wiki", aliases=["w"], help="Wiki一覧/詳細/作成/更新/削除"
+        "wiki",
+        aliases=["w"],
+        help="list: 一覧, view: 詳細, create: 作成, update: 更新, delete: 削除",
     )
     w_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     w_parser.add_argument("--full", action="store_true", help="JSON形式で全情報を出力")
     w_subparsers = w_parser.add_subparsers(dest="wiki_command")
+    w_subparsers.add_parser("list", aliases=["l"], help="Wikiページ一覧")
     w_view_parser = w_subparsers.add_parser(
         "view", aliases=["v"], help="Wikiページ詳細"
     )
@@ -185,5 +188,5 @@ def handle_wiki(args: argparse.Namespace) -> None:
             update_wiki(project_id, page_title, text)
         else:
             print("テキストが空のためキャンセルしました")
-    else:
+    elif cmd == "list" or cmd is None:
         list_wikis(project_id, full=args.full)


### PR DESCRIPTION
resolve #90 

## Summary
- `SUBCOMMAND_ALIASES` に `l` → `list` を追加
- サブコマンドを持つ各リソース (project/issue/version/wiki/user/group/issue_category/membership/time_entry/role/file) に `list` (alias: `l`) サブコマンドを登録し、引数無し呼び出しと同じ挙動にした
- 各リソースのヘルプ1行説明を `list: 一覧, view: 詳細, ...` 形式に整理

## Test plan
- [x] `task check` が通ること
- [x] `redi project list` / `redi project l` / `redi project` が同じ結果を返すこと
- [x] `redi issue l` などの他リソースでも同様に動作すること
- [x] `redi <resource> --help` で整理後のヘルプが表示されること