### PR TITLE
イシュー更新の対話モードで担当者を選べるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ redi issue update <issue_id> # (interactive)
 redi issue update <issue_id> --status_id <status_id> -n "notes"
 redi issue update <issue_id> --start_date 2026-04-26 --due_date 2026-05-31 --estimated_hours 1.5
 redi issue update <issue_id> --done_ratio 70
+redi issue update <issue_id> --assigned_to_id <user_id>
+redi issue update <issue_id> --assigned_to_id "" # unset assignee
 redi issue update <issue_id> --relate relates --to <other_issue_id>
 redi issue update <issue_id> --attach ./foo.png --attach ./bar.log
 redi issue comment <issue_id> "hello~"

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -281,7 +281,7 @@ def update_issue(
         issue_data["status_id"] = status_id
     if priority_id:
         issue_data["priority_id"] = priority_id
-    if assigned_to_id:
+    if assigned_to_id is not None:
         issue_data["assigned_to_id"] = assigned_to_id
     if fixed_version_id:
         issue_data["fixed_version_id"] = fixed_version_id

--- a/src/redi/api/membership.py
+++ b/src/redi/api/membership.py
@@ -16,6 +16,14 @@ def list_memberships(project_id: str, full: bool = False) -> None:
         print(_format_membership_line(m))
 
 
+def fetch_project_users(project_id: str) -> list[dict]:
+    """プロジェクトのメンバー（user）を返す。"""
+    response = client.get(f"/projects/{project_id}/memberships.json")
+    response.raise_for_status()
+    memberships = response.json()["memberships"]
+    return [m["user"] for m in memberships if m.get("user")]
+
+
 def fetch_membership(membership_id: str) -> dict:
     response = client.get(f"/memberships/{membership_id}.json")
     if response.status_code == 404:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -29,6 +29,7 @@ from redi.api.issue import (
 )
 from redi.api.issue_relation import create_relation, delete_relation
 from redi.api.issue_status import fetch_issue_statuses
+from redi.api.membership import fetch_project_users
 from redi.api.time_entry import create_time_entry
 from redi.api.tracker import fetch_trackers
 from redi.api.version import fetch_versions
@@ -219,6 +220,7 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         ("description", "説明 (description)"),
         ("status", "ステータス (status)"),
         ("priority", "優先度 (priority)"),
+        ("assigned_to", "担当者 (assigned_to)"),
         ("fixed_version", "対象バージョン (fixed_version)"),
         ("start_date", "開始日 (start_date)"),
         ("due_date", "期日 (due_date)"),
@@ -272,6 +274,24 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
             priority_labels = dict(priority_options)
             args.priority_id = inline_choice("優先度", priority_options)
             print(f"優先度: {priority_labels[args.priority_id]}")
+        if "assigned_to" in selected:
+            project_id = (current.get("project") or {}).get("id")
+            if not project_id:
+                print("プロジェクトが特定できないためキャンセルしました")
+                exit(1)
+            users = fetch_project_users(str(project_id))
+            assignee_options: list[tuple[str, str]] = [("", "（担当者なし）")] + [
+                (str(u["id"]), u["name"]) for u in users
+            ]
+            assignee_labels = dict(assignee_options)
+            current_assignee_id = (current.get("assigned_to") or {}).get("id")
+            default_assignee = (
+                str(current_assignee_id) if current_assignee_id is not None else ""
+            )
+            args.assigned_to_id = inline_choice(
+                "担当者", assignee_options, default=default_assignee
+            )
+            print(f"担当者: {assignee_labels[args.assigned_to_id]}")
         if "fixed_version" in selected:
             project_id = (current.get("project") or {}).get("id")
             if not project_id:
@@ -476,7 +496,7 @@ def handle_issue_update(args: argparse.Namespace) -> None:
         or args.tracker_id
         or args.status_id
         or args.priority_id
-        or args.assigned_to_id
+        or args.assigned_to_id is not None
         or args.fixed_version_id
         or args.parent_issue_id is not None
         or args.start_date is not None
@@ -505,7 +525,7 @@ def handle_issue_update(args: argparse.Namespace) -> None:
         or args.tracker_id
         or args.status_id
         or args.priority_id
-        or args.assigned_to_id
+        or args.assigned_to_id is not None
         or args.fixed_version_id
         or args.parent_issue_id is not None
         or args.start_date is not None


### PR DESCRIPTION
## Summary

- `redi issue update <issue_id>` の対話モード項目に「担当者 (assigned_to)」を追加 (closes #109 )
- プロジェクトメンバー一覧（`/projects/{id}/memberships.json`）から `inline_choice` で選択
- 「（担当者なし）」を選ぶと `assigned_to_id=""` を送って担当者を解除する
- これに伴い `update_issue` API と `handle_issue_update` の `assigned_to_id` 判定を truthy から `is not None` に変更（CLI から `--assigned_to_id ""` でも担当者解除が効くようになる）

## Test plan

- [ ] `task check` がパスする
- [x] `redi issue update <issue_id>` で「担当者」を選び、現在の担当者がカーソル位置（default）になっている
- [x] 候補にプロジェクトメンバーが並ぶ（管理者権限なしでもメンバー一覧が取れる）
- [x] 「（担当者なし）」を選ぶと担当者が解除される
- [x] `redi issue update <issue_id> --assigned_to_id ""` で担当者解除できる