### PR TITLE
[feat] config update/create で --language を指定可能にする #116 

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ redi config create <profile_name> --url <url> --api_key <key> # create new profi
 redi config create <profile_name> --url <url> --api_key <key> --set_default
 redi config update --default_profile <profile_name> # switch profile
 redi config update <profile_name> --editor nvim # update profile
+redi config update --language ja # switch language ("en" or "ja")
 redi --profile <profile_name> issue # temporarily switch profile for this command
 
 # project (alias: p)

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -2,6 +2,7 @@ import argparse
 
 from redi.cli._common import resolve_alias
 from redi.config import (
+    SUPPORTED_LANGUAGES,
     create_profile,
     set_default_profile,
     show_config,
@@ -33,6 +34,11 @@ def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
         "--wiki_project_id", help=messages.arg_help_config_set_wiki_project_id
     )
     c_update_parser.add_argument("--editor", help=messages.arg_help_config_set_editor)
+    c_update_parser.add_argument(
+        "--language",
+        choices=SUPPORTED_LANGUAGES,
+        help=messages.arg_help_config_set_language,
+    )
     c_update_parser.add_argument("--api_key", help=messages.arg_help_config_set_api_key)
     c_update_parser.add_argument("--url", help=messages.arg_help_config_set_url)
     c_update_parser.add_argument(
@@ -54,6 +60,11 @@ def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     c_create_parser.add_argument("--editor", help=messages.arg_help_config_editor)
     c_create_parser.add_argument(
+        "--language",
+        choices=SUPPORTED_LANGUAGES,
+        help=messages.arg_help_config_language,
+    )
+    c_create_parser.add_argument(
         "--set_default",
         action="store_true",
         help=messages.arg_help_config_set_default_flag,
@@ -70,6 +81,7 @@ def handle_config(args: argparse.Namespace) -> None:
             default_project_id=args.project_id,
             wiki_project_id=args.wiki_project_id,
             editor=args.editor,
+            language=args.language,
         )
         if not result.created:
             exit(1)
@@ -106,6 +118,10 @@ def handle_config(args: argparse.Namespace) -> None:
     if args.editor:
         update_config("editor", args.editor, profile)
         print(messages.editor_set.format(value=args.editor, suffix=profile_suffix))
+        updated = True
+    if args.language:
+        update_config("language", args.language, profile)
+        print(messages.language_set.format(value=args.language, suffix=profile_suffix))
         updated = True
     if args.api_key:
         update_config("redmine_api_key", args.api_key, profile)

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -9,6 +9,8 @@ from tomlkit.items import Table
 
 CONFIG_PATH = Path.home() / ".config" / "redi" / "config.toml"
 
+SUPPORTED_LANGUAGES = ("en", "ja")
+
 _default_config = {
     "redmine_url": "",
     "redmine_api_key": "",
@@ -126,6 +128,7 @@ def create_profile(
     default_project_id: str | None = None,
     wiki_project_id: str | None = None,
     editor: str | None = None,
+    language: str | None = None,
     config_path: Path | None = None,
 ) -> CreateProfileResult:
     path = config_path or CONFIG_PATH
@@ -153,6 +156,8 @@ def create_profile(
         table["wiki_project_id"] = wiki_project_id
     if editor is not None:
         table["editor"] = editor
+    if language is not None:
+        table["language"] = language
     doc[profile_name] = table
 
     profile_names = [k for k, v in doc.items() if isinstance(v, Table)]

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -19,6 +19,8 @@ class MessagesProto(Protocol):
     """default_project_id を設定。{value}, {suffix}"""
     editor_set: str
     """editor を設定。{value}, {suffix}"""
+    language_set: str
+    """language を設定。{value}, {suffix}"""
     redmine_api_key_set: str
     """redmine_api_key を設定。{suffix}"""
     redmine_url_set: str
@@ -675,6 +677,7 @@ class MessagesProto(Protocol):
     arg_help_config_set_default_project_id: str
     arg_help_config_set_wiki_project_id: str
     arg_help_config_set_editor: str
+    arg_help_config_set_language: str
     arg_help_config_set_api_key: str
     arg_help_config_set_url: str
     arg_help_config_set_default_profile: str
@@ -685,6 +688,7 @@ class MessagesProto(Protocol):
     arg_help_config_default_project_id: str
     arg_help_config_wiki_project_id: str
     arg_help_config_editor: str
+    arg_help_config_language: str
     arg_help_config_set_default_flag: str
 
     # ---- argparse helps (init) ----

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -8,6 +8,7 @@ class En(MessagesProto):
     default_profile_set = "Set default_profile to {name}"
     default_project_id_set = "Set default_project_id to {value}{suffix}"
     editor_set = "Set editor to {value}{suffix}"
+    language_set = "Set language to {value}{suffix}"
     redmine_api_key_set = "Set redmine_api_key{suffix}"
     redmine_url_set = "Set redmine_url to {value}{suffix}"
     wiki_project_id_set = "Set wiki_project_id to {value}{suffix}"
@@ -543,6 +544,7 @@ class En(MessagesProto):
     arg_help_config_set_default_project_id = "Set default project ID"
     arg_help_config_set_wiki_project_id = "Set wiki project ID"
     arg_help_config_set_editor = "Set editor"
+    arg_help_config_set_language = "Set language (en or ja)"
     arg_help_config_set_api_key = "Set Redmine API key"
     arg_help_config_set_url = "Set Redmine URL"
     arg_help_config_set_default_profile = "Set default profile"
@@ -553,6 +555,7 @@ class En(MessagesProto):
     arg_help_config_default_project_id = "Default project ID"
     arg_help_config_wiki_project_id = "Wiki project ID"
     arg_help_config_editor = "Editor"
+    arg_help_config_language = "Language (en or ja)"
     arg_help_config_set_default_flag = "Set the created profile as default_profile"
 
     # ---- argparse helps (init) ----

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -10,6 +10,7 @@ class Ja(MessagesProto):
     default_profile_set = "default_profileを {name} に設定しました"
     default_project_id_set = "default_project_idを {value} に設定しました{suffix}"
     editor_set = "editorを {value} に設定しました{suffix}"
+    language_set = "languageを {value} に設定しました{suffix}"
     redmine_api_key_set = "redmine_api_keyを設定しました{suffix}"
     redmine_url_set = "redmine_urlを {value} に設定しました{suffix}"
     wiki_project_id_set = "wiki_project_idを {value} に設定しました{suffix}"
@@ -551,6 +552,7 @@ class Ja(MessagesProto):
     arg_help_config_set_default_project_id = "デフォルトプロジェクトIDを設定"
     arg_help_config_set_wiki_project_id = "Wiki用プロジェクトIDを設定"
     arg_help_config_set_editor = "エディタを設定"
+    arg_help_config_set_language = "言語を設定 (en または ja)"
     arg_help_config_set_api_key = "Redmine APIキーを設定"
     arg_help_config_set_url = "Redmine URLを設定"
     arg_help_config_set_default_profile = "デフォルトプロファイルを設定"
@@ -561,6 +563,7 @@ class Ja(MessagesProto):
     arg_help_config_default_project_id = "デフォルトプロジェクトID"
     arg_help_config_wiki_project_id = "Wiki用プロジェクトID"
     arg_help_config_editor = "エディタ"
+    arg_help_config_language = "言語 (en または ja)"
     arg_help_config_set_default_flag = "作成したプロファイルをdefault_profileに設定"
 
     # ---- argparse helps (init) ----

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -20,6 +20,7 @@ class TestCreateProfile:
             default_project_id="1",
             wiki_project_id="2",
             editor="nvim",
+            language="ja",
             config_path=config_path,
         )
 
@@ -32,6 +33,7 @@ class TestCreateProfile:
             "default_project_id": "1",
             "wiki_project_id": "2",
             "editor": "nvim",
+            "language": "ja",
         }
 
     def test_skips_unspecified_keys(self, tmp_path):
@@ -186,6 +188,25 @@ class TestUpdateConfig:
         with open(config_path, "rb") as f:
             doc = tomllib.load(f)
         assert doc["main"]["redmine_url"] == "https://redmine.example.com/new"
+
+    def test_updates_language(self, tmp_path):
+        """language キーを更新できる"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://redmine.example.com"
+            language = "en"
+        """)
+        )
+
+        config.update_config("language", "ja", config_path=config_path)
+
+        with open(config_path, "rb") as f:
+            doc = tomllib.load(f)
+        assert doc["main"]["language"] == "ja"
 
     def test_updates_specified_profile(self, tmp_path):
         """profile引数で指定したプロファイルを更新する"""


### PR DESCRIPTION
resolve #116 

## Summary
- `redi config update --language <en|ja>` / `redi config create --language <en|ja>` で language を設定できるようにする
- argparse の `choices=("en", "ja")` で値を制限し、不正値は argparse のエラーで弾く
- `create_profile()` が `language` 引数を受け取り、toml に書き込めるようにする
- README に `redi config update --language ja` の例を追記

## Test plan
- [x] `uv run task check` が通る
- [x] `redi config update --help` / `redi config create --help` で `--language {en,ja}` が表示される
- [x] `redi config update --language ja` 実行で profile に `language = "ja"` が書き込まれる
- [x] `redi config update --language fr` のような未対応値は argparse のエラーで拒否される