### PR TITLE
[add] redi の各コマンドの e2e テストを追加

### DIFF
--- a/tests/e2e/test_attachment_cli.py
+++ b/tests/e2e/test_attachment_cli.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_issue_with_attachment(tmp_path: Path, content: str) -> tuple[str, str]:
+    """ファイルを添付した issue を作成し (issue_id, attachment_id) を返す。"""
+    subject = f"e2e attachment {unique_identifier('att')}"
+    create_result = run_redi(
+        "issue", "create", subject, "--tracker_id", "2", "--description", "att test"
+    )
+    assert create_result.returncode == 0, (
+        f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
+    )
+    issue_id = create_result.stdout.strip().rsplit("/", 1)[-1]
+    assert issue_id.isdigit(), f"想定外の create 出力:\n{create_result.stdout}"
+
+    file_path = tmp_path / f"{unique_identifier('attfile')}.txt"
+    file_path.write_text(content)
+
+    update_result = run_redi(
+        "issue", "update", issue_id, "--attach", str(file_path), "--notes", "attaching"
+    )
+    assert update_result.returncode == 0, (
+        f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+    )
+
+    view_result = run_redi(
+        "issue", "view", issue_id, "--include", "attachments", "--full"
+    )
+    assert view_result.returncode == 0, (
+        f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+    )
+    parsed = json.loads(view_result.stdout)
+    attachments = parsed.get("attachments") or []
+    assert attachments, f"attachment が紐付いていない:\n{view_result.stdout}"
+    return issue_id, str(attachments[0]["id"])
+
+
+@pytest.mark.e2e
+class TestAttachmentView:
+    """`redi attachment view <id>` は指定した添付の情報を表示する"""
+
+    def test_succeeds_for_existing_attachment(self, tmp_path):
+        """issue に添付したファイルの id を view すると filename が含まれる"""
+        _, attachment_id = _create_issue_with_attachment(tmp_path, "view test content")
+
+        result = run_redi("attachment", "view", attachment_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert ".txt" in result.stdout
+
+
+@pytest.mark.e2e
+class TestAttachmentUpdate:
+    """`redi attachment update` は添付ファイルの description を更新する"""
+
+    def test_updates_then_view_shows_new_description(self, tmp_path):
+        """update 後に view すると更新後の description が含まれる"""
+        _, attachment_id = _create_issue_with_attachment(tmp_path, "update test content")
+        new_description = f"e2e desc {unique_identifier('attdesc')}"
+
+        update_result = run_redi(
+            "attachment", "update", attachment_id, "-d", new_description
+        )
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("attachment", "view", attachment_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert new_description in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestAttachmentDelete:
+    """`redi attachment delete` は指定した添付ファイルを削除する"""
+
+    def test_deletes_then_view_fails(self, tmp_path):
+        """delete 後に view が失敗する"""
+        _, attachment_id = _create_issue_with_attachment(tmp_path, "delete test content")
+
+        delete_result = run_redi("attachment", "delete", attachment_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("attachment", "view", attachment_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Attachment not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_attachment_cli.py
+++ b/tests/e2e/test_attachment_cli.py
@@ -61,7 +61,9 @@ class TestAttachmentUpdate:
 
     def test_updates_then_view_shows_new_description(self, tmp_path):
         """update 後に view すると更新後の description が含まれる"""
-        _, attachment_id = _create_issue_with_attachment(tmp_path, "update test content")
+        _, attachment_id = _create_issue_with_attachment(
+            tmp_path, "update test content"
+        )
         new_description = f"e2e desc {unique_identifier('attdesc')}"
 
         update_result = run_redi(
@@ -84,7 +86,9 @@ class TestAttachmentDelete:
 
     def test_deletes_then_view_fails(self, tmp_path):
         """delete 後に view が失敗する"""
-        _, attachment_id = _create_issue_with_attachment(tmp_path, "delete test content")
+        _, attachment_id = _create_issue_with_attachment(
+            tmp_path, "delete test content"
+        )
 
         delete_result = run_redi("attachment", "delete", attachment_id, "-y")
         assert delete_result.returncode == 0, (

--- a/tests/e2e/test_custom_field_cli.py
+++ b/tests/e2e/test_custom_field_cli.py
@@ -1,0 +1,16 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestCustomFieldList:
+    """`redi custom_field` はカスタムフィールド一覧を表示する"""
+
+    def test_lists_init_custom_field(self):
+        """init-redmine.sh で作成された 'バージョン' カスタムフィールドが出力に含まれる"""
+        result = run_redi("custom_field")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "バージョン" in result.stdout

--- a/tests/e2e/test_document_category_cli.py
+++ b/tests/e2e/test_document_category_cli.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestDocumentCategoryList:
+    """`redi document_category` は文書カテゴリ一覧を表示する"""
+
+    def test_lists_default_categories(self):
+        """init-redmine.sh で読み込まれた既定の文書カテゴリ(ユーザー文書/技術文書)が出力に含まれる"""
+        result = run_redi("document_category")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("ユーザー文書", "技術文書"):
+            assert name in result.stdout, (
+                f"既定の文書カテゴリ '{name}' が出力に見当たらない\n{result.stdout}"
+            )

--- a/tests/e2e/test_file_cli.py
+++ b/tests/e2e/test_file_cli.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_project_for_file_test() -> str:
+    """file モジュールが有効なプロジェクトを作成し identifier を返す。
+
+    init-redmine.sh で作成される reditest プロジェクトは files モジュールが
+    無効なため、新規プロジェクトを使う必要がある(403 になる)。
+    """
+    identifier = unique_identifier("e2e-file")
+    name = f"e2e file {identifier}"
+    result = run_redi("project", "create", name, identifier)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    return identifier
+
+
+def _upload_file(project_identifier: str, file_path: Path) -> None:
+    result = run_redi("file", "create", str(file_path), "-p", project_identifier)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.e2e
+class TestFileList:
+    """`redi file list` はプロジェクトのファイル一覧を表示する"""
+
+    def test_lists_uploaded_file(self, tmp_path):
+        """事前 upload したファイル名が list に含まれる (create は正しい前提)"""
+        project_identifier = _create_project_for_file_test()
+        filename = f"{unique_identifier('listfile')}.txt"
+        file_path = tmp_path / filename
+        file_path.write_text("file list e2e content")
+        _upload_file(project_identifier, file_path)
+
+        result = run_redi("file", "-p", project_identifier, "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert filename in result.stdout
+
+
+@pytest.mark.e2e
+class TestFileCreate:
+    """`redi file create` はファイルをプロジェクトにアップロードする"""
+
+    def test_creates_then_list_shows_it(self, tmp_path):
+        """upload したファイルが list で取得できる (list は正しい前提)"""
+        project_identifier = _create_project_for_file_test()
+        filename = f"{unique_identifier('createfile')}.txt"
+        file_path = tmp_path / filename
+        file_path.write_text("file create e2e content")
+
+        upload_result = run_redi(
+            "file", "create", str(file_path), "-p", project_identifier
+        )
+        assert upload_result.returncode == 0, (
+            f"stdout:\n{upload_result.stdout}\nstderr:\n{upload_result.stderr}"
+        )
+
+        list_result = run_redi("file", "-p", project_identifier, "list")
+        assert list_result.returncode == 0, (
+            f"stdout:\n{list_result.stdout}\nstderr:\n{list_result.stderr}"
+        )
+        assert filename in list_result.stdout

--- a/tests/e2e/test_file_cli.py
+++ b/tests/e2e/test_file_cli.py
@@ -14,17 +14,13 @@ def _create_project_for_file_test() -> str:
     identifier = unique_identifier("e2e-file")
     name = f"e2e file {identifier}"
     result = run_redi("project", "create", name, identifier)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     return identifier
 
 
 def _upload_file(project_identifier: str, file_path: Path) -> None:
     result = run_redi("file", "create", str(file_path), "-p", project_identifier)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_group_cli.py
+++ b/tests/e2e/test_group_cli.py
@@ -6,9 +6,7 @@ from tests.e2e.utils import run_redi, unique_identifier
 def _create_group(name: str) -> str:
     """group を作成し group_id を返す。"""
     result = run_redi("group", "create", name)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     # 出力例: "Created group: 18 test-group-1 http://localhost:3000/groups/18"
     group_id = result.stdout.strip().split()[2]
     assert group_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"

--- a/tests/e2e/test_group_cli.py
+++ b/tests/e2e/test_group_cli.py
@@ -1,0 +1,110 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_group(name: str) -> str:
+    """group を作成し group_id を返す。"""
+    result = run_redi("group", "create", name)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # 出力例: "Created group: 18 test-group-1 http://localhost:3000/groups/18"
+    group_id = result.stdout.strip().split()[2]
+    assert group_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return group_id
+
+
+@pytest.mark.e2e
+class TestGroupList:
+    """`redi group list` はグループ一覧を表示する"""
+
+    def test_lists_created_group(self):
+        """事前 create した name が list に含まれる (create は正しい前提)"""
+        name = f"e2e-grp-list-{unique_identifier('list')}"
+        group_id = _create_group(name)
+
+        result = run_redi("group", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert name in result.stdout
+        assert group_id in result.stdout
+
+
+@pytest.mark.e2e
+class TestGroupView:
+    """`redi group view <id>` は指定したグループの情報を表示する"""
+
+    def test_succeeds_for_created_group(self):
+        """create した group を view すると name が含まれる (create は正しい前提)"""
+        name = f"e2e-grp-view-{unique_identifier('view')}"
+        group_id = _create_group(name)
+
+        result = run_redi("group", "view", group_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert name in result.stdout
+
+
+@pytest.mark.e2e
+class TestGroupCreate:
+    """`redi group create` は新しいグループを作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した group が view で取得できる (view は正しい前提)"""
+        name = f"e2e-grp-create-{unique_identifier('create')}"
+        group_id = _create_group(name)
+
+        view_result = run_redi("group", "view", group_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert name in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestGroupUpdate:
+    """`redi group update` は既存のグループを更新する"""
+
+    def test_updates_then_view_shows_new_name(self):
+        """create→update した後 view で更新後の name が確認できる (create/view は正しい前提)"""
+        original = f"e2e-grp-upd-orig-{unique_identifier('update')}"
+        updated = f"e2e-grp-upd-new-{unique_identifier('update')}"
+        group_id = _create_group(original)
+
+        update_result = run_redi("group", "update", group_id, "--name", updated)
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("group", "view", group_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert updated in view_result.stdout
+        assert original not in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestGroupDelete:
+    """`redi group delete` は指定したグループを削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        name = f"e2e-grp-del-{unique_identifier('delete')}"
+        group_id = _create_group(name)
+
+        delete_result = run_redi("group", "delete", group_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("group", "view", group_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Group not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_issue_category_cli.py
+++ b/tests/e2e/test_issue_category_cli.py
@@ -1,0 +1,112 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_category(name: str) -> str:
+    """issue category を作成し category_id を返す。"""
+    result = run_redi("issue_category", "create", name)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # 出力例: "Created category: 1 test-cat-1"
+    category_id = result.stdout.strip().split()[2]
+    assert category_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return category_id
+
+
+@pytest.mark.e2e
+class TestIssueCategoryList:
+    """`redi issue_category list` はカテゴリ一覧を表示する"""
+
+    def test_lists_created_category(self):
+        """事前 create した name が list に含まれる (create は正しい前提)"""
+        name = f"e2e-cat-list-{unique_identifier('list')}"
+        category_id = _create_category(name)
+
+        result = run_redi("issue_category", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert name in result.stdout
+        assert category_id in result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueCategoryView:
+    """`redi issue_category view <id>` は指定したカテゴリの情報を表示する"""
+
+    def test_succeeds_for_created_category(self):
+        """create した category を view すると name が含まれる (create は正しい前提)"""
+        name = f"e2e-cat-view-{unique_identifier('view')}"
+        category_id = _create_category(name)
+
+        result = run_redi("issue_category", "view", category_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert name in result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueCategoryCreate:
+    """`redi issue_category create` は新しいカテゴリを作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した category が view で取得できる (view は正しい前提)"""
+        name = f"e2e-cat-create-{unique_identifier('create')}"
+        category_id = _create_category(name)
+
+        view_result = run_redi("issue_category", "view", category_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert name in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueCategoryUpdate:
+    """`redi issue_category update` は既存のカテゴリを更新する"""
+
+    def test_updates_then_view_shows_new_name(self):
+        """create→update した後 view で更新後の name が確認できる (create/view は正しい前提)"""
+        original = f"e2e-cat-upd-orig-{unique_identifier('update')}"
+        updated = f"e2e-cat-upd-new-{unique_identifier('update')}"
+        category_id = _create_category(original)
+
+        update_result = run_redi(
+            "issue_category", "update", category_id, "--name", updated
+        )
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("issue_category", "view", category_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert updated in view_result.stdout
+        assert original not in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueCategoryDelete:
+    """`redi issue_category delete` は指定したカテゴリを削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        name = f"e2e-cat-del-{unique_identifier('delete')}"
+        category_id = _create_category(name)
+
+        delete_result = run_redi("issue_category", "delete", category_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("issue_category", "view", category_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Category not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_issue_category_cli.py
+++ b/tests/e2e/test_issue_category_cli.py
@@ -6,9 +6,7 @@ from tests.e2e.utils import run_redi, unique_identifier
 def _create_category(name: str) -> str:
     """issue category を作成し category_id を返す。"""
     result = run_redi("issue_category", "create", name)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     # 出力例: "Created category: 1 test-cat-1"
     category_id = result.stdout.strip().split()[2]
     assert category_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"

--- a/tests/e2e/test_issue_cli.py
+++ b/tests/e2e/test_issue_cli.py
@@ -12,9 +12,7 @@ def _create_issue(subject: str) -> str:
     result = run_redi(
         "issue", "create", subject, "--tracker_id", "2", "--description", "e2e desc"
     )
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     # 出力例: "Created issue: http://localhost:3000/issues/123"
     issue_id = result.stdout.strip().rsplit("/", 1)[-1]
     assert issue_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"

--- a/tests/e2e/test_issue_cli.py
+++ b/tests/e2e/test_issue_cli.py
@@ -1,0 +1,118 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_issue(subject: str) -> str:
+    """非インタラクティブに issue を作成し issue_id を返す。
+
+    bug トラッカー(id=1) は init-redmine.sh で必須カスタムフィールドが
+    設定されているので、それ以外のトラッカー(id=2 機能)を使う。
+    """
+    result = run_redi(
+        "issue", "create", subject, "--tracker_id", "2", "--description", "e2e desc"
+    )
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # 出力例: "Created issue: http://localhost:3000/issues/123"
+    issue_id = result.stdout.strip().rsplit("/", 1)[-1]
+    assert issue_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return issue_id
+
+
+@pytest.mark.e2e
+class TestIssueList:
+    """`redi issue list` は issue 一覧を表示する"""
+
+    def test_lists_created_issue(self):
+        """事前 create した subject が list に含まれる (create は正しい前提)"""
+        subject = f"e2e issue list {unique_identifier('list')}"
+        issue_id = _create_issue(subject)
+
+        result = run_redi("issue", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert issue_id in result.stdout
+        assert subject in result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueView:
+    """`redi issue view <id>` は指定した issue の情報を表示する"""
+
+    def test_succeeds_for_created_issue(self):
+        """create した issue を view すると subject が含まれる (create は正しい前提)"""
+        subject = f"e2e issue view {unique_identifier('view')}"
+        issue_id = _create_issue(subject)
+
+        result = run_redi("issue", "view", issue_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert subject in result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueCreate:
+    """`redi issue create` は新しい issue を作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した issue が view で取得できる (view は正しい前提)"""
+        subject = f"e2e issue create {unique_identifier('create')}"
+        issue_id = _create_issue(subject)
+
+        view_result = run_redi("issue", "view", issue_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert subject in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueUpdate:
+    """`redi issue update` は既存の issue を更新する"""
+
+    def test_updates_then_view_shows_new_subject(self):
+        """create→update した後 view で更新後の subject が確認できる (create/view は正しい前提)"""
+        original_subject = f"e2e issue update orig {unique_identifier('update')}"
+        updated_subject = f"e2e issue update new {unique_identifier('update')}"
+        issue_id = _create_issue(original_subject)
+
+        update_result = run_redi(
+            "issue", "update", issue_id, "--subject", updated_subject
+        )
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("issue", "view", issue_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert updated_subject in view_result.stdout
+        assert original_subject not in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestIssueDelete:
+    """`redi issue delete` は指定した issue を削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        subject = f"e2e issue delete {unique_identifier('delete')}"
+        issue_id = _create_issue(subject)
+
+        delete_result = run_redi("issue", "delete", issue_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("issue", "view", issue_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Issue not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_issue_priority_cli.py
+++ b/tests/e2e/test_issue_priority_cli.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestIssuePriorityList:
+    """`redi issue_priority` はチケット優先度一覧を表示する"""
+
+    def test_lists_default_priorities(self):
+        """init-redmine.sh で読み込まれた既定優先度(低め/通常/高め/今すぐ)が出力に含まれる"""
+        result = run_redi("issue_priority")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("低め", "通常", "高め", "今すぐ"):
+            assert name in result.stdout, (
+                f"既定の優先度 '{name}' が出力に見当たらない\n{result.stdout}"
+            )

--- a/tests/e2e/test_issue_status_cli.py
+++ b/tests/e2e/test_issue_status_cli.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestIssueStatusList:
+    """`redi issue_status` はチケットステータス一覧を表示する"""
+
+    def test_lists_default_statuses(self):
+        """init-redmine.sh で読み込まれた既定ステータス(新規/進行中/終了)が出力に含まれる"""
+        result = run_redi("issue_status")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("新規", "進行中", "終了"):
+            assert name in result.stdout, (
+                f"既定のステータス '{name}' が出力に見当たらない\n{result.stdout}"
+            )

--- a/tests/e2e/test_me_cli.py
+++ b/tests/e2e/test_me_cli.py
@@ -1,0 +1,45 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestMe:
+    """`redi me` は現在のユーザー情報を表示する"""
+
+    def test_shows_current_user_info(self):
+        """init-redmine.sh で sandbox_admin プロファイルが admin に紐付いており、admin の情報が表示される"""
+        result = run_redi("me")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "admin" in result.stdout
+        assert "admin@example.net" in result.stdout
+
+
+@pytest.mark.e2e
+class TestMeUpdate:
+    """`redi me update` は現在のユーザー情報を更新する"""
+
+    def test_updates_firstname_then_view_reflects_it(self):
+        """firstname を更新した後 me 表示で更新後の firstname が確認でき、再度元に戻せる"""
+        original_firstname = "Redmine"
+        new_firstname = "Redmine2"
+
+        update_result = run_redi("me", "update", "-f", new_firstname)
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        try:
+            view_result = run_redi("me")
+            assert view_result.returncode == 0, (
+                f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+            )
+            assert new_firstname in view_result.stdout
+        finally:
+            # 後続テストのため firstname を元に戻す
+            restore = run_redi("me", "update", "-f", original_firstname)
+            assert restore.returncode == 0, (
+                f"firstname の復元に失敗\nstdout:\n{restore.stdout}\nstderr:\n{restore.stderr}"
+            )

--- a/tests/e2e/test_membership_cli.py
+++ b/tests/e2e/test_membership_cli.py
@@ -22,9 +22,7 @@ def _create_user(login: str) -> str:
         "--password",
         "abcdABCD12",
     )
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     user_id = result.stdout.strip().split()[2]
     assert user_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
     return user_id
@@ -36,9 +34,7 @@ def _create_membership(user_id: str, role_ids: str = "4") -> str:
     role_ids 4=開発者 (init-redmine.sh で生成済み)。
     """
     result = run_redi("membership", "create", "-u", user_id, "-r", role_ids)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     # 出力例: "Created membership: 2 [user] 12 F L - 開発者"
     membership_id = result.stdout.strip().split()[2]
     assert membership_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"

--- a/tests/e2e/test_membership_cli.py
+++ b/tests/e2e/test_membership_cli.py
@@ -1,0 +1,140 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _unique_login(prefix: str) -> str:
+    return (prefix + unique_identifier("u")).replace("-", "")
+
+
+def _create_user(login: str) -> str:
+    """テスト用 user を作成し user_id を返す。"""
+    result = run_redi(
+        "user",
+        "create",
+        login,
+        "-f",
+        "F",
+        "-l",
+        "L",
+        "-m",
+        f"{login}@example.com",
+        "--password",
+        "abcdABCD12",
+    )
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    user_id = result.stdout.strip().split()[2]
+    assert user_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return user_id
+
+
+def _create_membership(user_id: str, role_ids: str = "4") -> str:
+    """指定 user で membership を作成し membership_id を返す。
+
+    role_ids 4=開発者 (init-redmine.sh で生成済み)。
+    """
+    result = run_redi("membership", "create", "-u", user_id, "-r", role_ids)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # 出力例: "Created membership: 2 [user] 12 F L - 開発者"
+    membership_id = result.stdout.strip().split()[2]
+    assert membership_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return membership_id
+
+
+@pytest.mark.e2e
+class TestMembershipList:
+    """`redi membership list` はメンバーシップ一覧を表示する"""
+
+    def test_lists_created_membership(self):
+        """事前 create した membership_id が list に含まれる (create は正しい前提)"""
+        user_id = _create_user(_unique_login("mlist"))
+        membership_id = _create_membership(user_id)
+
+        result = run_redi("membership", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert membership_id in result.stdout.split("\n")[0] or any(
+            line.startswith(f"{membership_id} ") for line in result.stdout.splitlines()
+        ), f"membership_id={membership_id} が list に見当たらない\n{result.stdout}"
+
+
+@pytest.mark.e2e
+class TestMembershipView:
+    """`redi membership view <id>` は指定したメンバーシップの情報を表示する"""
+
+    def test_succeeds_for_created_membership(self):
+        """create した membership を view すると role が含まれる (create は正しい前提)"""
+        user_id = _create_user(_unique_login("mview"))
+        membership_id = _create_membership(user_id)
+
+        result = run_redi("membership", "view", membership_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "開発者" in result.stdout
+
+
+@pytest.mark.e2e
+class TestMembershipCreate:
+    """`redi membership create` は新しいメンバーシップを作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した membership が view で取得できる (view は正しい前提)"""
+        user_id = _create_user(_unique_login("mcre"))
+        membership_id = _create_membership(user_id)
+
+        view_result = run_redi("membership", "view", membership_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+
+
+@pytest.mark.e2e
+class TestMembershipUpdate:
+    """`redi membership update` は既存のメンバーシップを更新する"""
+
+    def test_updates_then_view_shows_new_roles(self):
+        """create→update した後 view で更新後の roles が確認できる (create/view は正しい前提)"""
+        user_id = _create_user(_unique_login("mupd"))
+        membership_id = _create_membership(user_id, role_ids="4")
+
+        update_result = run_redi("membership", "update", membership_id, "-r", "4,5")
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("membership", "view", membership_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        # 4=開発者, 5=報告者 が両方含まれること
+        assert "開発者" in view_result.stdout
+        assert "報告者" in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestMembershipDelete:
+    """`redi membership delete` は指定したメンバーシップを削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        user_id = _create_user(_unique_login("mdel"))
+        membership_id = _create_membership(user_id)
+
+        delete_result = run_redi("membership", "delete", membership_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("membership", "view", membership_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Membership not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_news_cli.py
+++ b/tests/e2e/test_news_cli.py
@@ -1,0 +1,24 @@
+import json
+
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestNewsList:
+    """`redi news` はニュース一覧を表示する"""
+
+    def test_runs_successfully(self):
+        """REST API 経由での news 作成手段が無いため、コマンドが成功し --full 出力が JSON 配列であることのみ検証する"""
+        result = run_redi("news")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+        full_result = run_redi("news", "--full")
+        assert full_result.returncode == 0, (
+            f"stdout:\n{full_result.stdout}\nstderr:\n{full_result.stderr}"
+        )
+        parsed = json.loads(full_result.stdout)
+        assert isinstance(parsed, list)

--- a/tests/e2e/test_query_cli.py
+++ b/tests/e2e/test_query_cli.py
@@ -1,0 +1,28 @@
+import json
+
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestQueryList:
+    """`redi query` はカスタムクエリ一覧を表示する"""
+
+    def test_lists_default_queries(self):
+        """init-redmine.sh で読み込まれた既定のクエリ(担当しているチケット 等)が出力に含まれる"""
+        result = run_redi("query")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "担当しているチケット" in result.stdout
+
+    def test_full_outputs_json_array(self):
+        """--full は JSON 配列を出力する"""
+        result = run_redi("query", "--full")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        parsed = json.loads(result.stdout)
+        assert isinstance(parsed, list)
+        assert any(q.get("name") == "担当しているチケット" for q in parsed)

--- a/tests/e2e/test_relation_cli.py
+++ b/tests/e2e/test_relation_cli.py
@@ -1,0 +1,66 @@
+import json
+
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_issue(subject_suffix: str) -> str:
+    subject = f"e2e relation {subject_suffix} {unique_identifier('rel')}"
+    create_result = run_redi(
+        "issue", "create", subject, "--tracker_id", "2", "--description", "rel test"
+    )
+    assert create_result.returncode == 0, (
+        f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
+    )
+    issue_id = create_result.stdout.strip().rsplit("/", 1)[-1]
+    assert issue_id.isdigit(), f"想定外の create 出力:\n{create_result.stdout}"
+    return issue_id
+
+
+def _create_relation(from_id: str, to_id: str) -> str:
+    """from_id --[relates]--> to_id の relation を作って relation_id を返す。"""
+    update_result = run_redi(
+        "issue", "update", from_id, "--relate", "relates", "--to", to_id
+    )
+    assert update_result.returncode == 0, (
+        f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+    )
+
+    view_result = run_redi("issue", "view", from_id, "--include", "relations", "--full")
+    assert view_result.returncode == 0, (
+        f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+    )
+    parsed = json.loads(view_result.stdout)
+    relations = parsed.get("relations") or []
+    assert relations, f"relation が紐付いていない:\n{view_result.stdout}"
+    return str(relations[0]["id"])
+
+
+@pytest.mark.e2e
+class TestRelationView:
+    """`redi relation view <id>` は指定したリレーションの情報を表示する"""
+
+    def test_succeeds_for_existing_relation(self):
+        """issue 間に作成した relation を view すると issue_id 同士のリンクが含まれる"""
+        from_id = _create_issue("from")
+        to_id = _create_issue("to")
+        relation_id = _create_relation(from_id, to_id)
+
+        result = run_redi("relation", "view", relation_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert f"#{from_id}" in result.stdout
+        assert f"#{to_id}" in result.stdout
+        assert "relates" in result.stdout
+
+    def test_fails_for_nonexistent_relation(self):
+        """存在しない relation_id を view するとエラーになる"""
+        result = run_redi("relation", "view", "999999")
+        assert result.returncode != 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "Relation not found" in result.stdout, (
+            f"想定外のエラー\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )

--- a/tests/e2e/test_role_cli.py
+++ b/tests/e2e/test_role_cli.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestRoleList:
+    """`redi role list` はロール一覧を表示する"""
+
+    def test_lists_default_roles(self):
+        """init-redmine.sh で読み込まれた既定ロール(管理者/開発者/報告者)が出力に含まれる"""
+        result = run_redi("role", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("管理者", "開発者", "報告者"):
+            assert name in result.stdout, (
+                f"既定のロール '{name}' が出力に見当たらない\n{result.stdout}"
+            )
+
+
+@pytest.mark.e2e
+class TestRoleView:
+    """`redi role view <id>` は指定したロールの情報を表示する"""
+
+    def test_succeeds_for_existing_role(self):
+        """init-redmine.sh で作成された id=4(開発者)を view すると exit 0 で成功する"""
+        result = run_redi("role", "view", "4")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "開発者" in result.stdout
+
+    def test_fails_for_nonexistent_role(self):
+        """存在しないロール id を view するとエラーになる"""
+        result = run_redi("role", "view", "999999")
+        assert result.returncode != 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "Role not found" in result.stdout, (
+            f"想定外のエラー\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )

--- a/tests/e2e/test_search_cli.py
+++ b/tests/e2e/test_search_cli.py
@@ -1,0 +1,29 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+@pytest.mark.e2e
+class TestSearch:
+    """`redi search <query>` は Redmine の全文検索結果を表示する"""
+
+    def test_finds_created_issue_subject(self):
+        """事前 create した issue の subject が search の結果に含まれる (create/view は正しい前提)"""
+        token = unique_identifier("search-token")
+        subject = f"e2e search target {token}"
+
+        # bug トラッカー(id=1) は必須カスタムフィールドが設定されているので id=2 (機能) を使う
+        create_result = run_redi(
+            "issue", "create", subject, "--tracker_id", "2", "--description", "search test"
+        )
+        assert create_result.returncode == 0, (
+            f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
+        )
+
+        result = run_redi("search", token)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert token in result.stdout, (
+            f"作成した token が search 結果に見当たらない\n{result.stdout}"
+        )

--- a/tests/e2e/test_search_cli.py
+++ b/tests/e2e/test_search_cli.py
@@ -14,7 +14,13 @@ class TestSearch:
 
         # bug トラッカー(id=1) は必須カスタムフィールドが設定されているので id=2 (機能) を使う
         create_result = run_redi(
-            "issue", "create", subject, "--tracker_id", "2", "--description", "search test"
+            "issue",
+            "create",
+            subject,
+            "--tracker_id",
+            "2",
+            "--description",
+            "search test",
         )
         assert create_result.returncode == 0, (
             f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"

--- a/tests/e2e/test_time_entry_activity_cli.py
+++ b/tests/e2e/test_time_entry_activity_cli.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestTimeEntryActivityList:
+    """`redi time_entry_activity` は作業分類一覧を表示する"""
+
+    def test_lists_default_activities(self):
+        """init-redmine.sh で読み込まれた既定の作業分類(設計作業/開発作業)が出力に含まれる"""
+        result = run_redi("time_entry_activity")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("設計作業", "開発作業"):
+            assert name in result.stdout, (
+                f"既定の作業分類 '{name}' が出力に見当たらない\n{result.stdout}"
+            )

--- a/tests/e2e/test_time_entry_cli.py
+++ b/tests/e2e/test_time_entry_cli.py
@@ -1,0 +1,129 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_time_entry(hours: str = "1.5", comments: str | None = None) -> str:
+    """time entry を作成し time_entry_id を返す。
+
+    activity_id 9 = 開発作業 (init-redmine.sh で読み込まれた既定値)。
+    """
+    args = [
+        "time_entry",
+        "create",
+        hours,
+        "-p",
+        "reditest",
+        "--activity_id",
+        "9",
+    ]
+    if comments is not None:
+        args += ["--comments", comments]
+    result = run_redi(*args)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # 出力例: "Logged time entry: 1 1.5h (2026-04-29)"
+    time_entry_id = result.stdout.strip().split()[3]
+    assert time_entry_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return time_entry_id
+
+
+@pytest.mark.e2e
+class TestTimeEntryList:
+    """`redi time_entry list` は作業時間記録一覧を表示する"""
+
+    def test_lists_created_time_entry(self):
+        """事前 create した time entry の id が list に含まれる (create は正しい前提)"""
+        comment = f"te list {unique_identifier('list')}"
+        time_entry_id = _create_time_entry(comments=comment)
+
+        result = run_redi("time_entry", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert comment in result.stdout
+        assert any(
+            line.startswith(f"{time_entry_id} ")
+            for line in result.stdout.splitlines()
+        ), f"time_entry_id={time_entry_id} が list に見当たらない\n{result.stdout}"
+
+
+@pytest.mark.e2e
+class TestTimeEntryView:
+    """`redi time_entry view <id>` は指定した作業時間記録の情報を表示する"""
+
+    def test_succeeds_for_created_time_entry(self):
+        """create した time entry を view すると comments が含まれる (create は正しい前提)"""
+        comment = f"te view {unique_identifier('view')}"
+        time_entry_id = _create_time_entry(comments=comment)
+
+        result = run_redi("time_entry", "view", time_entry_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert comment in result.stdout
+
+
+@pytest.mark.e2e
+class TestTimeEntryCreate:
+    """`redi time_entry create` は新しい作業時間記録を作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した time entry が view で取得できる (view は正しい前提)"""
+        comment = f"te create {unique_identifier('create')}"
+        time_entry_id = _create_time_entry(comments=comment)
+
+        view_result = run_redi("time_entry", "view", time_entry_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert comment in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestTimeEntryUpdate:
+    """`redi time_entry update` は既存の作業時間記録を更新する"""
+
+    def test_updates_then_view_shows_new_comments(self):
+        """create→update した後 view で更新後の comments が確認できる (create/view は正しい前提)"""
+        original = f"te orig {unique_identifier('update')}"
+        updated = f"te new {unique_identifier('update')}"
+        time_entry_id = _create_time_entry(comments=original)
+
+        update_result = run_redi(
+            "time_entry", "update", time_entry_id, "--comments", updated
+        )
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("time_entry", "view", time_entry_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert updated in view_result.stdout
+        assert original not in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestTimeEntryDelete:
+    """`redi time_entry delete` は指定した作業時間記録を削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        comment = f"te del {unique_identifier('delete')}"
+        time_entry_id = _create_time_entry(comments=comment)
+
+        delete_result = run_redi("time_entry", "delete", time_entry_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("time_entry", "view", time_entry_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Time entry not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_time_entry_cli.py
+++ b/tests/e2e/test_time_entry_cli.py
@@ -6,6 +6,9 @@ from tests.e2e.utils import run_redi, unique_identifier
 def _create_time_entry(hours: str = "1.5", comments: str | None = None) -> str:
     """time entry を作成し time_entry_id を返す。
 
+    project_id=1 は init-redmine.sh で作成される reditest プロジェクト。
+    redi の time_entry API は identifier を内部で解決する際にプロジェクト一覧の
+    既定 limit(25) でしか引かないので、ここでは数値 id を直接指定する。
     activity_id 9 = 開発作業 (init-redmine.sh で読み込まれた既定値)。
     """
     args = [
@@ -13,16 +16,14 @@ def _create_time_entry(hours: str = "1.5", comments: str | None = None) -> str:
         "create",
         hours,
         "-p",
-        "reditest",
+        "1",
         "--activity_id",
         "9",
     ]
     if comments is not None:
         args += ["--comments", comments]
     result = run_redi(*args)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     # 出力例: "Logged time entry: 1 1.5h (2026-04-29)"
     time_entry_id = result.stdout.strip().split()[3]
     assert time_entry_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
@@ -44,8 +45,7 @@ class TestTimeEntryList:
         )
         assert comment in result.stdout
         assert any(
-            line.startswith(f"{time_entry_id} ")
-            for line in result.stdout.splitlines()
+            line.startswith(f"{time_entry_id} ") for line in result.stdout.splitlines()
         ), f"time_entry_id={time_entry_id} が list に見当たらない\n{result.stdout}"
 
 

--- a/tests/e2e/test_tracker_cli.py
+++ b/tests/e2e/test_tracker_cli.py
@@ -1,0 +1,19 @@
+import pytest
+
+from tests.e2e.utils import run_redi
+
+
+@pytest.mark.e2e
+class TestTrackerList:
+    """`redi tracker` はトラッカー一覧を表示する"""
+
+    def test_lists_default_trackers(self):
+        """init-redmine.sh で読み込まれた既定トラッカー(バグ/機能/サポート)が出力に含まれる"""
+        result = run_redi("tracker")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        for name in ("バグ", "機能", "サポート"):
+            assert name in result.stdout, (
+                f"既定のトラッカー '{name}' が出力に見当たらない\n{result.stdout}"
+            )

--- a/tests/e2e/test_user_cli.py
+++ b/tests/e2e/test_user_cli.py
@@ -24,9 +24,7 @@ def _create_user(login: str, firstname: str = "First", lastname: str = "Last") -
         "--password",
         "abcdABCD12",
     )
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     # 出力例: "Created user: 6 e2etest1 http://localhost:3000/users/6"
     parts = result.stdout.strip().split()
     user_id = parts[2]

--- a/tests/e2e/test_user_cli.py
+++ b/tests/e2e/test_user_cli.py
@@ -1,0 +1,128 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _unique_login(prefix: str) -> str:
+    """ユーザー login 用のユニーク文字列(英数のみ)。"""
+    # unique_identifier はハイフン区切りなので、login に使えるよう "-" を除く
+    return (prefix + unique_identifier("u")).replace("-", "")
+
+
+def _create_user(login: str, firstname: str = "First", lastname: str = "Last") -> str:
+    """user を作成し user_id を返す。"""
+    result = run_redi(
+        "user",
+        "create",
+        login,
+        "-f",
+        firstname,
+        "-l",
+        lastname,
+        "-m",
+        f"{login}@example.com",
+        "--password",
+        "abcdABCD12",
+    )
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # 出力例: "Created user: 6 e2etest1 http://localhost:3000/users/6"
+    parts = result.stdout.strip().split()
+    user_id = parts[2]
+    assert user_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return user_id
+
+
+@pytest.mark.e2e
+class TestUserList:
+    """`redi user list` はユーザー一覧を表示する"""
+
+    def test_lists_created_user(self):
+        """事前 create した login が list に含まれる (create は正しい前提)"""
+        login = _unique_login("e2elist")
+        user_id = _create_user(login)
+
+        result = run_redi("user", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert login in result.stdout
+        assert user_id in result.stdout
+
+
+@pytest.mark.e2e
+class TestUserView:
+    """`redi user view <id>` は指定したユーザーの情報を表示する"""
+
+    def test_succeeds_for_created_user(self):
+        """create した user を view すると login/mail が含まれる (create は正しい前提)"""
+        login = _unique_login("e2eview")
+        user_id = _create_user(login)
+
+        result = run_redi("user", "view", user_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert login in result.stdout
+
+
+@pytest.mark.e2e
+class TestUserCreate:
+    """`redi user create` は新しいユーザーを作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した user が view で取得できる (view は正しい前提)"""
+        login = _unique_login("e2ecre")
+        user_id = _create_user(login)
+
+        view_result = run_redi("user", "view", user_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert login in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestUserUpdate:
+    """`redi user update` は既存のユーザーを更新する"""
+
+    def test_updates_then_view_shows_new_firstname(self):
+        """create→update した後 view で更新後の firstname が確認できる (create/view は正しい前提)"""
+        login = _unique_login("e2eupd")
+        user_id = _create_user(login, firstname="Original")
+
+        update_result = run_redi("user", "update", user_id, "-f", "Updated")
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("user", "view", user_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Updated" in view_result.stdout
+        assert "Original" not in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestUserDelete:
+    """`redi user delete` は指定したユーザーを削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        login = _unique_login("e2edel")
+        user_id = _create_user(login)
+
+        delete_result = run_redi("user", "delete", user_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("user", "view", user_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "User not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_version_cli.py
+++ b/tests/e2e/test_version_cli.py
@@ -6,9 +6,7 @@ from tests.e2e.utils import run_redi, unique_identifier
 def _create_version(name: str) -> str:
     """version を作成し version_id を返す。"""
     result = run_redi("version", "create", name)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
     # 出力例: "Created version: 1 v-test-1 http://localhost:3000/versions/1"
     parts = result.stdout.strip().split()
     version_id = parts[2]

--- a/tests/e2e/test_version_cli.py
+++ b/tests/e2e/test_version_cli.py
@@ -1,0 +1,111 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _create_version(name: str) -> str:
+    """version を作成し version_id を返す。"""
+    result = run_redi("version", "create", name)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    # 出力例: "Created version: 1 v-test-1 http://localhost:3000/versions/1"
+    parts = result.stdout.strip().split()
+    version_id = parts[2]
+    assert version_id.isdigit(), f"想定外の create 出力:\n{result.stdout}"
+    return version_id
+
+
+@pytest.mark.e2e
+class TestVersionList:
+    """`redi version list` はバージョン一覧を表示する"""
+
+    def test_lists_created_version(self):
+        """事前 create した name が list に含まれる (create は正しい前提)"""
+        name = f"e2e-version-list-{unique_identifier('list')}"
+        version_id = _create_version(name)
+
+        result = run_redi("version", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert name in result.stdout
+        assert version_id in result.stdout
+
+
+@pytest.mark.e2e
+class TestVersionView:
+    """`redi version view <id>` は指定したバージョンの情報を表示する"""
+
+    def test_succeeds_for_created_version(self):
+        """create した version を view すると name が含まれる (create は正しい前提)"""
+        name = f"e2e-version-view-{unique_identifier('view')}"
+        version_id = _create_version(name)
+
+        result = run_redi("version", "view", version_id)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert name in result.stdout
+
+
+@pytest.mark.e2e
+class TestVersionCreate:
+    """`redi version create` は新しいバージョンを作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した version が view で取得できる (view は正しい前提)"""
+        name = f"e2e-version-create-{unique_identifier('create')}"
+        version_id = _create_version(name)
+
+        view_result = run_redi("version", "view", version_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert name in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestVersionUpdate:
+    """`redi version update` は既存のバージョンを更新する"""
+
+    def test_updates_then_view_shows_new_name(self):
+        """create→update した後 view で更新後の name が確認できる (create/view は正しい前提)"""
+        original = f"e2e-version-update-orig-{unique_identifier('update')}"
+        updated = f"e2e-version-update-new-{unique_identifier('update')}"
+        version_id = _create_version(original)
+
+        update_result = run_redi("version", "update", version_id, "--name", updated)
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("version", "view", version_id)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert updated in view_result.stdout
+        assert original not in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestVersionDelete:
+    """`redi version delete` は指定したバージョンを削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        name = f"e2e-version-delete-{unique_identifier('delete')}"
+        version_id = _create_version(name)
+
+        delete_result = run_redi("version", "delete", version_id, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("version", "view", version_id)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Version not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )

--- a/tests/e2e/test_wiki_cli.py
+++ b/tests/e2e/test_wiki_cli.py
@@ -14,9 +14,7 @@ def _unique_wiki_title(prefix: str) -> str:
 
 def _create_wiki(title: str, description: str) -> None:
     result = run_redi("wiki", "create", title, "--description", description)
-    assert result.returncode == 0, (
-        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
+    assert result.returncode == 0, f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
 
 
 @pytest.mark.e2e

--- a/tests/e2e/test_wiki_cli.py
+++ b/tests/e2e/test_wiki_cli.py
@@ -1,0 +1,116 @@
+import pytest
+
+from tests.e2e.utils import run_redi, unique_identifier
+
+
+def _unique_wiki_title(prefix: str) -> str:
+    """wiki page title 用のユニークな識別子。
+
+    Redmine のページ識別子は英数字とハイフン/アンダースコアに正規化されるので、
+    base の prefix もそれに合わせる。
+    """
+    return f"{prefix}-{unique_identifier('wiki')}"
+
+
+def _create_wiki(title: str, description: str) -> None:
+    result = run_redi("wiki", "create", title, "--description", description)
+    assert result.returncode == 0, (
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+@pytest.mark.e2e
+class TestWikiList:
+    """`redi wiki list` は wiki ページ一覧を表示する"""
+
+    def test_lists_created_wiki(self):
+        """事前 create した title が list に含まれる (create は正しい前提)"""
+        title = _unique_wiki_title("WikiList")
+        _create_wiki(title, "list test content")
+
+        result = run_redi("wiki", "list")
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert title in result.stdout
+
+
+@pytest.mark.e2e
+class TestWikiView:
+    """`redi wiki view <title>` は指定した wiki ページの内容を表示する"""
+
+    def test_succeeds_for_created_wiki(self):
+        """create した wiki を view すると description 内容が含まれる (create は正しい前提)"""
+        title = _unique_wiki_title("WikiView")
+        description = f"view content {title}"
+        _create_wiki(title, description)
+
+        result = run_redi("wiki", "view", title)
+        assert result.returncode == 0, (
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert description in result.stdout
+
+
+@pytest.mark.e2e
+class TestWikiCreate:
+    """`redi wiki create` は新しい wiki ページを作成する"""
+
+    def test_creates_then_view_shows_it(self):
+        """create した wiki が view で取得できる (view は正しい前提)"""
+        title = _unique_wiki_title("WikiCreate")
+        description = f"create content {title}"
+        _create_wiki(title, description)
+
+        view_result = run_redi("wiki", "view", title)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert description in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestWikiUpdate:
+    """`redi wiki update` は既存の wiki ページを更新する"""
+
+    def test_updates_then_view_shows_new_content(self):
+        """create→update した後 view で更新後の description が確認できる (create/view は正しい前提)"""
+        title = _unique_wiki_title("WikiUpdate")
+        original = f"orig content {title}"
+        updated = f"new content {title}"
+        _create_wiki(title, original)
+
+        update_result = run_redi("wiki", "update", title, "--description", updated)
+        assert update_result.returncode == 0, (
+            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
+        )
+
+        view_result = run_redi("wiki", "view", title)
+        assert view_result.returncode == 0, (
+            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert updated in view_result.stdout
+        assert original not in view_result.stdout
+
+
+@pytest.mark.e2e
+class TestWikiDelete:
+    """`redi wiki delete` は指定した wiki ページを削除する"""
+
+    def test_deletes_then_view_fails(self):
+        """create→delete した後 view が失敗する (create/view は正しい前提)"""
+        title = _unique_wiki_title("WikiDelete")
+        _create_wiki(title, "delete test content")
+
+        delete_result = run_redi("wiki", "delete", title, "-y")
+        assert delete_result.returncode == 0, (
+            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
+        )
+
+        view_result = run_redi("wiki", "view", title)
+        assert view_result.returncode != 0, (
+            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )
+        assert "Wiki page not found" in view_result.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        )


### PR DESCRIPTION
## Summary
- `redi` の主要コマンド 22 種(issue / version / wiki / user / me / membership / news / tracker / issue_status / issue_priority / time_entry_activity / document_category / role / group / query / custom_field / issue_category / search / attachment / relation / time_entry / file)に対する E2E テストを追加。
- 既存の \`tests/e2e/test_project_cli.py\` と同じ「create→view/list/update/delete」パターンで実装し、コマンド単位でコミットを分けた。
- 最終コミットで \`ruff format\` を適用し、\`time_entry\` の project 指定を identifier(reditest) → 数値 id(1) に変更(redi の time_entry API の identifier 解決が paginated list の既定 limit に依存するため、テスト用プロジェクトが増えると "Project not found" になる回避)。

## Test plan
- [ ] \`./script/init-redmine.sh\` でローカル Redmine を起動した状態で \`uv run pytest tests/e2e -m e2e\` が全件 pass
- [ ] \`task check\` (format → lint → typecheck → test) が pass
- [ ] 各テストファイルが docstring(日本語) ベースで pytest 表示名になることを確認