### PR TITLE
#103 TUI 作業時間タブに D キー削除を追加

### DIFF
--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -91,6 +91,8 @@ def _render_preview_current(state: TuiState) -> Renderable:
 def _render_status(state: TuiState) -> Renderable:
     if state.confirm_delete_prompt is not None:
         return [("reverse", f" {state.confirm_delete_prompt} ")]
+    if state.flash_message is not None:
+        return [("bold fg:ansiyellow", f" {state.flash_message} ")]
     if state.search_mode:
         return [("reverse", f" /{state.search_query}")]
     hint = TABS[state.tab].status_hint(state)
@@ -151,6 +153,7 @@ def run_issue_tui(
 
     def _clear_number_buffer() -> None:
         state.number_buffer = ""
+        state.flash_message = None
 
     @kb.add("tab", filter=normal_mode)
     def _(event):

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -151,13 +151,13 @@ def run_issue_tui(
     search_mode = Condition(lambda: state.search_mode)
     confirm_delete_mode = Condition(lambda: state.confirm_delete_prompt is not None)
 
-    def _clear_number_buffer() -> None:
+    def _clear_temporary_state() -> None:
         state.number_buffer = ""
         state.flash_message = None
 
     @kb.add("tab", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         tab_keys = list(TABS.keys())
         idx = tab_keys.index(state.tab)
         state.tab = tab_keys[(idx + 1) % len(tab_keys)]
@@ -165,7 +165,7 @@ def run_issue_tui(
 
     @kb.add("s-tab", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         tab_keys = list(TABS.keys())
         idx = tab_keys.index(state.tab)
         state.tab = tab_keys[(idx - 1) % len(tab_keys)]
@@ -175,19 +175,19 @@ def run_issue_tui(
     @kb.add("k", filter=normal_mode)
     @kb.add("c-p", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         TABS[state.tab].on_up(state)
 
     @kb.add("down", filter=normal_mode)
     @kb.add("j", filter=normal_mode)
     @kb.add("c-n", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         TABS[state.tab].on_down(state)
 
     @kb.add("g", "g", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         TABS[state.tab].on_goto_top(state)
 
     @kb.add("G", filter=normal_mode)
@@ -197,7 +197,7 @@ def run_issue_tui(
                 target_id = int(state.number_buffer)
             except ValueError:
                 target_id = None
-            _clear_number_buffer()
+            _clear_temporary_state()
             if target_id is not None:
                 TABS[state.tab].on_jump_to_id(state, target_id)
         else:
@@ -215,23 +215,23 @@ def run_issue_tui(
     @kb.add("right", filter=normal_mode)
     @kb.add("l", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         TABS[state.tab].on_page_forward(state)
 
     @kb.add("left", filter=normal_mode)
     @kb.add("h", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         TABS[state.tab].on_page_backward(state)
 
     @kb.add("enter", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         TABS[state.tab].on_enter(state)
 
     @kb.add("v", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         TABS[state.tab].on_open_web(state)
 
     @kb.add("V", filter=normal_mode)
@@ -241,7 +241,7 @@ def run_issue_tui(
                 target_id = int(state.number_buffer)
             except ValueError:
                 target_id = None
-            _clear_number_buffer()
+            _clear_temporary_state()
             if target_id is not None:
                 TABS[state.tab].on_open_web_by_id(state, target_id)
 
@@ -249,14 +249,14 @@ def run_issue_tui(
 
         @kb.add(action_key, filter=normal_mode)
         def _(event, action_key=action_key):
-            _clear_number_buffer()
+            _clear_temporary_state()
             result = TABS[state.tab].on_action_key(state, action_key)
             if result is not None:
                 event.app.exit(result=result)
 
     @kb.add("n", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         if state.search_query:
             TABS[state.tab].on_search(state, state.search_query, forward=True)
             return
@@ -266,19 +266,19 @@ def run_issue_tui(
 
     @kb.add("N", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         if state.search_query:
             TABS[state.tab].on_search(state, state.search_query, forward=False)
 
     @kb.add("/", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         state.search_mode = True
         state.search_query = ""
 
     @kb.add("D", filter=normal_mode)
     def _(event):
-        _clear_number_buffer()
+        _clear_temporary_state()
         if state.tab != "time_entries":
             return
         prompt = time_entry_request_delete(state)

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -22,7 +22,11 @@ from redi.tui.state import (
     TuiTab,
 )
 from redi.tui.tab import TabView
-from redi.tui.time_entry_tab import TIME_ENTRY_TAB
+from redi.tui.time_entry_tab import (
+    TIME_ENTRY_TAB,
+    confirm_delete as time_entry_confirm_delete,
+    request_delete as time_entry_request_delete,
+)
 from redi.tui.wiki_tab import WIKI_TAB
 
 TABS: dict[TuiTab, TabView] = {
@@ -85,6 +89,8 @@ def _render_preview_current(state: TuiState) -> Renderable:
 
 
 def _render_status(state: TuiState) -> Renderable:
+    if state.confirm_delete_prompt is not None:
+        return [("reverse", f" {state.confirm_delete_prompt} ")]
     if state.search_mode:
         return [("reverse", f" /{state.search_query}")]
     hint = TABS[state.tab].status_hint(state)
@@ -137,8 +143,11 @@ def run_issue_tui(
             state.time_entry_tab.cursor = min(last.position.cursor, max_cursor)
 
     kb = KeyBindings()
-    normal_mode = Condition(lambda: not state.search_mode)
+    normal_mode = Condition(
+        lambda: not state.search_mode and state.confirm_delete_prompt is None
+    )
     search_mode = Condition(lambda: state.search_mode)
+    confirm_delete_mode = Condition(lambda: state.confirm_delete_prompt is not None)
 
     def _clear_number_buffer() -> None:
         state.number_buffer = ""
@@ -263,6 +272,26 @@ def run_issue_tui(
         _clear_number_buffer()
         state.search_mode = True
         state.search_query = ""
+
+    @kb.add("D", filter=normal_mode)
+    def _(event):
+        _clear_number_buffer()
+        if state.tab != "time_entries":
+            return
+        prompt = time_entry_request_delete(state)
+        if prompt is not None:
+            state.confirm_delete_prompt = prompt
+
+    @kb.add("y", filter=confirm_delete_mode)
+    @kb.add("Y", filter=confirm_delete_mode)
+    def _(event):
+        state.confirm_delete_prompt = None
+        if state.tab == "time_entries":
+            time_entry_confirm_delete(state)
+
+    @kb.add("<any>", filter=confirm_delete_mode)
+    def _(event):
+        state.confirm_delete_prompt = None
 
     @kb.add("q", filter=normal_mode)
     @kb.add("escape", filter=normal_mode)

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -68,3 +68,5 @@ class TuiState:
     # / で検索中かどうか、および現在のクエリ (確定後も保持して n/N とハイライトに使う)。
     search_mode: bool = False
     search_query: str = ""
+    # D で削除確認中のとき、ステータスバーに出すプロンプト文字列
+    confirm_delete_prompt: str | None = None

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -70,3 +70,5 @@ class TuiState:
     search_query: str = ""
     # D で削除確認中のとき、ステータスバーに出すプロンプト文字列
     confirm_delete_prompt: str | None = None
+    # 直前のアクション結果をステータスバーに出す一時メッセージ。次のキー入力で消える。
+    flash_message: str | None = None

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -193,7 +193,7 @@ def confirm_delete(state: TuiState) -> None:
         response = client.delete(f"/time_entries/{te['id']}.json")
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        state.time_entry_tab.error = f"作業時間の削除に失敗しました: {e}"
+        state.flash_message = f"作業時間の削除に失敗しました: {e}"
         return
     entries.pop(cursor)
     if cursor >= len(entries):

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -102,7 +102,7 @@ def _render_preview(state: TuiState) -> Renderable:
 def _status_hint(state: TuiState) -> str:
     return (
         " ↑↓/jk:移動 gg/G:先頭末尾 /:検索 n/N:次前 "
-        "c:作成 u:更新 v:web Tab:タブ切替 q:終了 "
+        "c:作成 u:更新 D:削除 v:web Tab:タブ切替 q:終了 "
     )
 
 
@@ -168,6 +168,36 @@ def _on_search(state: TuiState, query: str, forward: bool = True) -> None:
         if query_lower in targets[idx]:
             state.time_entry_tab.cursor = idx
             return
+
+
+def request_delete(state: TuiState) -> str | None:
+    """カーソル行の削除確認プロンプトを返す。対象がなければ None。"""
+    entries = state.time_entry_tab.entries
+    if not entries:
+        return None
+    te = entries[state.time_entry_tab.cursor]
+    summary = format_time_entry_line(
+        te, issue_subjects=state.time_entry_tab.issue_subjects
+    )
+    return f"削除しますか? {summary} [y/N]"
+
+
+def confirm_delete(state: TuiState) -> None:
+    """カーソル行の time_entry を削除する。失敗時は error を設定する。"""
+    entries = state.time_entry_tab.entries
+    if not entries:
+        return
+    cursor = state.time_entry_tab.cursor
+    te = entries[cursor]
+    try:
+        response = client.delete(f"/time_entries/{te['id']}.json")
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        state.time_entry_tab.error = f"作業時間の削除に失敗しました: {e}"
+        return
+    entries.pop(cursor)
+    if cursor >= len(entries):
+        state.time_entry_tab.cursor = max(0, len(entries) - 1)
 
 
 def _on_open_web(state: TuiState) -> None:


### PR DESCRIPTION
## Summary
- 作業時間タブでカーソル行に対して `D` キーで削除を実行できるようにした (issue #103 )
- ステータスバーに `[y/N]` 確認プロンプトを表示し、`y` で削除実行・他キーでキャンセル
- 確認モード中は通常キーバインドを抑止して誤操作を防止

## Test plan
- [x] `task check` (format / lint / typecheck / pytest) が通る
- [x] TUI で作業時間タブを開き、`D` → `y` で対象 entry が一覧から消える
- [x] `D` → `n` 等で確認プロンプトがキャンセルされ何も削除されない
- [x] 末尾エントリ削除時にカーソルが残り件数内に収まる
- [x] API エラー時に「削除に失敗しました」がステータス/エラー表示される

Closes #103