### PR TITLE
TUI に f キーでイシューフィルタの floating window を追加 (closes #102 )

### DIFF
--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -18,11 +18,19 @@ from prompt_toolkit.layout.containers import (
 from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.widgets import Frame
 
-from redi.api.issue import fetch_issues
+from redi.api.issue_status import fetch_issue_statuses
+from redi.api.membership import fetch_project_users
 from redi.config import default_project_id
-from redi.tui.issue_tab import ISSUE_TAB, load_journals
+from redi.tui.issue_tab import (
+    ISSUE_TAB,
+    fetch_issues_with_filter,
+    load_journals,
+    reload_with_filter,
+)
 from redi.tui.state import (
     FIXED_ROWS,
+    FilterField,
+    IssueFilter,
     Renderable,
     TuiPosition,
     TuiResult,
@@ -96,6 +104,88 @@ def _render_preview_current(state: TuiState) -> Renderable:
     return TABS[state.tab].render_preview(state)
 
 
+def _build_status_choices() -> list[tuple[str | None, str]]:
+    """フィルタモーダルのステータス選択肢。先頭の3つは Redmine の特殊指定。"""
+    choices: list[tuple[str | None, str]] = [
+        (None, "open (デフォルト)"),
+        ("*", "全て (open + closed)"),
+        ("closed", "closed のみ"),
+    ]
+    try:
+        statuses = fetch_issue_statuses()
+    except Exception:
+        statuses = []
+    for s in statuses:
+        choices.append((str(s["id"]), s.get("name", "")))
+    return choices
+
+
+def _build_assignee_choices(project_id: str | None) -> list[tuple[str | None, str]]:
+    """フィルタモーダルの担当者選択肢。先頭は特殊指定 (未設定/me/未割当)。"""
+    choices: list[tuple[str | None, str]] = [
+        (None, "(指定なし)"),
+        ("me", "自分"),
+        ("!*", "未割当"),
+    ]
+    if project_id:
+        try:
+            users = fetch_project_users(project_id)
+        except Exception:
+            users = []
+        for u in users:
+            choices.append((str(u["id"]), u.get("name", "")))
+    return choices
+
+
+def _render_filter_section(
+    state: TuiState,
+    section: FilterField,
+    title: str,
+    choices: list[tuple[str | None, str]],
+    cursor: int,
+    active_id: str | None,
+) -> Renderable:
+    focused = state.filter_focus == section
+    header_style = "bold fg:ansicyan" if focused else "bold"
+    parts: Renderable = [(header_style, f"[{title}]\n")]
+    for i, (api_val, label) in enumerate(choices):
+        is_cursor = focused and i == cursor
+        is_active = api_val == active_id
+        cursor_mark = ">" if is_cursor else " "
+        active_mark = "*" if is_active else " "
+        line_style = "reverse" if is_cursor else ("bold" if is_active else "")
+        parts.append((line_style, f" {cursor_mark} {active_mark} {label}\n"))
+    return parts
+
+
+def _render_filter_modal(state: TuiState) -> Renderable:
+    f = state.issue_tab.filter
+    parts: Renderable = []
+    parts.extend(
+        _render_filter_section(
+            state,
+            "status",
+            "ステータス",
+            state.filter_status_choices,
+            state.filter_status_cursor,
+            f.status_id,
+        )
+    )
+    parts.append(("", "\n"))
+    parts.extend(
+        _render_filter_section(
+            state,
+            "assignee",
+            "担当者",
+            state.filter_assignee_choices,
+            state.filter_assignee_cursor,
+            f.assigned_to_id,
+        )
+    )
+    parts.append(("", "\nTab/h/l:列切替 jk:移動 Enter:適用 c:全クリア Esc/f:閉じる"))
+    return parts
+
+
 def _render_help(state: TuiState) -> Renderable:
     lines = TABS[state.tab].help_lines
     width = max(len(key) for key, _ in lines) + 2
@@ -138,11 +228,7 @@ def run_issue_tui(
     position = last.position if last else TuiPosition()
     state.page_size = max(1, shutil.get_terminal_size().lines - FIXED_ROWS)
     state.issue_tab.offset = position.offset if state.tab == "issues" else 0
-    state.issue_tab.issues = fetch_issues(
-        project_id=default_project_id,
-        limit=state.page_size,
-        offset=state.issue_tab.offset,
-    )
+    state.issue_tab.issues = fetch_issues_with_filter(state, state.issue_tab.offset)
     if state.tab == "issues" and not state.issue_tab.issues:
         print("イシューが見つかりません")
         return None
@@ -175,11 +261,13 @@ def run_issue_tui(
             not state.search_mode
             and state.confirm_delete_prompt is None
             and not state.show_help
+            and not state.show_filter
         )
     )
     search_mode = Condition(lambda: state.search_mode)
     confirm_delete_mode = Condition(lambda: state.confirm_delete_prompt is not None)
     help_mode = Condition(lambda: state.show_help)
+    filter_mode = Condition(lambda: state.show_filter)
 
     def _clear_temporary_state() -> None:
         state.number_buffer = ""
@@ -341,6 +429,87 @@ def run_issue_tui(
     def _(event):
         state.show_help = False
 
+    def _open_filter_modal() -> None:
+        state.filter_status_choices = _build_status_choices()
+        state.filter_assignee_choices = _build_assignee_choices(default_project_id)
+        state.filter_status_cursor = 0
+        for idx, (api_val, _label) in enumerate(state.filter_status_choices):
+            if api_val == state.issue_tab.filter.status_id:
+                state.filter_status_cursor = idx
+                break
+        state.filter_assignee_cursor = 0
+        for idx, (api_val, _label) in enumerate(state.filter_assignee_choices):
+            if api_val == state.issue_tab.filter.assigned_to_id:
+                state.filter_assignee_cursor = idx
+                break
+        state.filter_focus = "status"
+        state.show_filter = True
+
+    @kb.add("f", filter=normal_mode)
+    def _(event):
+        if state.tab != "issues":
+            return
+        _clear_temporary_state()
+        _open_filter_modal()
+
+    @kb.add("tab", filter=filter_mode)
+    @kb.add("s-tab", filter=filter_mode)
+    @kb.add("h", filter=filter_mode)
+    @kb.add("l", filter=filter_mode)
+    @kb.add("left", filter=filter_mode)
+    @kb.add("right", filter=filter_mode)
+    def _(event):
+        state.filter_focus = "assignee" if state.filter_focus == "status" else "status"
+
+    @kb.add("j", filter=filter_mode)
+    @kb.add("down", filter=filter_mode)
+    def _(event):
+        if state.filter_focus == "status":
+            state.filter_status_cursor = min(
+                len(state.filter_status_choices) - 1, state.filter_status_cursor + 1
+            )
+        else:
+            state.filter_assignee_cursor = min(
+                len(state.filter_assignee_choices) - 1, state.filter_assignee_cursor + 1
+            )
+
+    @kb.add("k", filter=filter_mode)
+    @kb.add("up", filter=filter_mode)
+    def _(event):
+        if state.filter_focus == "status":
+            state.filter_status_cursor = max(0, state.filter_status_cursor - 1)
+        else:
+            state.filter_assignee_cursor = max(0, state.filter_assignee_cursor - 1)
+
+    @kb.add("enter", filter=filter_mode)
+    def _(event):
+        if state.filter_focus == "status":
+            if not state.filter_status_choices:
+                return
+            api_val, label = state.filter_status_choices[state.filter_status_cursor]
+            state.issue_tab.filter.status_id = api_val
+            state.issue_tab.filter.status_label = label
+        else:
+            if not state.filter_assignee_choices:
+                return
+            api_val, label = state.filter_assignee_choices[state.filter_assignee_cursor]
+            state.issue_tab.filter.assigned_to_id = api_val
+            state.issue_tab.filter.assigned_to_label = label
+        reload_with_filter(state)
+
+    @kb.add("c", filter=filter_mode)
+    def _(event):
+        state.issue_tab.filter = IssueFilter()
+        state.filter_status_cursor = 0
+        state.filter_assignee_cursor = 0
+        reload_with_filter(state)
+
+    @kb.add("escape", filter=filter_mode)
+    @kb.add("f", filter=filter_mode)
+    @kb.add("q", filter=filter_mode)
+    def _(event):
+        state.show_filter = False
+
     @kb.add("enter", filter=search_mode)
     def _(event):
         if state.search_query:
@@ -425,8 +594,32 @@ def run_issue_tui(
         ),
     )
 
+    show_filter_cond = Condition(lambda: state.show_filter)
+    filter_float = Float(
+        content=ConditionalContainer(
+            content=VSplit(
+                [
+                    Window(width=1, char=" "),
+                    Frame(
+                        Window(
+                            FormattedTextControl(
+                                lambda: _render_filter_modal(state), show_cursor=False
+                            ),
+                            wrap_lines=False,
+                        ),
+                        title="フィルタ (Esc/f で閉じる)",
+                    ),
+                    Window(width=1, char=" "),
+                ]
+            ),
+            filter=show_filter_cond,
+        ),
+    )
+
     app = Application(
-        layout=Layout(FloatContainer(content=main_layout, floats=[help_float])),
+        layout=Layout(
+            FloatContainer(content=main_layout, floats=[help_float, filter_float])
+        ),
         key_bindings=kb,
         full_screen=True,
     )

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -30,6 +30,7 @@ from redi.tui.issue_tab import (
 from redi.tui.state import (
     FIXED_ROWS,
     FilterField,
+    FilterModalState,
     IssueFilter,
     Renderable,
     TuiPosition,
@@ -138,14 +139,14 @@ def _build_assignee_choices(project_id: str | None) -> list[tuple[str | None, st
 
 
 def _render_filter_section(
-    state: TuiState,
+    modal: FilterModalState,
     section: FilterField,
     title: str,
     choices: list[tuple[str | None, str]],
     cursor: int,
     active_id: str | None,
 ) -> Renderable:
-    focused = state.filter_focus == section
+    focused = modal.focus == section
     header_style = "bold fg:ansicyan" if focused else "bold"
     parts: Renderable = [(header_style, f"[{title}]\n")]
     for i, (api_val, label) in enumerate(choices):
@@ -160,25 +161,26 @@ def _render_filter_section(
 
 def _render_filter_modal(state: TuiState) -> Renderable:
     f = state.issue_tab.filter
+    modal = state.issue_tab.filter_modal
     parts: Renderable = []
     parts.extend(
         _render_filter_section(
-            state,
+            modal,
             "status",
             "ステータス",
-            state.filter_status_choices,
-            state.filter_status_cursor,
+            modal.status_choices,
+            modal.status_cursor,
             f.status_id,
         )
     )
     parts.append(("", "\n"))
     parts.extend(
         _render_filter_section(
-            state,
+            modal,
             "assignee",
             "担当者",
-            state.filter_assignee_choices,
-            state.filter_assignee_cursor,
+            modal.assignee_choices,
+            modal.assignee_cursor,
             f.assigned_to_id,
         )
     )
@@ -261,13 +263,13 @@ def run_issue_tui(
             not state.search_mode
             and state.confirm_delete_prompt is None
             and not state.show_help
-            and not state.show_filter
+            and not state.issue_tab.filter_modal.show
         )
     )
     search_mode = Condition(lambda: state.search_mode)
     confirm_delete_mode = Condition(lambda: state.confirm_delete_prompt is not None)
     help_mode = Condition(lambda: state.show_help)
-    filter_mode = Condition(lambda: state.show_filter)
+    filter_mode = Condition(lambda: state.issue_tab.filter_modal.show)
 
     def _clear_temporary_state() -> None:
         state.number_buffer = ""
@@ -430,20 +432,21 @@ def run_issue_tui(
         state.show_help = False
 
     def _open_filter_modal() -> None:
-        state.filter_status_choices = _build_status_choices()
-        state.filter_assignee_choices = _build_assignee_choices(default_project_id)
-        state.filter_status_cursor = 0
-        for idx, (api_val, _label) in enumerate(state.filter_status_choices):
+        modal = state.issue_tab.filter_modal
+        modal.status_choices = _build_status_choices()
+        modal.assignee_choices = _build_assignee_choices(default_project_id)
+        modal.status_cursor = 0
+        for idx, (api_val, _label) in enumerate(modal.status_choices):
             if api_val == state.issue_tab.filter.status_id:
-                state.filter_status_cursor = idx
+                modal.status_cursor = idx
                 break
-        state.filter_assignee_cursor = 0
-        for idx, (api_val, _label) in enumerate(state.filter_assignee_choices):
+        modal.assignee_cursor = 0
+        for idx, (api_val, _label) in enumerate(modal.assignee_choices):
             if api_val == state.issue_tab.filter.assigned_to_id:
-                state.filter_assignee_cursor = idx
+                modal.assignee_cursor = idx
                 break
-        state.filter_focus = "status"
-        state.show_filter = True
+        modal.focus = "status"
+        modal.show = True
 
     @kb.add("f", filter=normal_mode)
     def _(event):
@@ -459,40 +462,44 @@ def run_issue_tui(
     @kb.add("left", filter=filter_mode)
     @kb.add("right", filter=filter_mode)
     def _(event):
-        state.filter_focus = "assignee" if state.filter_focus == "status" else "status"
+        modal = state.issue_tab.filter_modal
+        modal.focus = "assignee" if modal.focus == "status" else "status"
 
     @kb.add("j", filter=filter_mode)
     @kb.add("down", filter=filter_mode)
     def _(event):
-        if state.filter_focus == "status":
-            state.filter_status_cursor = min(
-                len(state.filter_status_choices) - 1, state.filter_status_cursor + 1
+        modal = state.issue_tab.filter_modal
+        if modal.focus == "status":
+            modal.status_cursor = min(
+                len(modal.status_choices) - 1, modal.status_cursor + 1
             )
         else:
-            state.filter_assignee_cursor = min(
-                len(state.filter_assignee_choices) - 1, state.filter_assignee_cursor + 1
+            modal.assignee_cursor = min(
+                len(modal.assignee_choices) - 1, modal.assignee_cursor + 1
             )
 
     @kb.add("k", filter=filter_mode)
     @kb.add("up", filter=filter_mode)
     def _(event):
-        if state.filter_focus == "status":
-            state.filter_status_cursor = max(0, state.filter_status_cursor - 1)
+        modal = state.issue_tab.filter_modal
+        if modal.focus == "status":
+            modal.status_cursor = max(0, modal.status_cursor - 1)
         else:
-            state.filter_assignee_cursor = max(0, state.filter_assignee_cursor - 1)
+            modal.assignee_cursor = max(0, modal.assignee_cursor - 1)
 
     @kb.add("enter", filter=filter_mode)
     def _(event):
-        if state.filter_focus == "status":
-            if not state.filter_status_choices:
+        modal = state.issue_tab.filter_modal
+        if modal.focus == "status":
+            if not modal.status_choices:
                 return
-            api_val, label = state.filter_status_choices[state.filter_status_cursor]
+            api_val, label = modal.status_choices[modal.status_cursor]
             state.issue_tab.filter.status_id = api_val
             state.issue_tab.filter.status_label = label
         else:
-            if not state.filter_assignee_choices:
+            if not modal.assignee_choices:
                 return
-            api_val, label = state.filter_assignee_choices[state.filter_assignee_cursor]
+            api_val, label = modal.assignee_choices[modal.assignee_cursor]
             state.issue_tab.filter.assigned_to_id = api_val
             state.issue_tab.filter.assigned_to_label = label
         reload_with_filter(state)
@@ -500,15 +507,16 @@ def run_issue_tui(
     @kb.add("c", filter=filter_mode)
     def _(event):
         state.issue_tab.filter = IssueFilter()
-        state.filter_status_cursor = 0
-        state.filter_assignee_cursor = 0
+        modal = state.issue_tab.filter_modal
+        modal.status_cursor = 0
+        modal.assignee_cursor = 0
         reload_with_filter(state)
 
     @kb.add("escape", filter=filter_mode)
     @kb.add("f", filter=filter_mode)
     @kb.add("q", filter=filter_mode)
     def _(event):
-        state.show_filter = False
+        state.issue_tab.filter_modal.show = False
 
     @kb.add("enter", filter=search_mode)
     def _(event):
@@ -594,7 +602,7 @@ def run_issue_tui(
         ),
     )
 
-    show_filter_cond = Condition(lambda: state.show_filter)
+    show_filter_cond = Condition(lambda: state.issue_tab.filter_modal.show)
     filter_float = Float(
         content=ConditionalContainer(
             content=VSplit(

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -112,11 +112,7 @@ def _build_status_choices() -> list[tuple[str | None, str]]:
         ("*", "全て (open + closed)"),
         ("closed", "closed のみ"),
     ]
-    try:
-        statuses = fetch_issue_statuses()
-    except Exception:
-        statuses = []
-    for s in statuses:
+    for s in fetch_issue_statuses():
         choices.append((str(s["id"]), s.get("name", "")))
     return choices
 
@@ -129,11 +125,7 @@ def _build_assignee_choices(project_id: str | None) -> list[tuple[str | None, st
         ("!*", "未割当"),
     ]
     if project_id:
-        try:
-            users = fetch_project_users(project_id)
-        except Exception:
-            users = []
-        for u in users:
+        for u in fetch_project_users(project_id):
             choices.append((str(u["id"]), u.get("name", "")))
     return choices
 

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -101,10 +101,13 @@ def _render_preview(state: TuiState) -> Renderable:
 
 def _status_hint(state: TuiState) -> str:
     page = state.issue_tab.offset // state.page_size + 1
-    return (
+    hint = (
         f" Page {page} (offset={state.issue_tab.offset})  "
-        "jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
+        "jk:移動 /:検索 f:フィルタ c:作成 u:更新 v:web ?:ヘルプ q:終了 "
     )
+    if state.issue_tab.filter.is_active():
+        hint = f" [{state.issue_tab.filter.short_label()}]" + hint
+    return hint
 
 
 def _on_up(state: TuiState) -> None:
@@ -143,11 +146,27 @@ def _on_enter(state: TuiState) -> None:
     load_journals(issue)
 
 
-def _on_page_forward(state: TuiState) -> None:
-    next_issues = fetch_issues(
+def fetch_issues_with_filter(state: TuiState, offset: int) -> list[dict]:
+    f = state.issue_tab.filter
+    return fetch_issues(
         project_id=default_project_id,
+        status_id=f.status_id,
+        assigned_to=f.assigned_to_id,
         limit=state.page_size,
-        offset=state.issue_tab.offset + state.page_size,
+        offset=offset,
+    )
+
+
+def reload_with_filter(state: TuiState) -> None:
+    """フィルタ条件で先頭ページから再取得する。filter modal からの適用で呼ぶ。"""
+    state.issue_tab.offset = 0
+    state.issue_tab.issues = fetch_issues_with_filter(state, 0)
+    state.issue_tab.cursor = 0
+
+
+def _on_page_forward(state: TuiState) -> None:
+    next_issues = fetch_issues_with_filter(
+        state, state.issue_tab.offset + state.page_size
     )
     if next_issues:
         state.issue_tab.offset += state.page_size
@@ -159,11 +178,7 @@ def _on_page_backward(state: TuiState) -> None:
     if state.issue_tab.offset <= 0:
         return
     state.issue_tab.offset = max(0, state.issue_tab.offset - state.page_size)
-    state.issue_tab.issues = fetch_issues(
-        project_id=default_project_id,
-        limit=state.page_size,
-        offset=state.issue_tab.offset,
-    )
+    state.issue_tab.issues = fetch_issues_with_filter(state, state.issue_tab.offset)
     state.issue_tab.cursor = 0
 
 
@@ -223,6 +238,8 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("検索", ""),
     ("  /", "検索開始"),
     ("  n / N", "次 / 前の検索結果"),
+    ("フィルタ", ""),
+    ("  f", "ステータス/担当者でフィルタ (フローティング)"),
     ("アクション", ""),
     ("  Enter", "選択イシューのコメントを読込"),
     ("  c / u", "イシュー作成 / 更新"),

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -56,11 +56,31 @@ class IssueFilter:
 
 
 @dataclass
+class FilterModalState:
+    """f で開くフィルタ modal の表示・選択肢キャッシュ・カーソル状態。
+
+    実際のフィルタ条件 (`IssueFilter`) とは別にして、modal を閉じれば破棄してよい
+    一時的な UI 状態をここにまとめる。
+    """
+
+    show: bool = False
+    # 現在カーソルがあるセクション (status か assignee)
+    focus: FilterField = "status"
+    # 各セクションの選択肢: (Redmine API に渡す値, 表示ラベル) の組
+    status_choices: list[tuple[str | None, str]] = field(default_factory=list)
+    assignee_choices: list[tuple[str | None, str]] = field(default_factory=list)
+    # 各セクション内のカーソル位置
+    status_cursor: int = 0
+    assignee_cursor: int = 0
+
+
+@dataclass
 class IssueTabState:
     offset: int = 0
     cursor: int = 0
     issues: list[dict] = field(default_factory=list)
     filter: IssueFilter = field(default_factory=IssueFilter)
+    filter_modal: FilterModalState = field(default_factory=FilterModalState)
 
 
 @dataclass
@@ -101,13 +121,3 @@ class TuiState:
     flash_message: str | None = None
     # ? でヘルプの floating window を表示しているかどうか。
     show_help: bool = False
-    # f で開く Issue フィルタの floating window を表示中かどうか。
-    show_filter: bool = False
-    # 1ウインドウ式モーダルで現在カーソルがあるセクション (status か assignee)
-    filter_focus: FilterField = "status"
-    # 各セクションの選択肢: (Redmine API に渡す値, 表示ラベル) の組
-    filter_status_choices: list[tuple[str | None, str]] = field(default_factory=list)
-    filter_assignee_choices: list[tuple[str | None, str]] = field(default_factory=list)
-    # 各セクション内のカーソル位置
-    filter_status_cursor: int = 0
-    filter_assignee_cursor: int = 0

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 TuiAction = Literal["update", "create", "comment", "create_time_entry"]
 TuiTab = Literal["issues", "wiki", "time_entries"]
+FilterField = Literal["status", "assignee"]
 
 # prompt_toolkit の FormattedTextControl に渡す `(style, text)` 断片のリスト。
 Renderable = list[tuple[str, str]]
@@ -30,10 +31,36 @@ class TuiResult:
 
 
 @dataclass
+class IssueFilter:
+    """Issue 一覧のサーバーサイドフィルタ条件。
+
+    Redmine API の `status_id` / `assigned_to_id` パラメータに渡す値を保持する。
+    `status_id is None` のときは Redmine デフォルト挙動 (open のみ) になる。
+    """
+
+    status_id: str | None = None
+    status_label: str = "open (デフォルト)"
+    assigned_to_id: str | None = None
+    assigned_to_label: str = "(指定なし)"
+
+    def is_active(self) -> bool:
+        return self.status_id is not None or self.assigned_to_id is not None
+
+    def short_label(self) -> str:
+        parts = []
+        if self.status_id is not None:
+            parts.append(f"status={self.status_label}")
+        if self.assigned_to_id is not None:
+            parts.append(f"assignee={self.assigned_to_label}")
+        return " ".join(parts)
+
+
+@dataclass
 class IssueTabState:
     offset: int = 0
     cursor: int = 0
     issues: list[dict] = field(default_factory=list)
+    filter: IssueFilter = field(default_factory=IssueFilter)
 
 
 @dataclass
@@ -74,3 +101,13 @@ class TuiState:
     flash_message: str | None = None
     # ? でヘルプの floating window を表示しているかどうか。
     show_help: bool = False
+    # f で開く Issue フィルタの floating window を表示中かどうか。
+    show_filter: bool = False
+    # 1ウインドウ式モーダルで現在カーソルがあるセクション (status か assignee)
+    filter_focus: FilterField = "status"
+    # 各セクションの選択肢: (Redmine API に渡す値, 表示ラベル) の組
+    filter_status_choices: list[tuple[str | None, str]] = field(default_factory=list)
+    filter_assignee_choices: list[tuple[str | None, str]] = field(default_factory=list)
+    # 各セクション内のカーソル位置
+    filter_status_cursor: int = 0
+    filter_assignee_cursor: int = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,23 @@
 def pytest_itemcollected(item):
     """テストの表示名をdocstringの日本語に差し替える"""
     doc = item.obj.__doc__
-    if doc:
-        parent_doc = ""
-        if item.parent and hasattr(item.parent, "obj") and item.parent.obj.__doc__:
-            parent_doc = item.parent.obj.__doc__ + " > "
-        # parametrize されたテストにのみ callspec が存在し、id にパラメータ値が入る
-        suffix = ""
-        callspec = getattr(item, "callspec", None)
-        if callspec is not None:
-            suffix = f" [{callspec.id}]"
-        item._nodeid = f"{item.path.name}::{parent_doc}{doc}{suffix}"
+    if not doc:
+        return
+    # 祖先 class の docstring を内側→外側の順で集める (Module は除外)
+    parent_docs = []
+    parent = item.parent
+    while parent is not None and hasattr(parent, "obj"):
+        parent_obj = parent.obj
+        if not isinstance(parent_obj, type):
+            break
+        if parent_obj.__doc__:
+            parent_docs.append(parent_obj.__doc__)
+        parent = parent.parent
+    parent_docs.reverse()
+    parent_prefix = " > ".join(parent_docs) + " > " if parent_docs else ""
+    # parametrize されたテストにのみ callspec が存在し、id にパラメータ値が入る
+    suffix = ""
+    callspec = getattr(item, "callspec", None)
+    if callspec is not None:
+        suffix = f" [{callspec.id}]"
+    item._nodeid = f"{item.path.name}::{parent_prefix}{doc}{suffix}"

--- a/tests/unit/test_issue_filter.py
+++ b/tests/unit/test_issue_filter.py
@@ -1,0 +1,127 @@
+from redi.tui import issue_tab
+from redi.tui.state import IssueFilter, TuiState
+
+
+class TestIssueFilterIsActive:
+    """IssueFilter.is_active()はフィルタが何か設定されているかを返す"""
+
+    def test_both_fields_unset_is_inactive(self):
+        """status_id も assigned_to_id も None なら非アクティブ"""
+        f = IssueFilter()
+        assert f.is_active() is False
+
+    def test_status_set_is_active(self):
+        """status_id だけ設定でもアクティブ"""
+        f = IssueFilter(status_id="closed", status_label="closed のみ")
+        assert f.is_active() is True
+
+    def test_assignee_set_is_active(self):
+        """assigned_to_id だけ設定でもアクティブ"""
+        f = IssueFilter(assigned_to_id="me", assigned_to_label="自分")
+        assert f.is_active() is True
+
+
+class TestIssueFilterShortLabel:
+    """IssueFilter.short_label()はステータスバー表示用のラベルを返す"""
+
+    def test_no_filter_returns_empty(self):
+        """フィルタ未設定なら空文字を返す"""
+        assert IssueFilter().short_label() == ""
+
+    def test_status_only(self):
+        """status のみ設定なら status= だけ返す"""
+        f = IssueFilter(status_id="closed", status_label="closed のみ")
+        assert f.short_label() == "status=closed のみ"
+
+    def test_assignee_only(self):
+        """assignee のみ設定なら assignee= だけ返す"""
+        f = IssueFilter(assigned_to_id="me", assigned_to_label="自分")
+        assert f.short_label() == "assignee=自分"
+
+    def test_both_fields(self):
+        """両方設定なら両方を空白区切りで返す"""
+        f = IssueFilter(
+            status_id="*",
+            status_label="全て (open + closed)",
+            assigned_to_id="me",
+            assigned_to_label="自分",
+        )
+        assert f.short_label() == "status=全て (open + closed) assignee=自分"
+
+
+class TestFetchIssuesWithFilter:
+    """fetch_issues_with_filter()はTuiStateのfilterをfetch_issuesに渡す"""
+
+    def test_passes_filter_values_to_api(self, monkeypatch):
+        """state.issue_tab.filter の値が fetch_issues の引数に反映される"""
+        captured: dict = {}
+
+        def fake_fetch(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr(issue_tab, "fetch_issues", fake_fetch)
+        monkeypatch.setattr(issue_tab, "default_project_id", "demo")
+
+        state = TuiState()
+        state.page_size = 20
+        state.issue_tab.filter = IssueFilter(
+            status_id="closed",
+            status_label="closed のみ",
+            assigned_to_id="me",
+            assigned_to_label="自分",
+        )
+        issue_tab.fetch_issues_with_filter(state, offset=40)
+
+        assert captured == {
+            "project_id": "demo",
+            "status_id": "closed",
+            "assigned_to": "me",
+            "limit": 20,
+            "offset": 40,
+        }
+
+    def test_passes_none_when_filter_unset(self, monkeypatch):
+        """フィルタ未設定なら status_id / assigned_to も None で渡す"""
+        captured: dict = {}
+
+        def fake_fetch(**kwargs):
+            captured.update(kwargs)
+            return []
+
+        monkeypatch.setattr(issue_tab, "fetch_issues", fake_fetch)
+        monkeypatch.setattr(issue_tab, "default_project_id", "demo")
+
+        state = TuiState()
+        state.page_size = 10
+        issue_tab.fetch_issues_with_filter(state, offset=0)
+
+        assert captured["status_id"] is None
+        assert captured["assigned_to"] is None
+
+
+class TestReloadWithFilter:
+    """reload_with_filter()はoffset/cursorをリセットしてフィルタで再取得する"""
+
+    def test_resets_offset_cursor_and_fetches(self, monkeypatch):
+        """offset=0 で再取得し、cursor も 0 に戻す"""
+        monkeypatch.setattr(
+            issue_tab,
+            "fetch_issues",
+            lambda **kwargs: [{"id": 1, "subject": "filtered"}],
+        )
+        monkeypatch.setattr(issue_tab, "default_project_id", "demo")
+
+        state = TuiState()
+        state.page_size = 20
+        state.issue_tab.offset = 100
+        state.issue_tab.cursor = 5
+        state.issue_tab.filter = IssueFilter(
+            status_id="closed", status_label="closed のみ"
+        )
+
+        issue_tab.reload_with_filter(state)
+
+        assert state.issue_tab.offset == 0
+        assert state.issue_tab.cursor == 0
+        assert state.issue_tab.issues == [{"id": 1, "subject": "filtered"}]

--- a/tests/unit/test_issue_filter.py
+++ b/tests/unit/test_issue_filter.py
@@ -1,48 +1,50 @@
 from redi.tui.state import IssueFilter
 
 
-class TestIssueFilterIsActive:
-    """IssueFilter.is_active()はフィルタが何か設定されているかを返す"""
+class TestIssueFilter:
+    """IssueFilter は Issue 一覧のサーバーサイドフィルタ条件を保持する"""
 
-    def test_both_fields_unset_is_inactive(self):
-        """status_id も assigned_to_id も None なら非アクティブ"""
-        f = IssueFilter()
-        assert f.is_active() is False
+    class TestIsActive:
+        """is_active()はフィルタが何か設定されているかを返す"""
 
-    def test_status_set_is_active(self):
-        """status_id だけ設定でもアクティブ"""
-        f = IssueFilter(status_id="closed", status_label="closed のみ")
-        assert f.is_active() is True
+        def test_both_fields_unset_is_inactive(self):
+            """status_id も assigned_to_id も None なら非アクティブ"""
+            f = IssueFilter()
+            assert f.is_active() is False
 
-    def test_assignee_set_is_active(self):
-        """assigned_to_id だけ設定でもアクティブ"""
-        f = IssueFilter(assigned_to_id="me", assigned_to_label="自分")
-        assert f.is_active() is True
+        def test_status_set_is_active(self):
+            """status_id だけ設定でもアクティブ"""
+            f = IssueFilter(status_id="closed", status_label="closed のみ")
+            assert f.is_active() is True
 
+        def test_assignee_set_is_active(self):
+            """assigned_to_id だけ設定でもアクティブ"""
+            f = IssueFilter(assigned_to_id="me", assigned_to_label="自分")
+            assert f.is_active() is True
 
-class TestIssueFilterShortLabel:
-    """IssueFilter.short_label()はステータスバー表示用のラベルを返す"""
+    class TestShortLabel:
+        """short_label()はステータスバー表示用のラベルを返す"""
 
-    def test_no_filter_returns_empty(self):
-        """フィルタ未設定なら空文字を返す"""
-        assert IssueFilter().short_label() == ""
+        def test_no_filter_returns_empty(self):
+            """フィルタ未設定なら空文字を返す"""
+            assert IssueFilter().short_label() == ""
 
-    def test_status_only(self):
-        """status のみ設定なら status= だけ返す"""
-        f = IssueFilter(status_id="closed", status_label="closed のみ")
-        assert f.short_label() == "status=closed のみ"
+        def test_status_only(self):
+            """status のみ設定なら status= だけ返す"""
+            f = IssueFilter(status_id="closed", status_label="closed のみ")
+            assert f.short_label() == "status=closed のみ"
 
-    def test_assignee_only(self):
-        """assignee のみ設定なら assignee= だけ返す"""
-        f = IssueFilter(assigned_to_id="me", assigned_to_label="自分")
-        assert f.short_label() == "assignee=自分"
+        def test_assignee_only(self):
+            """assignee のみ設定なら assignee= だけ返す"""
+            f = IssueFilter(assigned_to_id="me", assigned_to_label="自分")
+            assert f.short_label() == "assignee=自分"
 
-    def test_both_fields(self):
-        """両方設定なら両方を空白区切りで返す"""
-        f = IssueFilter(
-            status_id="*",
-            status_label="全て (open + closed)",
-            assigned_to_id="me",
-            assigned_to_label="自分",
-        )
-        assert f.short_label() == "status=全て (open + closed) assignee=自分"
+        def test_both_fields(self):
+            """両方設定なら両方を空白区切りで返す"""
+            f = IssueFilter(
+                status_id="*",
+                status_label="全て (open + closed)",
+                assigned_to_id="me",
+                assigned_to_label="自分",
+            )
+            assert f.short_label() == "status=全て (open + closed) assignee=自分"

--- a/tests/unit/test_issue_filter.py
+++ b/tests/unit/test_issue_filter.py
@@ -1,5 +1,4 @@
-from redi.tui import issue_tab
-from redi.tui.state import IssueFilter, TuiState
+from redi.tui.state import IssueFilter
 
 
 class TestIssueFilterIsActive:
@@ -47,81 +46,3 @@ class TestIssueFilterShortLabel:
             assigned_to_label="自分",
         )
         assert f.short_label() == "status=全て (open + closed) assignee=自分"
-
-
-class TestFetchIssuesWithFilter:
-    """fetch_issues_with_filter()はTuiStateのfilterをfetch_issuesに渡す"""
-
-    def test_passes_filter_values_to_api(self, monkeypatch):
-        """state.issue_tab.filter の値が fetch_issues の引数に反映される"""
-        captured: dict = {}
-
-        def fake_fetch(**kwargs):
-            captured.update(kwargs)
-            return []
-
-        monkeypatch.setattr(issue_tab, "fetch_issues", fake_fetch)
-        monkeypatch.setattr(issue_tab, "default_project_id", "demo")
-
-        state = TuiState()
-        state.page_size = 20
-        state.issue_tab.filter = IssueFilter(
-            status_id="closed",
-            status_label="closed のみ",
-            assigned_to_id="me",
-            assigned_to_label="自分",
-        )
-        issue_tab.fetch_issues_with_filter(state, offset=40)
-
-        assert captured == {
-            "project_id": "demo",
-            "status_id": "closed",
-            "assigned_to": "me",
-            "limit": 20,
-            "offset": 40,
-        }
-
-    def test_passes_none_when_filter_unset(self, monkeypatch):
-        """フィルタ未設定なら status_id / assigned_to も None で渡す"""
-        captured: dict = {}
-
-        def fake_fetch(**kwargs):
-            captured.update(kwargs)
-            return []
-
-        monkeypatch.setattr(issue_tab, "fetch_issues", fake_fetch)
-        monkeypatch.setattr(issue_tab, "default_project_id", "demo")
-
-        state = TuiState()
-        state.page_size = 10
-        issue_tab.fetch_issues_with_filter(state, offset=0)
-
-        assert captured["status_id"] is None
-        assert captured["assigned_to"] is None
-
-
-class TestReloadWithFilter:
-    """reload_with_filter()はoffset/cursorをリセットしてフィルタで再取得する"""
-
-    def test_resets_offset_cursor_and_fetches(self, monkeypatch):
-        """offset=0 で再取得し、cursor も 0 に戻す"""
-        monkeypatch.setattr(
-            issue_tab,
-            "fetch_issues",
-            lambda **kwargs: [{"id": 1, "subject": "filtered"}],
-        )
-        monkeypatch.setattr(issue_tab, "default_project_id", "demo")
-
-        state = TuiState()
-        state.page_size = 20
-        state.issue_tab.offset = 100
-        state.issue_tab.cursor = 5
-        state.issue_tab.filter = IssueFilter(
-            status_id="closed", status_label="closed のみ"
-        )
-
-        issue_tab.reload_with_filter(state)
-
-        assert state.issue_tab.offset == 0
-        assert state.issue_tab.cursor == 0
-        assert state.issue_tab.issues == [{"id": 1, "subject": "filtered"}]


### PR DESCRIPTION
## Summary
- TUI のイシュータブで `f` キーを押すと、ステータス・担当者の2項目をサーバーサイドフィルタとして指定できる floating window を表示
- 1ウインドウ内に両セクションの選択肢を縦に並べ、`Tab/h/l` で列切替・`j/k` で項目移動・`Enter` で適用・`c` で全クリア・`Esc/f` で閉じる
- アクティブなフィルタはステータスラインに `[status=... assignee=...]` 形式で表示（フィルタ未設定時は非表示）
- フィルタ条件はセッション中のみ保持

## 構造
- `IssueFilter` (フィルタ条件) と `FilterModalState` (modal の表示・選択肢キャッシュ・カーソル) を分離し、いずれも `IssueTabState` 配下に配置 (`state.issue_tab.filter` / `state.issue_tab.filter_modal`)
- `TuiState` 直下に新フィールドを増やさず、issue タブ関連の状態を `state.issue_tab.*` に集約
- pytest の `conftest.py` を入れ子 class の docstring 連結に対応させ、`TestIssueFilter > TestIsActive > test_*` のような階層的なテスト名表示が可能に

## Commits
- `b686409` [feat] f キーでイシューフィルタの floating window を追加
- `6fe6efb` [refactor] フィルタ modal の状態を FilterModalState に集約
- `9412975` [update] 引数の受け渡しだけのテストを削除
- `da2fe79` [refactor] IssueFilter のテストを TestIssueFilter の入れ子クラスに整理
- `bfba3ef` [refactor] pytest テスト名の docstring 連結を多階層 class に対応

## Test plan
- [ ] `task check` (format / lint / typecheck / test 141件) が pass
- [x] `redi --tui` で `f` を押してフィルタ modal が開く
- [x] ステータスを `closed のみ` などに変えて Enter を押すと、一覧が再取得される
- [x] 担当者を `自分` に変えて Enter を押すと、自分担当のみに絞られる
- [x] `c` でフィルタが全クリアされ、デフォルトの open のみ表示に戻る
- [x] フィルタ適用中はステータスラインに `[status=... assignee=...]` が表示される
- [x] `Esc` / `f` で modal が閉じる
- [x] modal を開いた状態で `?` ヘルプや検索 (`/`) は反応しない（モード分離）
