### PR TITLE
E2Eテストの作成/CIでの実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,29 @@ jobs:
 
       - name: Test
         run: uv run pytest
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Install redi as a tool
+        run: |
+          uv tool install -e .
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        # https://docs.github.com/ja/actions/reference/workflows-and-actions/workflow-commands#example-of-adding-a-system-path
+
+      - name: Initialize Redmine for test
+        run: ./script/init-redmine.sh
+
+      - name: Run e2e tests
+        run: uv run pytest -m e2e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,9 @@ dev = [
 
 [tool.uv.build-backend]
 module-name = "redi"
+
+[tool.pytest.ini_options]
+markers = [
+  "e2e: E2E test (needs Redmine initialized by script/init-redmine.sh)",
+]
+addopts = "-m 'not e2e'"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -30,9 +30,14 @@ tasks:
       - uv run ty check
 
   test:
-    desc: run tests
+    desc: run tests (except E2E)
     cmds:
       - uv run pytest -v
+
+  test:e2e:
+    desc: run E2E tests
+    cmds:
+      - uv run pytest -m e2e
 
   release:
     desc: release next version

--- a/tests/e2e/test_project_cli.py
+++ b/tests/e2e/test_project_cli.py
@@ -1,0 +1,20 @@
+import subprocess
+
+import pytest
+
+
+@pytest.mark.e2e
+class TestProjectView:
+    """`redi project view <id>` は指定したプロジェクトの情報を表示する"""
+
+    def test_succeeds_for_existing_project_id(self):
+        """init-redmine.sh で作成された id=1 のプロジェクト(reditest)を表示すると exit 0 で成功する"""
+        result = subprocess.run(
+            ["redi", "project", "view", "1"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "reditest" in result.stdout


### PR DESCRIPTION
- **[add] e2e のマーカーを追加; uv run pytest -m e2e でローカルで成功**
- **[add] e2e job**
