### PR TITLE
[fix] 言語変更時に変更後の言語で結果メッセージを出力 (refs #119 )

### DIFF
--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -8,7 +8,7 @@ from redi.config import (
     show_config,
     update_config,
 )
-from redi.i18n import messages
+from redi.i18n import messages, select_messages
 
 
 def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
@@ -121,7 +121,12 @@ def handle_config(args: argparse.Namespace) -> None:
         updated = True
     if args.language:
         update_config("language", args.language, profile)
-        print(messages.language_set.format(value=args.language, suffix=profile_suffix))
+        new_lang_messages = select_messages(args.language)
+        print(
+            new_lang_messages.language_set.format(
+                value=args.language, suffix=profile_suffix
+            )
+        )
         updated = True
     if args.api_key:
         update_config("redmine_api_key", args.api_key, profile)

--- a/src/redi/i18n/__init__.py
+++ b/src/redi/i18n/__init__.py
@@ -5,10 +5,10 @@ from .en import En
 from .ja import Ja
 
 
-def _select(lang: str) -> MessagesProto:
+def select_messages(lang: str) -> MessagesProto:
     if lang == "ja":
         return Ja()
     return En()
 
 
-messages: MessagesProto = _select(config.language)
+messages: MessagesProto = select_messages(config.language)

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -32,20 +32,20 @@ class TestPlaceholdersParity:
         assert not mismatched, mismatched
 
 
-class TestSelect:
-    """_select() は config.language に応じて Ja / En を返す"""
+class TestSelectMessages:
+    """select_messages() は config.language に応じて Ja / En を返す"""
 
     def test_returns_ja_for_ja(self):
         """language='ja' のとき Ja を返す"""
-        assert isinstance(i18n._select("ja"), Ja)
+        assert isinstance(i18n.select_messages("ja"), Ja)
 
     def test_returns_en_for_en(self):
         """language='en' のとき En を返す"""
-        assert isinstance(i18n._select("en"), En)
+        assert isinstance(i18n.select_messages("en"), En)
 
     def test_falls_back_to_en_for_unknown(self):
         """未知の言語コードは default(en) にフォールバックする"""
-        assert isinstance(i18n._select("zz"), En)
+        assert isinstance(i18n.select_messages("zz"), En)
 
 
 class TestFormat:


### PR DESCRIPTION
resolve #119 

## Summary
- `redi config update --language <lang>` で切り替え結果の `language を ... に設定しました` が旧言語のまま表示されていた問題を修正
- `i18n._select` を公開関数 `select_messages` にリネームし、`handle_config` で更新後の言語の messages インスタンスを使ってメッセージを出力するようにした

## Test plan
- [x] `task check` がパスする
- [x] `redi config update --language en` を ja プロファイルで実行すると `Set language to en...` が表示される
- [x] `redi config update --language ja` を en プロファイルで実行すると `languageを ja に設定しました...` が表示される