### PR TITLE
redi init コマンドの作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ uv tool install -e .
 
 To use redi, you need to set remdine url and redmine_api_key in one of below ways.
 
-#### environment variable
+#### redi init (interactive, recommended for first time)
 
 ```sh
-export REDMINE_URL=https://redmine.example.com
-export REDMINE_API_KEY=<your_api_key>
+redi init
 ```
 
-#### ~/.config/redi/config.toml
+Then, profile will be created in `~/.config/redi/config.toml` like below format.
+You can also create profile by `redi config create`, and update profile by `redi config update` (and also by manual edit).
 
 ```toml
-default_profile = "main"
+default_profile = "default"
 
-["main"]
+["default"]
 redmine_url = "https://redmine.example.com"
-redmine_api_key = "<your_api_key"
+redmine_api_key = "<your_api_key>"
 default_project_id = "1"
 wiki_project_id = "2"
 editor = "nvim"
@@ -52,6 +52,14 @@ wiki_project_id = "3"
 editor = "code"
 ```
 
+#### environment variable
+
+```sh
+export REDMINE_URL=https://redmine.example.com
+export REDMINE_API_KEY=<your_api_key>
+```
+
+
 ### setup completion
 
 ```sh
@@ -62,6 +70,9 @@ echo 'eval "$(register-python-argcomplete redi)"' >> ~/.zshrc
 ## usage(example)
 
 ```sh
+# init
+redi init (interactive)
+
 # config (alias: c)
 redi config
 redi config create <profile_name> --url <url> --api_key <key> # create new profile

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -6,6 +6,7 @@ from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
 
 from redi.cli._common import inline_choice
+from redi.cli.prompt_util import UrlValidator
 from redi.config import CONFIG_PATH, create_profile
 
 PROFILE_NAME = "default"
@@ -81,7 +82,7 @@ def handle_init(_args: argparse.Namespace) -> None:
         error_message="入力してください",
     )
     try:
-        url = prompt("Redmine URL: ", validator=non_empty_validator).strip()
+        url = prompt("Redmine URL: ", validator=UrlValidator()).strip()
         print(f"APIキーは {url.rstrip('/')}/my/account で確認できます")
         api_key = prompt(
             "Redmine APIキー: ",

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -40,6 +40,7 @@ def _fetch_projects(url: str, api_key: str) -> list[dict]:
             f"{url}/projects.json",
             headers={"X-Redmine-API-Key": api_key},
             params={"limit": 100},
+            timeout=10,
         )
         response.raise_for_status()
         return response.json().get("projects", [])

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -1,0 +1,127 @@
+import argparse
+
+import requests
+import tomlkit
+from prompt_toolkit import prompt
+from prompt_toolkit.validation import Validator
+from tomlkit.items import Table
+
+from redi.cli._common import inline_choice
+from redi.config import CONFIG_PATH, create_profile
+
+
+def add_init_parser(subparsers: argparse._SubParsersAction) -> None:
+    subparsers.add_parser(
+        "init",
+        help="初回セットアップ（URL/APIキーの疎通確認後にプロファイルを作成）",
+    )
+
+
+def _verify_connection(url: str, api_key: str) -> dict | None:
+    try:
+        response = requests.get(
+            f"{url}/my/account.json",
+            headers={"X-Redmine-API-Key": api_key},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json().get("user")
+    except requests.exceptions.HTTPError as e:
+        print(f"接続失敗: {e.response.status_code} {e.response.reason}")
+    except requests.exceptions.RequestException as e:
+        print(f"接続失敗: {e}")
+    return None
+
+
+def _fetch_projects(url: str, api_key: str) -> list[dict]:
+    try:
+        response = requests.get(
+            f"{url}/projects.json",
+            headers={"X-Redmine-API-Key": api_key},
+            params={"limit": 100},
+        )
+        response.raise_for_status()
+        return response.json().get("projects", [])
+    except requests.exceptions.RequestException as e:
+        print(f"プロジェクト一覧の取得に失敗しました: {e}")
+        return []
+
+
+def _select_project_id(message: str, projects: list[dict]) -> str:
+    options: list[tuple[str, str]] = [
+        (str(p["id"]), f"{p['id']} {p['name']}") for p in projects
+    ]
+    try:
+        return inline_choice(message, options)
+    except KeyboardInterrupt:
+        print("キャンセルしました")
+        exit(1)
+
+
+PROFILE_NAME = "default"
+
+
+def _has_existing_profile() -> bool:
+    if not CONFIG_PATH.exists():
+        return False
+    with open(CONFIG_PATH) as f:
+        doc = tomlkit.load(f)
+    return any(isinstance(v, Table) for v in doc.values())
+
+
+def handle_init(_args: argparse.Namespace) -> None:
+    if _has_existing_profile():
+        print(
+            f"既にプロファイルが存在します ({CONFIG_PATH})。"
+            "追加するプロファイルは `redi config create` で作成してください"
+        )
+        exit(1)
+
+    non_empty_validator = Validator.from_callable(
+        lambda text: len(text.strip()) > 0,
+        error_message="入力してください",
+    )
+    try:
+        url = prompt("Redmine URL: ", validator=non_empty_validator).strip()
+        api_key = prompt(
+            "Redmine APIキー: ",
+            validator=non_empty_validator,
+            is_password=True,
+        ).strip()
+    except (KeyboardInterrupt, EOFError):
+        print("キャンセルしました")
+        exit(1)
+
+    print("接続を確認しています...")
+    user = _verify_connection(url, api_key)
+    if user is None:
+        exit(1)
+    name = " ".join(filter(None, [user.get("firstname"), user.get("lastname")]))
+    print(f"接続成功: {user.get('login', '')} ({name})")
+
+    projects = _fetch_projects(url, api_key)
+    default_project_id: str | None = None
+    wiki_project_id: str | None = None
+    if projects:
+        projects_by_id = {str(p["id"]): p for p in projects}
+        default_project_id = _select_project_id(
+            "普段使用しているプロジェクトを選択してください", projects
+        )
+        print(f"デフォルトプロジェクト: {projects_by_id[default_project_id]['name']}")
+        wiki_project_id = _select_project_id(
+            "普段閲覧しているwikiのあるプロジェクトを選択してください", projects
+        )
+        print(f"wikiプロジェクト: {projects_by_id[wiki_project_id]['name']}")
+    else:
+        print("プロジェクトが存在しないため project_id の設定をスキップします")
+
+    result = create_profile(
+        profile_name=PROFILE_NAME,
+        redmine_url=url,
+        redmine_api_key=api_key,
+        default_project_id=default_project_id,
+        wiki_project_id=wiki_project_id,
+    )
+    if not result.created:
+        exit(1)
+    print(f"{CONFIG_PATH}に設定が作成されました")

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -1,13 +1,14 @@
 import argparse
+import tomllib
 
 import requests
-import tomlkit
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
-from tomlkit.items import Table
 
 from redi.cli._common import inline_choice
 from redi.config import CONFIG_PATH, create_profile
+
+PROFILE_NAME = "default"
 
 
 def add_init_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -53,20 +54,17 @@ def _select_project_id(message: str, projects: list[dict]) -> str:
     ]
     try:
         return inline_choice(message, options)
-    except KeyboardInterrupt:
+    except (KeyboardInterrupt, EOFError):
         print("キャンセルしました")
         exit(1)
-
-
-PROFILE_NAME = "default"
 
 
 def _has_existing_profile() -> bool:
     if not CONFIG_PATH.exists():
         return False
-    with open(CONFIG_PATH) as f:
-        doc = tomlkit.load(f)
-    return any(isinstance(v, Table) for v in doc.values())
+    with open(CONFIG_PATH, "rb") as f:
+        doc = tomllib.load(f)
+    return any(isinstance(v, dict) for v in doc.values())
 
 
 def handle_init(_args: argparse.Namespace) -> None:

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -97,7 +97,7 @@ def handle_init(_args: argparse.Namespace) -> None:
     if user is None:
         exit(1)
     name = " ".join(filter(None, [user.get("firstname"), user.get("lastname")]))
-    print(f"接続成功: {user.get('login', '')} ({name})")
+    print(f"\033[32m✓\033[0m 接続成功: {user.get('login', '')} ({name})")
 
     projects = _fetch_projects(url, api_key)
     default_project_id: str | None = None
@@ -124,4 +124,4 @@ def handle_init(_args: argparse.Namespace) -> None:
     )
     if not result.created:
         exit(1)
-    print(f"{CONFIG_PATH}に設定が作成されました")
+    print(f"\033[32m✓\033[0m {CONFIG_PATH}に設定が作成されました")

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -83,6 +83,7 @@ def handle_init(_args: argparse.Namespace) -> None:
     )
     try:
         url = prompt("Redmine URL: ", validator=non_empty_validator).strip()
+        print(f"APIキーは {url.rstrip('/')}/my/account で確認できます")
         api_key = prompt(
             "Redmine APIキー: ",
             validator=non_empty_validator,

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -20,6 +20,7 @@ from redi.cli.enumerations_command import (
 )
 from redi.cli._common import open_editor
 from redi.cli.group_command import add_group_parser, handle_group
+from redi.cli.init_command import add_init_parser, handle_init
 from redi.cli.issue_category_command import (
     add_issue_category_parser,
     handle_issue_category,
@@ -79,6 +80,7 @@ def _build_parser() -> tuple[
     add_version_parser(subparsers)
     add_wiki_parser(subparsers)
     add_config_parser(subparsers)
+    add_init_parser(subparsers)
     add_user_parser(subparsers)
     add_me_parser(subparsers)
     add_membership_parser(subparsers)
@@ -122,6 +124,10 @@ def main() -> None:
 
     if args.command in ("config", "c"):
         handle_config(args)
+        return
+
+    if args.command == "init":
+        handle_init(args)
         return
 
     check_config()

--- a/src/redi/cli/prompt_util.py
+++ b/src/redi/cli/prompt_util.py
@@ -1,5 +1,29 @@
+from prompt_toolkit.document import Document
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.keys import Keys
+from prompt_toolkit.validation import ValidationError, Validator
+
+_URL_PREFIXES = ("http://", "https://")
+
+
+class UrlValidator(Validator):
+    """http:// または https:// で始まるURLを許容するValidator。
+
+    入力途中でも `_URL_PREFIXES` のいずれかのプレフィックスとマッチしている間は
+    エラーを出さず、明らかに外れた入力でのみエラーを出す。
+    """
+
+    def validate(self, document: Document) -> None:
+        text = document.text.strip()
+        if not text:
+            raise ValidationError(message="入力してください")
+        if text.startswith(_URL_PREFIXES):
+            return
+        if any(p.startswith(text) for p in _URL_PREFIXES):
+            return
+        raise ValidationError(
+            message="http:// または https:// で始まるURLを入力してください"
+        )
 
 
 def digit_only_key_bindings() -> KeyBindings:

--- a/tests/unit/test_prompt_util.py
+++ b/tests/unit/test_prompt_util.py
@@ -2,8 +2,11 @@ from dataclasses import dataclass
 
 import pytest
 from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.document import Document
+from prompt_toolkit.validation import ValidationError
 
 from redi.cli.prompt_util import (
+    UrlValidator,
     digit_and_period_key_bindings,
     digit_only_key_bindings,
 )
@@ -75,3 +78,60 @@ class TestDigitOnlyKeyBindings:
     def test_rejected_input_preserves_existing_text(self):
         """拒否された入力は既存バッファを変更しない"""
         assert _invoke(digit_only_key_bindings(), ".", initial="12") == "12"
+
+
+class TestUrlValidator:
+    """UrlValidator()はhttp(s)://で始まるURLを検証する"""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "http://example.com",
+            "https://example.com",
+            "https://example.com:3000/redmine",
+            "http://localhost:3000",
+        ],
+    )
+    def test_complete_url_passes(self, text: str):
+        """http(s)://で始まる完成形URLはエラーにならない"""
+        UrlValidator().validate(Document(text=text))
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "h",
+            "ht",
+            "htt",
+            "http",
+            "http:",
+            "http:/",
+            "https",
+            "https:",
+            "https:/",
+        ],
+    )
+    def test_prefix_in_progress_passes(self, text: str):
+        """プレフィックス入力途中はエラーにならない"""
+        UrlValidator().validate(Document(text=text))
+
+    def test_surrounding_whitespace_is_stripped(self):
+        """前後の空白は無視して評価される"""
+        UrlValidator().validate(Document(text="  http://example.com  "))
+
+    @pytest.mark.parametrize("text", ["", " "])
+    def test_empty_or_whitespace_raises_required(self, text: str):
+        """空文字や空白のみは『入力してください』でエラーになる"""
+        with pytest.raises(ValidationError, match="入力してください"):
+            UrlValidator().validate(Document(text=text))
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "http:/example.com",
+            "http//example.com",
+        ],
+    )
+    def test_invalid_prefix_raises(self, text: str):
+        """プレフィックスがhttp(s)://以外ならURLメッセージでエラーになる"""
+        with pytest.raises(ValidationError, match="http://"):
+            UrlValidator().validate(Document(text=text))


### PR DESCRIPTION
TUI使用で最低限の設定を行うコマンドを追加

- url
- api_key
- default_project_id
- wiki_project_id

```
$ redi init
Redmine URL: http://localhost:3000
APIキーは http://localhost:3000/my/account で確認できます
Redmine APIキー: ****************************************
接続を確認しています...
✓ 接続成功: admin (Redmine Admin)
デフォルトプロジェクト: reditestプロジェクト
wikiプロジェクト: reditestプロジェクト
✓ /home/kawagh/.config/redi/config.tomlに設定が作成されました
```
