### PR TITLE
TUI に ? で開くヘルプウィンドウを追加 (closes #111 )

### DIFF
--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -100,9 +100,13 @@ def _render_help(state: TuiState) -> Renderable:
     lines = TABS[state.tab].help_lines
     width = max(len(key) for key, _ in lines) + 2
     parts: Renderable = []
+    seen_section = False
     for key, desc in lines:
         if not desc:
+            if seen_section:
+                parts.append(("", "\n"))
             parts.append(("bold", f"{key}\n"))
+            seen_section = True
         else:
             parts.append(("bold fg:ansicyan", key.ljust(width)))
             parts.append(("", f"  {desc}\n"))

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -96,34 +96,11 @@ def _render_preview_current(state: TuiState) -> Renderable:
     return TABS[state.tab].render_preview(state)
 
 
-_HELP_LINES: list[tuple[str, str]] = [
-    ("移動", ""),
-    ("  ↑/k/Ctrl+P", "上へ"),
-    ("  ↓/j/Ctrl+N", "下へ"),
-    ("  gg / G", "先頭 / 末尾へ"),
-    ("  <N>G", "#N のイシューへジャンプ"),
-    ("  ←/h / →/l", "前ページ / 次ページ"),
-    ("  Tab / Shift+Tab", "タブ切替 (次 / 前)"),
-    ("検索", ""),
-    ("  /", "検索開始"),
-    ("  n / N", "次 / 前の検索結果"),
-    ("アクション", ""),
-    ("  Enter", "選択 (イシューはコメント読込)"),
-    ("  c / u", "作成 / 更新"),
-    ("  n", "コメント追加 (検索クエリ未設定時)"),
-    ("  t", "時間登録"),
-    ("  v / <N>V", "web で開く / #N を web で開く"),
-    ("  D", "削除 (time_entries タブのみ)"),
-    ("その他", ""),
-    ("  ?", "このヘルプを表示 / 閉じる"),
-    ("  q / Esc / Ctrl+C", "終了 (ヘルプ表示中は閉じる)"),
-]
-
-
 def _render_help(state: TuiState) -> Renderable:
-    width = max(len(key) for key, _ in _HELP_LINES) + 2
+    lines = TABS[state.tab].help_lines
+    width = max(len(key) for key, _ in lines) + 2
     parts: Renderable = []
-    for key, desc in _HELP_LINES:
+    for key, desc in lines:
         if not desc:
             parts.append(("bold", f"{key}\n"))
         else:
@@ -426,7 +403,9 @@ def run_issue_tui(
                     ),
                     wrap_lines=False,
                 ),
-                title="ヘルプ (? / Esc / q で閉じる)",
+                title=lambda: (
+                    f"ヘルプ - {TABS[state.tab].label} タブ (? / Esc / q で閉じる)"
+                ),
             ),
             filter=help_mode,
         ),

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -7,8 +7,16 @@ from prompt_toolkit.data_structures import Point
 from prompt_toolkit.filters import Condition
 from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.layout import Layout
-from prompt_toolkit.layout.containers import HSplit, VSplit, Window
+from prompt_toolkit.layout.containers import (
+    ConditionalContainer,
+    Float,
+    FloatContainer,
+    HSplit,
+    VSplit,
+    Window,
+)
 from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.widgets import Frame
 
 from redi.api.issue import fetch_issues
 from redi.config import default_project_id
@@ -88,6 +96,42 @@ def _render_preview_current(state: TuiState) -> Renderable:
     return TABS[state.tab].render_preview(state)
 
 
+_HELP_LINES: list[tuple[str, str]] = [
+    ("移動", ""),
+    ("  ↑/k/Ctrl+P", "上へ"),
+    ("  ↓/j/Ctrl+N", "下へ"),
+    ("  gg / G", "先頭 / 末尾へ"),
+    ("  <N>G", "#N のイシューへジャンプ"),
+    ("  ←/h / →/l", "前ページ / 次ページ"),
+    ("  Tab / Shift+Tab", "タブ切替 (次 / 前)"),
+    ("検索", ""),
+    ("  /", "検索開始"),
+    ("  n / N", "次 / 前の検索結果"),
+    ("アクション", ""),
+    ("  Enter", "選択 (イシューはコメント読込)"),
+    ("  c / u", "作成 / 更新"),
+    ("  n", "コメント追加 (検索クエリ未設定時)"),
+    ("  t", "時間登録"),
+    ("  v / <N>V", "web で開く / #N を web で開く"),
+    ("  D", "削除 (time_entries タブのみ)"),
+    ("その他", ""),
+    ("  ?", "このヘルプを表示 / 閉じる"),
+    ("  q / Esc / Ctrl+C", "終了 (ヘルプ表示中は閉じる)"),
+]
+
+
+def _render_help(state: TuiState) -> Renderable:
+    width = max(len(key) for key, _ in _HELP_LINES) + 2
+    parts: Renderable = []
+    for key, desc in _HELP_LINES:
+        if not desc:
+            parts.append(("bold", f"{key}\n"))
+        else:
+            parts.append(("bold fg:ansicyan", key.ljust(width)))
+            parts.append(("", f"  {desc}\n"))
+    return parts
+
+
 def _render_status(state: TuiState) -> Renderable:
     if state.confirm_delete_prompt is not None:
         return [("reverse", f" {state.confirm_delete_prompt} ")]
@@ -146,10 +190,15 @@ def run_issue_tui(
 
     kb = KeyBindings()
     normal_mode = Condition(
-        lambda: not state.search_mode and state.confirm_delete_prompt is None
+        lambda: (
+            not state.search_mode
+            and state.confirm_delete_prompt is None
+            and not state.show_help
+        )
     )
     search_mode = Condition(lambda: state.search_mode)
     confirm_delete_mode = Condition(lambda: state.confirm_delete_prompt is not None)
+    help_mode = Condition(lambda: state.show_help)
 
     def _clear_temporary_state() -> None:
         state.number_buffer = ""
@@ -302,6 +351,18 @@ def run_issue_tui(
     def _(event):
         event.app.exit(result=None)
 
+    @kb.add("?", filter=normal_mode)
+    def _(event):
+        _clear_temporary_state()
+        state.show_help = True
+
+    @kb.add("?", filter=help_mode)
+    @kb.add("q", filter=help_mode)
+    @kb.add("escape", filter=help_mode)
+    @kb.add("c-c", filter=help_mode)
+    def _(event):
+        state.show_help = False
+
     @kb.add("enter", filter=search_mode)
     def _(event):
         if state.search_query:
@@ -327,43 +388,52 @@ def run_issue_tui(
         if data and len(data) == 1 and data.isprintable():
             state.search_query += data
 
-    app = Application(
-        layout=Layout(
-            HSplit(
+    main_layout = HSplit(
+        [
+            Window(
+                FormattedTextControl(lambda: _render_tabs(state), show_cursor=False),
+                height=1,
+            ),
+            Window(height=1, char="─"),
+            VSplit(
                 [
                     Window(
                         FormattedTextControl(
-                            lambda: _render_tabs(state), show_cursor=False
-                        ),
-                        height=1,
-                    ),
-                    Window(height=1, char="─"),
-                    VSplit(
-                        [
-                            Window(
-                                FormattedTextControl(
-                                    lambda: _render_list_current(state),
-                                    show_cursor=False,
-                                    get_cursor_position=lambda: Point(
-                                        0, TABS[state.tab].get_cursor_y(state)
-                                    ),
-                                )
+                            lambda: _render_list_current(state),
+                            show_cursor=False,
+                            get_cursor_position=lambda: Point(
+                                0, TABS[state.tab].get_cursor_y(state)
                             ),
-                            Window(width=1, char="│"),
-                            Window(
-                                FormattedTextControl(
-                                    lambda: _render_preview_current(state)
-                                ),
-                                wrap_lines=True,
-                            ),
-                        ]
+                        )
                     ),
+                    Window(width=1, char="│"),
                     Window(
-                        FormattedTextControl(lambda: _render_status(state)), height=1
+                        FormattedTextControl(lambda: _render_preview_current(state)),
+                        wrap_lines=True,
                     ),
                 ]
-            )
+            ),
+            Window(FormattedTextControl(lambda: _render_status(state)), height=1),
+        ]
+    )
+
+    help_float = Float(
+        content=ConditionalContainer(
+            content=Frame(
+                Window(
+                    FormattedTextControl(
+                        lambda: _render_help(state), show_cursor=False
+                    ),
+                    wrap_lines=False,
+                ),
+                title="ヘルプ (? / Esc / q で閉じる)",
+            ),
+            filter=help_mode,
         ),
+    )
+
+    app = Application(
+        layout=Layout(FloatContainer(content=main_layout, floats=[help_float])),
         key_bindings=kb,
         full_screen=True,
     )

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -391,18 +391,31 @@ def run_issue_tui(
         ]
     )
 
+    # Frame を VSplit で挟んで左右に幅1の空白パディングを置く。
+    # Float の真下の行が CJK 文字 (display width=2) で終わると、その2セル目と
+    # Frame の左ボーダーが同じ列に重なり、prompt_toolkit のレンダラが wide
+    # char の幅ぶんカーソルを進めて Frame ボーダーのセルをスキップしてしまう
+    # (= 縁が表示されない)。1セルの空白を挟むとスキップ先がボーダーではなく
+    # 空白セルに変わるので、ボーダーは常に描画される。
     help_float = Float(
         content=ConditionalContainer(
-            content=Frame(
-                Window(
-                    FormattedTextControl(
-                        lambda: _render_help(state), show_cursor=False
+            content=VSplit(
+                [
+                    Window(width=1, char=" "),
+                    Frame(
+                        Window(
+                            FormattedTextControl(
+                                lambda: _render_help(state), show_cursor=False
+                            ),
+                            wrap_lines=False,
+                        ),
+                        title=lambda: (
+                            f"ヘルプ - {TABS[state.tab].label} タブ "
+                            "(任意のキーで閉じる)"
+                        ),
                     ),
-                    wrap_lines=False,
-                ),
-                title=lambda: (
-                    f"ヘルプ - {TABS[state.tab].label} タブ (任意のキーで閉じる)"
-                ),
+                    Window(width=1, char=" "),
+                ]
             ),
             filter=help_mode,
         ),

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -333,10 +333,7 @@ def run_issue_tui(
         _clear_temporary_state()
         state.show_help = True
 
-    @kb.add("?", filter=help_mode)
-    @kb.add("q", filter=help_mode)
-    @kb.add("escape", filter=help_mode)
-    @kb.add("c-c", filter=help_mode)
+    @kb.add("<any>", filter=help_mode)
     def _(event):
         state.show_help = False
 
@@ -404,7 +401,7 @@ def run_issue_tui(
                     wrap_lines=False,
                 ),
                 title=lambda: (
-                    f"ヘルプ - {TABS[state.tab].label} タブ (? / Esc / q で閉じる)"
+                    f"ヘルプ - {TABS[state.tab].label} タブ (任意のキーで閉じる)"
                 ),
             ),
             filter=help_mode,

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -103,9 +103,7 @@ def _status_hint(state: TuiState) -> str:
     page = state.issue_tab.offset // state.page_size + 1
     return (
         f" Page {page} (offset={state.issue_tab.offset})  "
-        "↑↓/jk:移動 gg/G:先頭末尾 <N>G:#Nへ ←→/hl:ページ /:検索 n/N:次前 "
-        "Enter:コメント読込 c:作成 u:更新 n:コメント t:時間登録 v:web <N>V:#Nをweb "
-        "Tab:タブ切替 ?:ヘルプ q:終了 "
+        "jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
     )
 
 

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -214,6 +214,29 @@ def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
     return None
 
 
+_HELP_LINES: list[tuple[str, str]] = [
+    ("移動", ""),
+    ("  ↑/k/Ctrl+P", "上へ"),
+    ("  ↓/j/Ctrl+N", "下へ"),
+    ("  gg / G", "先頭 / 末尾へ"),
+    ("  <N>G", "#N のイシューへジャンプ"),
+    ("  ←/h / →/l", "前ページ / 次ページ"),
+    ("  Tab / Shift+Tab", "タブ切替 (次 / 前)"),
+    ("検索", ""),
+    ("  /", "検索開始"),
+    ("  n / N", "次 / 前の検索結果"),
+    ("アクション", ""),
+    ("  Enter", "選択イシューのコメントを読込"),
+    ("  c / u", "イシュー作成 / 更新"),
+    ("  n", "コメント追加 (検索クエリ未設定時)"),
+    ("  t", "時間記録の作成"),
+    ("  v / <N>V", "選択イシューを web で開く / #N を web で開く"),
+    ("その他", ""),
+    ("  ?", "このヘルプを表示 / 閉じる"),
+    ("  q / Esc / Ctrl+C", "終了"),
+]
+
+
 ISSUE_TAB = TabView(
     label="イシュー",
     render_list=_render_list,
@@ -233,4 +256,5 @@ ISSUE_TAB = TabView(
     on_action_key=_on_action_key,
     on_search=_on_search,
     get_cursor_y=lambda state: state.issue_tab.cursor,
+    help_lines=_HELP_LINES,
 )

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -105,7 +105,7 @@ def _status_hint(state: TuiState) -> str:
         f" Page {page} (offset={state.issue_tab.offset})  "
         "↑↓/jk:移動 gg/G:先頭末尾 <N>G:#Nへ ←→/hl:ページ /:検索 n/N:次前 "
         "Enter:コメント読込 c:作成 u:更新 n:コメント t:時間登録 v:web <N>V:#Nをweb "
-        "Tab:タブ切替 q:終了 "
+        "Tab:タブ切替 ?:ヘルプ q:終了 "
     )
 
 

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -72,3 +72,5 @@ class TuiState:
     confirm_delete_prompt: str | None = None
     # 直前のアクション結果をステータスバーに出す一時メッセージ。次のキー入力で消える。
     flash_message: str | None = None
+    # ? でヘルプの floating window を表示しているかどうか。
+    show_help: bool = False

--- a/src/redi/tui/tab.py
+++ b/src/redi/tui/tab.py
@@ -25,6 +25,10 @@ class TabView:
     on_search: Callable[..., None]
     # 一覧内でのカーソル行 (0-indexed)。prompt_toolkit の Window 自動スクロールに使う。
     get_cursor_y: Callable[[TuiState], int]
+    # ? で開くヘルプの行データ。`(キー, 説明)` の組のリストで、説明が空の要素は
+    # セクション見出しとして描画される。タブごとに利用可能なキーが異なるため
+    # 各タブが自前で定義する。
+    help_lines: list[tuple[str, str]]
 
 
 def noop(state: TuiState) -> None:

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -102,7 +102,7 @@ def _render_preview(state: TuiState) -> Renderable:
 def _status_hint(state: TuiState) -> str:
     return (
         " ↑↓/jk:移動 gg/G:先頭末尾 /:検索 n/N:次前 "
-        "c:作成 u:更新 D:削除 v:web Tab:タブ切替 q:終了 "
+        "c:作成 u:更新 D:削除 v:web Tab:タブ切替 ?:ヘルプ q:終了 "
     )
 
 

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -100,10 +100,7 @@ def _render_preview(state: TuiState) -> Renderable:
 
 
 def _status_hint(state: TuiState) -> str:
-    return (
-        " ↑↓/jk:移動 gg/G:先頭末尾 /:検索 n/N:次前 "
-        "c:作成 u:更新 D:削除 v:web Tab:タブ切替 ?:ヘルプ q:終了 "
-    )
+    return " jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
 
 
 def _on_action_key(state: TuiState, key: str) -> TuiResult | None:

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -212,6 +212,26 @@ def _on_open_web(state: TuiState) -> None:
         webbrowser.open(f"{redmine_url}/time_entries")
 
 
+_HELP_LINES: list[tuple[str, str]] = [
+    ("移動", ""),
+    ("  ↑/k/Ctrl+P", "上へ"),
+    ("  ↓/j/Ctrl+N", "下へ"),
+    ("  gg / G", "先頭 / 末尾へ"),
+    ("  Tab / Shift+Tab", "タブ切替 (次 / 前)"),
+    ("検索", ""),
+    ("  /", "検索開始"),
+    ("  n / N", "次 / 前の検索結果"),
+    ("アクション", ""),
+    ("  c", "時間記録を作成"),
+    ("  u", "選択した時間記録を更新"),
+    ("  D", "選択した時間記録を削除 (y/Y で確定)"),
+    ("  v", "選択行のイシューを web で開く"),
+    ("その他", ""),
+    ("  ?", "このヘルプを表示 / 閉じる"),
+    ("  q / Esc / Ctrl+C", "終了"),
+]
+
+
 TIME_ENTRY_TAB = TabView(
     label="作業時間",
     render_list=_render_list,
@@ -231,4 +251,5 @@ TIME_ENTRY_TAB = TabView(
     on_action_key=_on_action_key,
     on_search=_on_search,
     get_cursor_y=lambda state: state.time_entry_tab.cursor,
+    help_lines=_HELP_LINES,
 )

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -105,7 +105,7 @@ def _render_preview(state: TuiState) -> Renderable:
 def _status_hint(state: TuiState) -> str:
     return (
         " ↑↓/jk:移動 gg/G:先頭末尾 /:検索 n/N:次前 Enter:本文ロード "
-        "c:作成 u:更新 v:web Tab:タブ切替 q:終了 "
+        "c:作成 u:更新 v:web Tab:タブ切替 ?:ヘルプ q:終了 "
     )
 
 

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -197,6 +197,26 @@ def _on_open_web(state: TuiState) -> None:
         webbrowser.open(f"{redmine_url}/projects/{project}/wiki/{title}")
 
 
+_HELP_LINES: list[tuple[str, str]] = [
+    ("移動", ""),
+    ("  ↑/k/Ctrl+P", "上へ"),
+    ("  ↓/j/Ctrl+N", "下へ"),
+    ("  gg / G", "先頭 / 末尾へ"),
+    ("  Tab / Shift+Tab", "タブ切替 (次 / 前)"),
+    ("検索", ""),
+    ("  /", "検索開始"),
+    ("  n / N", "次 / 前の検索結果"),
+    ("アクション", ""),
+    ("  Enter", "選択ページの本文を読込"),
+    ("  c", "選択ページの子ページを作成"),
+    ("  u", "選択ページを更新"),
+    ("  v", "選択ページを web で開く"),
+    ("その他", ""),
+    ("  ?", "このヘルプを表示 / 閉じる"),
+    ("  q / Esc / Ctrl+C", "終了"),
+]
+
+
 WIKI_TAB = TabView(
     label="Wiki",
     render_list=_render_list,
@@ -216,4 +236,5 @@ WIKI_TAB = TabView(
     on_action_key=_on_action_key,
     on_search=_on_search,
     get_cursor_y=lambda state: state.wiki_tab.cursor,
+    help_lines=_HELP_LINES,
 )

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -103,10 +103,7 @@ def _render_preview(state: TuiState) -> Renderable:
 
 
 def _status_hint(state: TuiState) -> str:
-    return (
-        " ↑↓/jk:移動 gg/G:先頭末尾 /:検索 n/N:次前 Enter:本文ロード "
-        "c:作成 u:更新 v:web Tab:タブ切替 ?:ヘルプ q:終了 "
-    )
+    return " jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
 
 
 def _exit_result(


### PR DESCRIPTION
## Summary
- `?` 押下で表示する floating window でキーバインド一覧を提供し、ステータスラインの長文ヒントを最小限 (`jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了`) に圧縮
- ヘルプ内容はタブ (イシュー / Wiki / 作業時間) ごとに `TabView.help_lines` で個別定義し、その時点で実際に有効なキーだけを掲載
- ヘルプ表示中は任意のキー押下で閉じる (`<any>` フィルタ)。タイトルにはアクティブタブ名と「任意のキーで閉じる」を表示
- カテゴリ (移動 / 検索 / アクション / その他) の間に空行を入れて視認性を改善

## 既知の prompt_toolkit 問題への対処
下のレイヤの行末が CJK 文字 (display width=2) で終わるとき、ヘルプ Float の左ボーダー `│` が描画されないことがあった。原因は prompt_toolkit のレンダラ (renderer.py の paint ループ) が wide char を出力した直後に `c += char_width` でカーソルを 2 セル進めるため、ボーダーセルが「読み飛ばされ」てターミナルへ送られないこと。Frame の左右に幅 1 の空白フィラーを `VSplit` で挟み、スキップ先がボーダーではなく空白セルに当たるようにして解消。

## Test plan
- [x] `redi --tui` 起動後、各タブで `?` を押すとヘルプ floating window が中央に表示される
- [x] ヘルプ表示中に任意のキー (`?` / `q` / `Esc` / 矢印キー / その他文字) を押すと閉じる
- [x] イシュー一覧で行末が日本語の行と重なる位置にヘルプを表示しても、左ボーダー `│` が欠けない
- [x] タブを切り替えた状態で `?` を開くと、そのタブで実際に有効なキーだけが表示される (例: Wiki タブで `<N>G` や `←→/hl` が出ない)
- [x] ステータスラインが `jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了` のみ (イシュータブは Page 情報も含む) になっている
- [x] `task check` (ruff format / ruff check / ty check / pytest) が全部 green

closes #111