### PR TITLE
[feat] TUI の右ペイン (preview) をスクロール可能にする (refs #97 )

### DIFF
--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -848,6 +848,8 @@ class MessagesProto(Protocol):
     tui_help_jump_to_issue_n: str
     tui_help_prev_next_page: str
     tui_help_switch_tab: str
+    tui_help_preview_scroll_line: str
+    tui_help_preview_scroll_half_page: str
     tui_help_start_search: str
     tui_help_next_prev_match: str
     tui_help_filter_status_assignee: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -722,6 +722,8 @@ class En(MessagesProto):
     tui_help_jump_to_issue_n = "Jump to issue #N"
     tui_help_prev_next_page = "Previous / next page"
     tui_help_switch_tab = "Switch tab (next / prev)"
+    tui_help_preview_scroll_line = "Scroll preview up / down by 1 line"
+    tui_help_preview_scroll_half_page = "Scroll preview up / down by half page"
     tui_help_start_search = "Start search"
     tui_help_next_prev_match = "Next / previous match"
     tui_help_filter_status_assignee = "Filter by status/assignee (floating)"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -730,6 +730,8 @@ class Ja(MessagesProto):
     tui_help_jump_to_issue_n = "#N のイシューへジャンプ"
     tui_help_prev_next_page = "前ページ / 次ページ"
     tui_help_switch_tab = "タブ切替 (次 / 前)"
+    tui_help_preview_scroll_line = "プレビューを 1 行スクロール (上 / 下)"
+    tui_help_preview_scroll_half_page = "プレビューを半ページスクロール (上 / 下)"
     tui_help_start_search = "検索開始"
     tui_help_next_prev_match = "次 / 前の検索結果"
     tui_help_filter_status_assignee = "ステータス/担当者でフィルタ (フローティング)"

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -313,9 +313,21 @@ def run_issue_tui(
         state.number_buffer = ""
         state.flash_message = None
 
+    def _reset_preview_scroll() -> None:
+        state.preview_scroll = 0
+
+    def _scroll_preview(delta: int) -> None:
+        new_scroll = max(0, state.preview_scroll + delta)
+        # 最低 1 行は表示が残るように、クランプは「論理行数 - 1」まで。
+        # wrap_lines=True で実視覚行は logical を超え得るが、簡易クランプとして許容。
+        total = _count_logical_lines(TABS[state.tab].render_preview(state))
+        new_scroll = min(new_scroll, max(0, total - 1))
+        state.preview_scroll = new_scroll
+
     @kb.add("tab", filter=normal_mode)
     def _(event):
         _clear_temporary_state()
+        _reset_preview_scroll()
         tab_keys = list(TABS.keys())
         idx = tab_keys.index(state.tab)
         state.tab = tab_keys[(idx + 1) % len(tab_keys)]
@@ -324,6 +336,7 @@ def run_issue_tui(
     @kb.add("s-tab", filter=normal_mode)
     def _(event):
         _clear_temporary_state()
+        _reset_preview_scroll()
         tab_keys = list(TABS.keys())
         idx = tab_keys.index(state.tab)
         state.tab = tab_keys[(idx - 1) % len(tab_keys)]
@@ -334,6 +347,7 @@ def run_issue_tui(
     @kb.add("c-p", filter=normal_mode)
     def _(event):
         _clear_temporary_state()
+        _reset_preview_scroll()
         TABS[state.tab].on_up(state)
 
     @kb.add("down", filter=normal_mode)
@@ -341,11 +355,13 @@ def run_issue_tui(
     @kb.add("c-n", filter=normal_mode)
     def _(event):
         _clear_temporary_state()
+        _reset_preview_scroll()
         TABS[state.tab].on_down(state)
 
     @kb.add("g", "g", filter=normal_mode)
     def _(event):
         _clear_temporary_state()
+        _reset_preview_scroll()
         TABS[state.tab].on_goto_top(state)
 
     @kb.add("G", filter=normal_mode)
@@ -356,9 +372,11 @@ def run_issue_tui(
             except ValueError:
                 target_id = None
             _clear_temporary_state()
+            _reset_preview_scroll()
             if target_id is not None:
                 TABS[state.tab].on_jump_to_id(state, target_id)
         else:
+            _reset_preview_scroll()
             TABS[state.tab].on_goto_bottom(state)
 
     for digit in "0123456789":
@@ -374,13 +392,31 @@ def run_issue_tui(
     @kb.add("l", filter=normal_mode)
     def _(event):
         _clear_temporary_state()
+        _reset_preview_scroll()
         TABS[state.tab].on_page_forward(state)
 
     @kb.add("left", filter=normal_mode)
     @kb.add("h", filter=normal_mode)
     def _(event):
         _clear_temporary_state()
+        _reset_preview_scroll()
         TABS[state.tab].on_page_backward(state)
+
+    @kb.add("c-e", filter=normal_mode)
+    def _(event):
+        _scroll_preview(1)
+
+    @kb.add("c-y", filter=normal_mode)
+    def _(event):
+        _scroll_preview(-1)
+
+    @kb.add("c-d", filter=normal_mode)
+    def _(event):
+        _scroll_preview(max(1, state.page_size // 2))
+
+    @kb.add("c-u", filter=normal_mode)
+    def _(event):
+        _scroll_preview(-max(1, state.page_size // 2))
 
     @kb.add("enter", filter=normal_mode)
     def _(event):
@@ -416,6 +452,7 @@ def run_issue_tui(
     def _(event):
         _clear_temporary_state()
         if state.search_query:
+            _reset_preview_scroll()
             TABS[state.tab].on_search(state, state.search_query, forward=True)
             return
         result = TABS[state.tab].on_action_key(state, "n")
@@ -426,6 +463,7 @@ def run_issue_tui(
     def _(event):
         _clear_temporary_state()
         if state.search_query:
+            _reset_preview_scroll()
             TABS[state.tab].on_search(state, state.search_query, forward=False)
 
     @kb.add("/", filter=normal_mode)
@@ -540,6 +578,7 @@ def run_issue_tui(
             api_val, label = modal.assignee_choices[modal.assignee_cursor]
             state.issue_tab.filter.assigned_to_id = api_val
             state.issue_tab.filter.assigned_to_label = label
+        _reset_preview_scroll()
         reload_with_filter(state)
 
     @kb.add("c", filter=filter_mode)
@@ -548,6 +587,7 @@ def run_issue_tui(
         modal = state.issue_tab.filter_modal
         modal.status_cursor = 0
         modal.assignee_cursor = 0
+        _reset_preview_scroll()
         reload_with_filter(state)
 
     @kb.add("escape", filter=filter_mode)
@@ -559,6 +599,7 @@ def run_issue_tui(
     @kb.add("enter", filter=search_mode)
     def _(event):
         if state.search_query:
+            _reset_preview_scroll()
             TABS[state.tab].on_search(state, state.search_query)
         state.search_mode = False
 
@@ -581,6 +622,11 @@ def run_issue_tui(
         if data and len(data) == 1 and data.isprintable():
             state.search_query += data
 
+    preview_window = Window(
+        FormattedTextControl(lambda: _render_preview_current(state)),
+        wrap_lines=True,
+    )
+
     main_layout = HSplit(
         [
             Window(
@@ -600,10 +646,7 @@ def run_issue_tui(
                         )
                     ),
                     Window(width=1, char="│"),
-                    Window(
-                        FormattedTextControl(lambda: _render_preview_current(state)),
-                        wrap_lines=True,
-                    ),
+                    preview_window,
                 ]
             ),
             Window(FormattedTextControl(lambda: _render_status(state)), height=1),

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -102,8 +102,48 @@ def _render_list_current(state: TuiState) -> Renderable:
     return TABS[state.tab].render_list(state)
 
 
+def _skip_lines(parts: Renderable, n: int) -> Renderable:
+    """`parts` の先頭から論理行 (newline 区切り) を `n` 個分捨てて残りを返す。
+
+    prompt_toolkit の `Window` は `wrap_lines=True` 時に `get_vertical_scroll`
+    を参照しないため、レンダー結果側で先頭をスライスしてプレビューのスクロール
+    を実現する。
+    """
+    if n <= 0:
+        return list(parts)
+    result: Renderable = []
+    seen = 0
+    started = False
+    for style, text in parts:
+        if started:
+            result.append((style, text))
+            continue
+        nl_in_text = text.count("\n")
+        if seen + nl_in_text < n:
+            seen += nl_in_text
+            continue
+        need = n - seen
+        idx = -1
+        for _ in range(need):
+            idx = text.find("\n", idx + 1)
+        rest = text[idx + 1 :]
+        if rest:
+            result.append((style, rest))
+        started = True
+    return result
+
+
+def _count_logical_lines(parts: Renderable) -> int:
+    if not parts:
+        return 0
+    return sum(text.count("\n") for _, text in parts) + 1
+
+
 def _render_preview_current(state: TuiState) -> Renderable:
-    return TABS[state.tab].render_preview(state)
+    parts = TABS[state.tab].render_preview(state)
+    if state.preview_scroll <= 0:
+        return parts
+    return _skip_lines(parts, state.preview_scroll)
 
 
 def _build_status_choices() -> list[tuple[str | None, str]]:

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -246,6 +246,8 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  <N>G", messages.tui_help_jump_to_issue_n),
     ("  ←/h / →/l", messages.tui_help_prev_next_page),
     ("  Tab / Shift+Tab", messages.tui_help_switch_tab),
+    ("  Ctrl+E / Ctrl+Y", messages.tui_help_preview_scroll_line),
+    ("  Ctrl+D / Ctrl+U", messages.tui_help_preview_scroll_half_page),
     (messages.tui_help_section_search, ""),
     ("  /", messages.tui_help_start_search),
     ("  n / N", messages.tui_help_next_prev_match),

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -124,3 +124,6 @@ class TuiState:
     flash_message: str | None = None
     # ? でヘルプの floating window を表示しているかどうか。
     show_help: bool = False
+    # 右ペイン (preview) のスクロール位置 (先頭からの行数)。
+    # カーソル移動・タブ切り替え時に 0 に戻す。
+    preview_scroll: int = 0

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -230,6 +230,8 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  ↓/j/Ctrl+N", messages.tui_help_move_down),
     ("  gg / G", messages.tui_help_goto_top_bottom),
     ("  Tab / Shift+Tab", messages.tui_help_switch_tab),
+    ("  Ctrl+E / Ctrl+Y", messages.tui_help_preview_scroll_line),
+    ("  Ctrl+D / Ctrl+U", messages.tui_help_preview_scroll_half_page),
     (messages.tui_help_section_search, ""),
     ("  /", messages.tui_help_start_search),
     ("  n / N", messages.tui_help_next_prev_match),

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -202,6 +202,8 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  ↓/j/Ctrl+N", messages.tui_help_move_down),
     ("  gg / G", messages.tui_help_goto_top_bottom),
     ("  Tab / Shift+Tab", messages.tui_help_switch_tab),
+    ("  Ctrl+E / Ctrl+Y", messages.tui_help_preview_scroll_line),
+    ("  Ctrl+D / Ctrl+U", messages.tui_help_preview_scroll_half_page),
     (messages.tui_help_section_search, ""),
     ("  /", messages.tui_help_start_search),
     ("  n / N", messages.tui_help_next_prev_match),


### PR DESCRIPTION
## Summary
- TUI の右ペイン (preview) を vim 風キーでスクロールできるようにする (`Ctrl+E`/`Ctrl+Y` で 1 行、`Ctrl+D`/`Ctrl+U` で半ページ)
- `wrap_lines=True` の `Window` は `get_vertical_scroll` を参照しないため、レンダー結果側 (`_skip_lines`) で先頭の論理行を捨てる方式で実現
- カーソル移動・タブ切替・検索ジャンプ・フィルタ確定で `preview_scroll` を 0 にリセット

## Test plan
- [x] `task check` (format / lint / typecheck / test) がローカルで通る
- [x] `redi --tui` でイシュー一覧を開き、本文が長いイシューで `Ctrl+E` / `Ctrl+Y` / `Ctrl+D` / `Ctrl+U` がそれぞれ期待通りスクロールする
- [x] j/k でカーソルを動かすと preview スクロール位置が先頭にリセットされる
- [x] Tab / Shift+Tab で wiki / 作業時間タブに切り替えてもスクロールが効く
- [x] `?` のヘルプに `Ctrl+E / Ctrl+Y` と `Ctrl+D / Ctrl+U` の行が表示される (issues / wiki / time_entries 各タブ)
- [x] 言語を `en` に切り替えても英語のヘルプ文言で同じキーが表示される