### PR TITLE
[feat] time_entry create を対話的に入力できるように対応

### DIFF
--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -87,11 +87,6 @@ def fetch_issue(issue_id: str, include: str = "") -> dict:
     return response.json()["issue"]
 
 
-def issue_exists(issue_id: str) -> bool:
-    response = client.get(f"/issues/{issue_id}.json")
-    return response.status_code == 200
-
-
 def read_issue(
     issue_id: str, include: str = "", full: bool = False, web: bool = False
 ) -> None:

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -87,6 +87,11 @@ def fetch_issue(issue_id: str, include: str = "") -> dict:
     return response.json()["issue"]
 
 
+def issue_exists(issue_id: str) -> bool:
+    response = client.get(f"/issues/{issue_id}.json")
+    return response.status_code == 200
+
+
 def read_issue(
     issue_id: str, include: str = "", full: bool = False, web: bool = False
 ) -> None:

--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -8,13 +8,30 @@ from redi.config import redmine_url
 
 
 def list_projects(full: bool = False) -> None:
-    response = client.get("/projects.json")
-    projects = response.json()["projects"]
+    projects = fetch_projects()
     if full:
         print(json.dumps(projects, ensure_ascii=False))
     else:
         for project in projects:
             print(f"{project['id']} {project['name']}")
+
+
+def fetch_projects() -> list[dict]:
+    response = client.get("/projects.json")
+    response.raise_for_status()
+    data = response.json()
+    return data.get("projects", [])
+
+
+def resolve_project_id(value: str) -> str:
+    if str(value).isdigit():
+        return str(value)
+    projects = fetch_projects()
+    for p in projects:
+        if p.get("identifier") == value or p.get("name") == value:
+            return str(p["id"])
+    print(f"プロジェクトが見つかりません: {value}")
+    exit(1)
 
 
 def fetch_project(project_id: str, include: str = "") -> dict:

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -16,6 +16,11 @@ def create_time_entry(
     if not issue_id and not project_id:
         print("issue_idまたはproject_idを指定してください")
         exit(1)
+    # time_entries は他の API と異なり project_id に slug を受け付けず整数のみ許容
+    # https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
+    if project_id is not None and not str(project_id).isdigit():
+        print(f"project_idは整数値で指定してください（slug不可）: {project_id}")
+        exit(1)
     data: dict = {"hours": hours}
     if issue_id:
         data["issue_id"] = issue_id
@@ -102,6 +107,11 @@ def update_time_entry(
     spent_on: str | None = None,
     comments: str | None = None,
 ) -> None:
+    # time_entries は他の API と異なり project_id に slug を受け付けず整数のみ許容
+    # https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
+    if project_id is not None and not str(project_id).isdigit():
+        print(f"project_idは整数値で指定してください（slug不可）: {project_id}")
+        exit(1)
     data: dict = {}
     if hours is not None:
         data["hours"] = hours

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from redi.api.project import resolve_project_id
 from redi.client import client
 
 
@@ -18,9 +19,8 @@ def create_time_entry(
         exit(1)
     # time_entries は他の API と異なり project_id に slug を受け付けず整数のみ許容
     # https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
-    if project_id is not None and not str(project_id).isdigit():
-        print(f"project_idは整数値で指定してください（slug不可）: {project_id}")
-        exit(1)
+    if project_id is not None:
+        project_id = resolve_project_id(project_id)
     data: dict = {"hours": hours}
     if issue_id:
         data["issue_id"] = issue_id
@@ -109,9 +109,8 @@ def update_time_entry(
 ) -> None:
     # time_entries は他の API と異なり project_id に slug を受け付けず整数のみ許容
     # https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
-    if project_id is not None and not str(project_id).isdigit():
-        print(f"project_idは整数値で指定してください（slug不可）: {project_id}")
-        exit(1)
+    if project_id is not None:
+        project_id = resolve_project_id(project_id)
     data: dict = {}
     if hours is not None:
         data["hours"] = hours

--- a/src/redi/cli/prompt_util.py
+++ b/src/redi/cli/prompt_util.py
@@ -1,0 +1,13 @@
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
+
+
+def digit_only_key_bindings() -> KeyBindings:
+    kb = KeyBindings()
+
+    @kb.add(Keys.Any)
+    def _(event) -> None:
+        if event.data.isdigit():
+            event.current_buffer.insert_text(event.data)
+
+    return kb

--- a/src/redi/cli/prompt_util.py
+++ b/src/redi/cli/prompt_util.py
@@ -11,3 +11,14 @@ def digit_only_key_bindings() -> KeyBindings:
             event.current_buffer.insert_text(event.data)
 
     return kb
+
+
+def digit_and_period_key_bindings() -> KeyBindings:
+    kb = KeyBindings()
+
+    @kb.add(Keys.Any)
+    def _(event) -> None:
+        if event.data.isdigit() or event.data == ".":
+            event.current_buffer.insert_text(event.data)
+
+    return kb

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -74,8 +74,14 @@ def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
             if issue_id:
                 args.issue_id = issue_id
             else:
+                project_id_validator = Validator.from_callable(
+                    lambda v: v.isdigit(),
+                    error_message="整数値を入力してください",
+                )
                 project_id = prompt(
-                    "プロジェクトID: ", default=default_project_id or ""
+                    "プロジェクトID: ",
+                    default=default_project_id or "",
+                    validator=project_id_validator,
                 ).strip()
                 if not project_id:
                     print(

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -1,11 +1,13 @@
 import argparse
 
 from prompt_toolkit import prompt
+from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.validation import Validator
 
 from redi.cli._common import confirm_delete, inline_choice, resolve_alias
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_time_entry_activities
+from redi.api.project import fetch_projects
 from redi.api.time_entry import (
     create_time_entry,
     delete_time_entry,
@@ -74,15 +76,27 @@ def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
             if issue_id:
                 args.issue_id = issue_id
             else:
+                projects = fetch_projects()
+                valid_values: set[str] = set()
+                for p in projects:
+                    valid_values.add(str(p["id"]))
+                    if p.get("identifier"):
+                        valid_values.add(p["identifier"])
+                    if p.get("name"):
+                        valid_values.add(p["name"])
+                project_validator = Validator.from_callable(
+                    lambda v: v in valid_values,
+                    error_message="該当するプロジェクトがありません",
+                )
+                completer = WordCompleter(
+                    sorted(valid_values), ignore_case=True, match_middle=True
+                )
                 project_id = prompt(
                     "プロジェクトID または 名前/identifier: ",
                     default=default_project_id or "",
+                    validator=project_validator,
+                    completer=completer,
                 ).strip()
-                if not project_id:
-                    print(
-                        "イシューIDまたはプロジェクトIDが必要です。キャンセルしました"
-                    )
-                    exit(1)
                 args.project_id = project_id
         hours_validator = Validator.from_callable(
             lambda v: v.replace(".", "", 1).isdigit(),

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -1,7 +1,11 @@
 import argparse
 
-from redi.cli._common import confirm_delete, resolve_alias
+from prompt_toolkit import prompt
+from prompt_toolkit.validation import Validator
+
+from redi.cli._common import confirm_delete, inline_choice, resolve_alias
 from redi.config import default_project_id
+from redi.api.enumeration import fetch_time_entry_activities
 from redi.api.time_entry import (
     create_time_entry,
     delete_time_entry,
@@ -29,7 +33,9 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     te_create_parser = te_subparsers.add_parser(
         "create", aliases=["c"], help="作業時間登録"
     )
-    te_create_parser.add_argument("hours", type=float, help="時間（例: 1.5）")
+    te_create_parser.add_argument(
+        "hours", type=float, nargs="?", help="時間（例: 1.5、省略で対話的に入力）"
+    )
     te_create_parser.add_argument("--issue_id", "-i", help="イシューID")
     te_create_parser.add_argument("--project_id", "-p", help="プロジェクトID")
     te_create_parser.add_argument("--activity_id", "-a", help="作業分類ID")
@@ -61,9 +67,52 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
+    try:
+        if not args.issue_id and not args.project_id:
+            issue_id = prompt("イシューID（省略でプロジェクト指定に切替）: ").strip()
+            if issue_id:
+                args.issue_id = issue_id
+            else:
+                project_id = prompt(
+                    "プロジェクトID: ", default=default_project_id or ""
+                ).strip()
+                if not project_id:
+                    print(
+                        "イシューIDまたはプロジェクトIDが必要です。キャンセルしました"
+                    )
+                    exit(1)
+                args.project_id = project_id
+        hours_validator = Validator.from_callable(
+            lambda v: v.replace(".", "", 1).isdigit(),
+            error_message="数値を入力してください",
+        )
+        hours_str = prompt(
+            "作業時間（例: 1.5 (h)）: ", validator=hours_validator
+        ).strip()
+        args.hours = float(hours_str)
+        if not args.activity_id:
+            activities = fetch_time_entry_activities()
+            activity_options: list[tuple[str, str]] = [
+                (str(a["id"]), a["name"]) for a in activities
+            ]
+            activity_labels = dict(activity_options)
+            args.activity_id = inline_choice("作業分類", activity_options)
+            print(f"作業分類: {activity_labels[args.activity_id]}")
+        if not args.spent_on:
+            args.spent_on = prompt("作業日（YYYY-MM-DD、省略で今日）: ").strip() or None
+        if not args.comments:
+            args.comments = prompt("コメント: ").strip() or None
+    except (KeyboardInterrupt, EOFError):
+        print("キャンセルしました")
+        exit(1)
+
+
 def handle_time_entry(args: argparse.Namespace) -> None:
     cmd = resolve_alias(args.time_entry_command)
     if cmd == "create":
+        if args.hours is None:
+            _interactive_fill_time_entry_create_args(args)
         project_id = args.project_id or default_project_id
         create_time_entry(
             issue_id=args.issue_id,

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -7,6 +7,7 @@ from prompt_toolkit.validation import Validator
 from redi.cli._common import confirm_delete, inline_choice, resolve_alias
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_time_entry_activities
+from redi.api.issue import fetch_issue, issue_exists
 from redi.api.project import fetch_projects
 from redi.api.time_entry import (
     create_time_entry,
@@ -72,9 +73,19 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
 def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
     try:
         if not args.issue_id and not args.project_id:
-            issue_id = prompt("イシューID（省略でプロジェクト指定に切替）: ").strip()
+            issue_validator = Validator.from_callable(
+                lambda v: v == "" or (v.isdigit() and issue_exists(v)),
+                error_message="該当するイシューがありません",
+            )
+            issue_id = prompt(
+                "イシューID（省略でプロジェクト指定に切替）: ",
+                validator=issue_validator,
+                validate_while_typing=False,
+            ).strip()
             if issue_id:
                 args.issue_id = issue_id
+                issue = fetch_issue(issue_id)
+                print(f"イシュー: #{issue['id']} {issue['subject']}")
             else:
                 projects = fetch_projects()
                 valid_values: set[str] = set()

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -74,14 +74,9 @@ def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
             if issue_id:
                 args.issue_id = issue_id
             else:
-                project_id_validator = Validator.from_callable(
-                    lambda v: v.isdigit(),
-                    error_message="整数値を入力してください",
-                )
                 project_id = prompt(
-                    "プロジェクトID: ",
+                    "プロジェクトID または 名前/identifier: ",
                     default=default_project_id or "",
-                    validator=project_id_validator,
                 ).strip()
                 if not project_id:
                     print(

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -5,7 +5,10 @@ from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.validation import Validator
 
 from redi.cli._common import confirm_delete, inline_choice, resolve_alias
-from redi.cli.prompt_util import digit_only_key_bindings
+from redi.cli.prompt_util import (
+    digit_and_period_key_bindings,
+    digit_only_key_bindings,
+)
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_time_entry_activities
 from redi.api.issue import fetch_issue
@@ -110,7 +113,9 @@ def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
             error_message="数値を入力してください",
         )
         hours_str = prompt(
-            "作業時間（例: 1.5 (h)）: ", validator=hours_validator
+            "作業時間（例: 1.5 (h)）: ",
+            validator=hours_validator,
+            key_bindings=digit_and_period_key_bindings(),
         ).strip()
         args.hours = float(hours_str)
         if not args.activity_id:

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -2,11 +2,10 @@ import argparse
 
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
-from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.keys import Keys
 from prompt_toolkit.validation import Validator
 
 from redi.cli._common import confirm_delete, inline_choice, resolve_alias
+from redi.cli.prompt_util import digit_only_key_bindings
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_time_entry_activities
 from redi.api.issue import fetch_issue
@@ -72,23 +71,12 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
-def _digit_only_key_bindings() -> KeyBindings:
-    kb = KeyBindings()
-
-    @kb.add(Keys.Any)
-    def _(event) -> None:
-        if event.data.isdigit():
-            event.current_buffer.insert_text(event.data)
-
-    return kb
-
-
 def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
     try:
         if not args.issue_id and not args.project_id:
             issue_id = prompt(
                 "イシューID（省略でプロジェクト指定に切替）: ",
-                key_bindings=_digit_only_key_bindings(),
+                key_bindings=digit_only_key_bindings(),
             ).strip()
             if issue_id:
                 args.issue_id = issue_id

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -2,12 +2,14 @@ import argparse
 
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.keys import Keys
 from prompt_toolkit.validation import Validator
 
 from redi.cli._common import confirm_delete, inline_choice, resolve_alias
 from redi.config import default_project_id
 from redi.api.enumeration import fetch_time_entry_activities
-from redi.api.issue import fetch_issue, issue_exists
+from redi.api.issue import fetch_issue
 from redi.api.project import fetch_projects
 from redi.api.time_entry import (
     create_time_entry,
@@ -70,17 +72,23 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+def _digit_only_key_bindings() -> KeyBindings:
+    kb = KeyBindings()
+
+    @kb.add(Keys.Any)
+    def _(event) -> None:
+        if event.data.isdigit():
+            event.current_buffer.insert_text(event.data)
+
+    return kb
+
+
 def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
     try:
         if not args.issue_id and not args.project_id:
-            issue_validator = Validator.from_callable(
-                lambda v: v == "" or (v.isdigit() and issue_exists(v)),
-                error_message="該当するイシューがありません",
-            )
             issue_id = prompt(
                 "イシューID（省略でプロジェクト指定に切替）: ",
-                validator=issue_validator,
-                validate_while_typing=False,
+                key_bindings=_digit_only_key_bindings(),
             ).strip()
             if issue_id:
                 args.issue_id = issue_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,4 +5,9 @@ def pytest_itemcollected(item):
         parent_doc = ""
         if item.parent and hasattr(item.parent, "obj") and item.parent.obj.__doc__:
             parent_doc = item.parent.obj.__doc__ + " > "
-        item._nodeid = f"{item.path.name}::{parent_doc}{doc}"
+        # parametrize されたテストにのみ callspec が存在し、id にパラメータ値が入る
+        suffix = ""
+        callspec = getattr(item, "callspec", None)
+        if callspec is not None:
+            suffix = f" [{callspec.id}]"
+        item._nodeid = f"{item.path.name}::{parent_doc}{doc}{suffix}"

--- a/tests/unit/test_prompt_util.py
+++ b/tests/unit/test_prompt_util.py
@@ -9,8 +9,10 @@ from redi.cli.prompt_util import (
 )
 
 
+# prompt_toolkit.key_binding.key_processor.KeyPressEvent の duck-type。
+# handler が参照する data と current_buffer のみを持つ最小実装。
 @dataclass
-class _FakeEvent:
+class _FakeKeyPressEvent:
     data: str
     current_buffer: Buffer
 
@@ -19,7 +21,7 @@ def _invoke(kb, data: str, initial: str = "") -> str:
     buffer = Buffer()
     if initial:
         buffer.insert_text(initial)
-    kb.bindings[0].handler(_FakeEvent(data=data, current_buffer=buffer))
+    kb.bindings[0].handler(_FakeKeyPressEvent(data=data, current_buffer=buffer))
     return buffer.text
 
 

--- a/tests/unit/test_prompt_util.py
+++ b/tests/unit/test_prompt_util.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+
+import pytest
+from prompt_toolkit.buffer import Buffer
+
+from redi.cli.prompt_util import (
+    digit_and_period_key_bindings,
+    digit_only_key_bindings,
+)
+
+
+@dataclass
+class _FakeEvent:
+    data: str
+    current_buffer: Buffer
+
+
+def _invoke(kb, data: str, initial: str = "") -> str:
+    buffer = Buffer()
+    if initial:
+        buffer.insert_text(initial)
+    kb.bindings[0].handler(_FakeEvent(data=data, current_buffer=buffer))
+    return buffer.text
+
+
+class TestDigitAndPeriodKeyBindings:
+    """digit_and_period_key_bindings()は数字とperiodのみを入力可能にする"""
+
+    @pytest.mark.parametrize("ch", list("0123456789"))
+    def test_digits_are_inserted(self, ch: str):
+        """数字はすべてバッファに挿入される"""
+        assert _invoke(digit_and_period_key_bindings(), ch) == ch
+
+    def test_period_is_inserted(self):
+        """periodはバッファに挿入される"""
+        assert _invoke(digit_and_period_key_bindings(), ".") == "."
+
+    @pytest.mark.parametrize("ch", ["a", "Z", "-", "+", " ", ",", "/", "*"])
+    def test_non_digit_non_period_are_rejected(self, ch: str):
+        """数字とperiod以外はバッファに挿入されない"""
+        assert _invoke(digit_and_period_key_bindings(), ch) == ""
+
+    def test_appends_to_existing_text(self):
+        """既存のバッファ内容の末尾に追加される"""
+        assert _invoke(digit_and_period_key_bindings(), "5", initial="1.") == "1.5"
+
+    def test_rejected_input_preserves_existing_text(self):
+        """拒否された入力は既存バッファを変更しない"""
+        assert _invoke(digit_and_period_key_bindings(), "a", initial="12") == "12"
+
+
+class TestDigitOnlyKeyBindings:
+    """digit_only_key_bindings()は数字のみを入力可能にする"""
+
+    @pytest.mark.parametrize("ch", list("0123456789"))
+    def test_digits_are_inserted(self, ch: str):
+        """数字はすべてバッファに挿入される"""
+        assert _invoke(digit_only_key_bindings(), ch) == ch
+
+    def test_period_is_rejected(self):
+        """periodはバッファに挿入されない"""
+        assert _invoke(digit_only_key_bindings(), ".") == ""
+
+    @pytest.mark.parametrize("ch", ["a", "Z", "-", "+", " ", ",", "/", "*"])
+    def test_non_digit_are_rejected(self, ch: str):
+        """数字以外はバッファに挿入されない"""
+        assert _invoke(digit_only_key_bindings(), ch) == ""
+
+    def test_appends_to_existing_text(self):
+        """既存のバッファ内容の末尾に追加される"""
+        assert _invoke(digit_only_key_bindings(), "3", initial="12") == "123"
+
+    def test_rejected_input_preserves_existing_text(self):
+        """拒否された入力は既存バッファを変更しない"""
+        assert _invoke(digit_only_key_bindings(), ".", initial="12") == "12"


### PR DESCRIPTION
## Summary
- `redi time_entry create` で hours を省略すると対話入力フロー (issue_id/project_id, hours, activity, spent_on, comments) に入るように
- 入力制御:
  - issue_id: `KeyBindings` で数字以外の入力を抑止。submit 後に `fetch_issue` で存在確認 + 題名を表示
  - hours: `KeyBindings` で数字と period のみに限定 + `Validator` で float として妥当かチェック
  - project_id: プロンプト直前に `GET /projects` を取得し id/identifier/name の membership で検証、`WordCompleter` で補完
- `POST/PUT /time_entries` が project_id に slug を受け付けない仕様に合わせ、API 層で `resolve_project_id` を呼んで名前/identifier → 整数 ID に解決してから送信
- `src/redi/cli/prompt_util.py` に `digit_only_key_bindings` / `digit_and_period_key_bindings` を切り出し、ユニットテスト (`tests/unit/test_prompt_util.py`) を追加
- `tests/conftest.py` の表示名フックを parametrize 対応 (末尾に `[id]` を付与)

## Test plan
- [x] `redi time_entry create` で対話フローが起動し、各項目が入力できる
- [x] issue_id プロンプトで非数字キーが入力できず、存在しない ID で「イシューが見つかりません」と出る
- [x] hours プロンプトで数字と `.` 以外のキーが入力できない
- [x] project_id に名前/identifier を入力しても登録が成功する
- [x] `redi time_entry create 1.5 -i <id>` など既存の非対話呼び出しが従来通り動作する
- [x] `task check` が通る