### PR TITLE
[feat] TUI wiki タブから create/update を呼び出せるようにする

### DIFF
--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -138,7 +138,7 @@ def main() -> None:
             if tui_result is None:
                 return
             tui_state = TuiState(last_result=tui_result)
-            if tui_result.action == "update":
+            if tui_result.action == "update" and tui_result.tab == "issues":
                 update_args = argparse.Namespace(
                     issue_id=tui_result.issue_id,
                     subject=None,
@@ -163,7 +163,7 @@ def main() -> None:
                     remove_watcher_ids=None,
                 )
                 handle_issue_update(update_args)
-            elif tui_result.action == "create":
+            elif tui_result.action == "create" and tui_result.tab == "issues":
                 create_args = argparse.Namespace(
                     subject=None,
                     project_id=None,
@@ -180,6 +180,27 @@ def main() -> None:
                 notes = open_editor()
                 if notes:
                     add_note(tui_result.issue_id, notes)
+            elif tui_result.action == "create" and tui_result.tab == "wiki":
+                handle_wiki(
+                    argparse.Namespace(
+                        wiki_command="create",
+                        project_id=None,
+                        full=False,
+                        page_title=None,
+                        parent_title=None,
+                        description=None,
+                    )
+                )
+            elif tui_result.action == "update" and tui_result.tab == "wiki":
+                handle_wiki(
+                    argparse.Namespace(
+                        wiki_command="update",
+                        project_id=None,
+                        full=False,
+                        page_title=tui_result.wiki_title,
+                        description=None,
+                    )
+                )
 
     if args.command in ("project", "p"):
         handle_project(args)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -187,7 +187,7 @@ def main() -> None:
                         project_id=None,
                         full=False,
                         page_title=None,
-                        parent_title=None,
+                        parent_title=tui_result.parent_wiki_title,
                         description=None,
                     )
                 )

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -92,20 +92,23 @@ def run_issue_tui(
     if state is None:
         state = TuiState()
     last = state.last_result
+    if last:
+        state.tab = last.tab
     position = last.position if last else TuiPosition()
     state.page_size = max(1, shutil.get_terminal_size().lines - FIXED_ROWS)
-    state.issue_tab.offset = position.offset
+    state.issue_tab.offset = position.offset if state.tab == "issues" else 0
     state.issue_tab.issues = fetch_issues(
         project_id=default_project_id,
         limit=state.page_size,
         offset=state.issue_tab.offset,
     )
-    if not state.issue_tab.issues:
+    if state.tab == "issues" and not state.issue_tab.issues:
         print("イシューが見つかりません")
         return None
-    state.issue_tab.cursor = max(
-        0, min(position.cursor, len(state.issue_tab.issues) - 1)
-    )
+    if state.issue_tab.issues:
+        state.issue_tab.cursor = max(
+            0, min(position.cursor, len(state.issue_tab.issues) - 1)
+        )
     if last and last.action == "comment" and last.issue_id:
         target_id = int(last.issue_id)
         target = next(
@@ -113,6 +116,12 @@ def run_issue_tui(
         )
         if target is not None:
             load_journals(target)
+    if state.tab == "wiki":
+        TABS["wiki"].on_activate(state)
+        if last and last.tab == "wiki" and last.wiki_title:
+            titles = [p.get("title") for p in state.wiki_tab.pages]
+            if last.wiki_title in titles:
+                state.wiki_tab.cursor = titles.index(last.wiki_title)
 
     kb = KeyBindings()
 

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -19,6 +19,7 @@ def _exit_result(
         issue_id = str(state.issue_tab.issues[state.issue_tab.cursor]["id"])
     return TuiResult(
         action=action,
+        tab="issues",
         issue_id=issue_id,
         position=TuiPosition(
             offset=state.issue_tab.offset, cursor=state.issue_tab.cursor

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -21,8 +21,10 @@ class TuiPosition:
 @dataclass
 class TuiResult:
     action: TuiAction
-    issue_id: str | None
-    position: TuiPosition
+    tab: TuiTab
+    issue_id: str | None = None
+    wiki_title: str | None = None
+    position: TuiPosition = field(default_factory=TuiPosition)
 
 
 @dataclass

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -24,6 +24,7 @@ class TuiResult:
     tab: TuiTab
     issue_id: str | None = None
     wiki_title: str | None = None
+    parent_wiki_title: str | None = None
     position: TuiPosition = field(default_factory=TuiPosition)
 
 

--- a/src/redi/tui/tab.py
+++ b/src/redi/tui/tab.py
@@ -24,7 +24,3 @@ class TabView:
 
 def noop(state: TuiState) -> None:
     pass
-
-
-def no_action(state: TuiState, key: str) -> TuiResult | None:
-    return None

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -104,7 +104,10 @@ def _status_hint(state: TuiState) -> str:
 
 
 def _exit_result(
-    state: TuiState, action: TuiAction, wiki_title: str | None = None
+    state: TuiState,
+    action: TuiAction,
+    wiki_title: str | None = None,
+    parent_wiki_title: str | None = None,
 ) -> TuiResult:
     if wiki_title is None and state.wiki_tab.pages:
         wiki_title = state.wiki_tab.pages[state.wiki_tab.cursor].get("title")
@@ -112,6 +115,7 @@ def _exit_result(
         action=action,
         tab="wiki",
         wiki_title=wiki_title,
+        parent_wiki_title=parent_wiki_title,
         position=TuiPosition(cursor=state.wiki_tab.cursor),
     )
 
@@ -137,7 +141,10 @@ def _on_enter(state: TuiState) -> None:
 
 def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
     if key == "c":
-        return _exit_result(state, "create", wiki_title="")
+        parent = None
+        if state.wiki_tab.pages:
+            parent = state.wiki_tab.pages[state.wiki_tab.cursor].get("title")
+        return _exit_result(state, "create", parent_wiki_title=parent)
     if key == "u":
         if not state.wiki_tab.pages:
             return None

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -5,8 +5,14 @@ import requests
 from redi.api.wiki import fetch_wiki, fetch_wikis, flatten_wiki_tree
 from redi.config import default_project_id, redmine_url, wiki_project_id
 from redi.tui.render import render_meta_table
-from redi.tui.state import Renderable, TuiState
-from redi.tui.tab import TabView, no_action, noop
+from redi.tui.state import (
+    Renderable,
+    TuiAction,
+    TuiPosition,
+    TuiResult,
+    TuiState,
+)
+from redi.tui.tab import TabView, noop
 
 
 def _wiki_project() -> str | None:
@@ -94,7 +100,20 @@ def _render_preview(state: TuiState) -> Renderable:
 
 
 def _status_hint(state: TuiState) -> str:
-    return " ↑↓/jk:移動 Enter:本文ロード v:web Tab:タブ切替 q:終了 "
+    return " ↑↓/jk:移動 Enter:本文ロード c:作成 u:更新 v:web Tab:タブ切替 q:終了 "
+
+
+def _exit_result(
+    state: TuiState, action: TuiAction, wiki_title: str | None = None
+) -> TuiResult:
+    if wiki_title is None and state.wiki_tab.pages:
+        wiki_title = state.wiki_tab.pages[state.wiki_tab.cursor].get("title")
+    return TuiResult(
+        action=action,
+        tab="wiki",
+        wiki_title=wiki_title,
+        position=TuiPosition(cursor=state.wiki_tab.cursor),
+    )
 
 
 def _on_up(state: TuiState) -> None:
@@ -114,6 +133,16 @@ def _on_enter(state: TuiState) -> None:
     title = state.wiki_tab.pages[state.wiki_tab.cursor].get("title")
     if title:
         _load_wiki_text(state, title)
+
+
+def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
+    if key == "c":
+        return _exit_result(state, "create", wiki_title="")
+    if key == "u":
+        if not state.wiki_tab.pages:
+            return None
+        return _exit_result(state, "update")
+    return None
 
 
 def _on_open_web(state: TuiState) -> None:
@@ -139,6 +168,6 @@ WIKI_TAB = TabView(
     on_page_backward=noop,
     on_open_web=_on_open_web,
     on_activate=_load_wikis,
-    on_action_key=no_action,
+    on_action_key=_on_action_key,
     get_cursor_y=lambda state: state.wiki_tab.cursor,
 )


### PR DESCRIPTION
## Summary
- closes #93 
- wiki タブで `c` / `u` キーを押すと TUI を抜けて `handle_wiki` の create/update に委譲し、完了後に TUI へ再入場して wiki 一覧を再ロードする
- `TuiResult` にタブ識別 (`tab`) と `wiki_title` / `parent_wiki_title` を持たせ、再入場時に同タイトルへカーソルを復元する
- `c` ではカーソル上のページを `parent_wiki_title` として持ち出し、`handle_wiki` の親選択プロンプトをスキップしてそのまま子ページを作成できる
- issues 一覧が空でも wiki タブから再入場できるようエラー終了条件を active タブ依存に緩和

## Test plan
- [x] `redi --tui` を起動 → Tab で wiki タブへ切替 → `c` で新規ページ作成フローに入れる
- [x] カーソル上のページが親ページとして自動採用され、親選択プロンプトがスキップされる
- [x] wiki タブでページを選択 → `u` で当該ページの update フロー（editor 起動）に入れる
- [x] 作成/更新後に TUI へ戻り、一覧に反映され編集したページへカーソルが戻る
- [x] issue タブ側の既存の `c` / `u` / `n` 動作がリグレッションしていない