### PR TITLE
各コマンドにエイリアスを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Most commands follow the form:
 redi <resource> <action> [<resource_id>] [options]
 ```
 
-- `<resource>` — `issue`, `project`, `wiki`, ... (most have a short alias such as `i` / `p` / `w`)
+- `<resource>` — `issue`, `project`, `time_entry`, ... (almost every resource has a short alias such as `i` / `p` / `te`; `init` / `me` / `relation` have no alias)
 - `<action>` — `list` / `view` / `create` / `update` / `delete` / `comment` (also has aliases: `v` / `c` / `u` / `d` / `co`)
     - `redi <resource>` alone is shorthand for `redi <resource> list`
 - `<resource_id>` — required for actions that target a specific item (`view`, `update`, `delete`, `comment`)
@@ -142,11 +142,11 @@ redi wiki view <page_title>
 redi wiki create # (interactive)
 redi wiki update # (interactive)
 
-# file (project files)
+# file (alias: f, project files)
 redi file -p <project_id> # list
 redi file create ./foo.zip -p <project_id> -d "description"
 
-# attachment
+# attachment (alias: a)
 redi attachment view <attachment_id>
 redi attachment update <attachment_id> -f new_name.png -d "desc"
 redi attachment delete <attachment_id> # confirm before delete (-y to skip)
@@ -154,7 +154,7 @@ redi attachment delete <attachment_id> # confirm before delete (-y to skip)
 # relation (issue relation details)
 redi relation view <relation_id>
 
-# time_entry
+# time_entry (alias: te)
 redi time_entry -p <project_id> -u me
 redi time_entry create 1.5 -i <issue_id> -a <activity_id> -c "comment"
 redi time_entry update <time_entry_id> --hours 2.0
@@ -168,25 +168,25 @@ redi me update -f <firstname> -l <lastname> -m <mail>
 redi membership -p <project_id>
 redi membership view <membership_id>
 
-# news
+# news (alias: n)
 redi news -p <project_id>
 
-# issue_category
+# issue_category (alias: ic)
 redi issue_category -p <project_id>
 redi issue_category create "category" -p <project_id>
 
 # others
 redi user # list users (alias: u)
-redi tracker # list trackers
-redi issue_status # list issue statuses
-redi issue_priority # list priorities
-redi time_entry_activity # list activities
-redi document_category # list document categories
-redi role # list roles
-redi group # list groups
-redi custom_field # list custom fields
-redi query # list custom queries
-redi search "keyword"
+redi tracker # list trackers (alias: t)
+redi issue_status # list issue statuses (alias: is)
+redi issue_priority # list priorities (alias: ip)
+redi time_entry_activity # list activities (alias: tea)
+redi document_category # list document categories (alias: dc)
+redi role # list roles (alias: r)
+redi group # list groups (alias: g)
+redi custom_field # list custom fields (alias: cf)
+redi query # list custom queries (alias: q)
+redi search "keyword" # (alias: s)
 redi --version
 ```
 

--- a/src/redi/cli/attachment_command.py
+++ b/src/redi/cli/attachment_command.py
@@ -12,7 +12,7 @@ from redi.i18n import messages
 
 def add_attachment_parser(subparsers: argparse._SubParsersAction) -> None:
     a_parser = subparsers.add_parser(
-        "attachment", help=messages.arg_help_attachment_command
+        "attachment", aliases=["a"], help=messages.arg_help_attachment_command
     )
     a_subparsers = a_parser.add_subparsers(dest="attachment_command")
     a_parser.set_defaults(_print_help=a_parser.print_help)

--- a/src/redi/cli/enumerations_command.py
+++ b/src/redi/cli/enumerations_command.py
@@ -5,7 +5,7 @@ from redi.i18n import messages
 
 def add_tracker_parser(subparsers: argparse._SubParsersAction) -> None:
     tracker_parser = subparsers.add_parser(
-        "tracker", help=messages.arg_help_tracker_command
+        "tracker", aliases=["t"], help=messages.arg_help_tracker_command
     )
     tracker_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
@@ -14,7 +14,7 @@ def add_tracker_parser(subparsers: argparse._SubParsersAction) -> None:
 
 def add_issue_status_parser(subparsers: argparse._SubParsersAction) -> None:
     issue_status_parser = subparsers.add_parser(
-        "issue_status", help=messages.arg_help_issue_status_command
+        "issue_status", aliases=["is"], help=messages.arg_help_issue_status_command
     )
     issue_status_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
@@ -23,7 +23,7 @@ def add_issue_status_parser(subparsers: argparse._SubParsersAction) -> None:
 
 def add_issue_priority_parser(subparsers: argparse._SubParsersAction) -> None:
     ip_parser = subparsers.add_parser(
-        "issue_priority", help=messages.arg_help_issue_priority_command
+        "issue_priority", aliases=["ip"], help=messages.arg_help_issue_priority_command
     )
     ip_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
@@ -32,7 +32,9 @@ def add_issue_priority_parser(subparsers: argparse._SubParsersAction) -> None:
 
 def add_time_entry_activity_parser(subparsers: argparse._SubParsersAction) -> None:
     tea_parser = subparsers.add_parser(
-        "time_entry_activity", help=messages.arg_help_time_entry_activity_command
+        "time_entry_activity",
+        aliases=["tea"],
+        help=messages.arg_help_time_entry_activity_command,
     )
     tea_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
@@ -41,7 +43,9 @@ def add_time_entry_activity_parser(subparsers: argparse._SubParsersAction) -> No
 
 def add_document_category_parser(subparsers: argparse._SubParsersAction) -> None:
     dc_parser = subparsers.add_parser(
-        "document_category", help=messages.arg_help_document_category_command
+        "document_category",
+        aliases=["dc"],
+        help=messages.arg_help_document_category_command,
     )
     dc_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
@@ -49,7 +53,9 @@ def add_document_category_parser(subparsers: argparse._SubParsersAction) -> None
 
 
 def add_query_parser(subparsers: argparse._SubParsersAction) -> None:
-    query_parser = subparsers.add_parser("query", help=messages.arg_help_query_command)
+    query_parser = subparsers.add_parser(
+        "query", aliases=["q"], help=messages.arg_help_query_command
+    )
     query_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
@@ -57,7 +63,7 @@ def add_query_parser(subparsers: argparse._SubParsersAction) -> None:
 
 def add_custom_field_parser(subparsers: argparse._SubParsersAction) -> None:
     cf_parser = subparsers.add_parser(
-        "custom_field", help=messages.arg_help_custom_field_command
+        "custom_field", aliases=["cf"], help=messages.arg_help_custom_field_command
     )
     cf_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json

--- a/src/redi/cli/file_command.py
+++ b/src/redi/cli/file_command.py
@@ -7,7 +7,9 @@ from redi.i18n import messages
 
 
 def add_file_parser(subparsers: argparse._SubParsersAction) -> None:
-    f_parser = subparsers.add_parser("file", help=messages.arg_help_file_command)
+    f_parser = subparsers.add_parser(
+        "file", aliases=["f"], help=messages.arg_help_file_command
+    )
     f_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     f_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -17,6 +17,7 @@ from redi.api.group import (
 def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
     group_parser = subparsers.add_parser(
         "group",
+        aliases=["g"],
         help=messages.arg_help_group_command,
     )
     group_parser.add_argument(

--- a/src/redi/cli/issue_category_command.py
+++ b/src/redi/cli/issue_category_command.py
@@ -16,6 +16,7 @@ from redi.api.issue_category import (
 def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
     ic_parser = subparsers.add_parser(
         "issue_category",
+        aliases=["ic"],
         help=messages.arg_help_issue_category_command,
     )
     ic_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -273,37 +273,37 @@ def main() -> None:
         handle_me(args)
     elif args.command in ("membership", "m"):
         handle_membership(args)
-    elif args.command == "news":
+    elif args.command in ("news", "n"):
         handle_news(args)
-    elif args.command == "tracker":
+    elif args.command in ("tracker", "t"):
         list_trackers(full=args.full)
-    elif args.command == "issue_status":
+    elif args.command in ("issue_status", "is"):
         list_issue_statuses(full=args.full)
-    elif args.command == "issue_priority":
+    elif args.command in ("issue_priority", "ip"):
         list_issue_priorities(full=args.full)
-    elif args.command == "time_entry_activity":
+    elif args.command in ("time_entry_activity", "tea"):
         list_time_entry_activities(full=args.full)
-    elif args.command == "document_category":
+    elif args.command in ("document_category", "dc"):
         list_document_categories(full=args.full)
-    elif args.command == "role":
+    elif args.command in ("role", "r"):
         handle_role(args)
-    elif args.command == "group":
+    elif args.command in ("group", "g"):
         handle_group(args)
-    elif args.command == "query":
+    elif args.command in ("query", "q"):
         list_queries(full=args.full)
-    elif args.command == "custom_field":
+    elif args.command in ("custom_field", "cf"):
         list_custom_fields(full=args.full)
-    elif args.command == "issue_category":
+    elif args.command in ("issue_category", "ic"):
         handle_issue_category(args)
-    elif args.command == "search":
+    elif args.command in ("search", "s"):
         handle_search(args)
-    elif args.command == "attachment":
+    elif args.command in ("attachment", "a"):
         handle_attachment(args)
     elif args.command == "relation":
         handle_relation(args)
-    elif args.command == "time_entry":
+    elif args.command in ("time_entry", "te"):
         handle_time_entry(args)
-    elif args.command == "file":
+    elif args.command in ("file", "f"):
         handle_file(args)
     else:
         parser.print_help()

--- a/src/redi/cli/news_command.py
+++ b/src/redi/cli/news_command.py
@@ -6,7 +6,9 @@ from redi.api.news import list_news
 
 
 def add_news_parser(subparsers: argparse._SubParsersAction) -> None:
-    n_parser = subparsers.add_parser("news", help=messages.arg_help_news_command)
+    n_parser = subparsers.add_parser(
+        "news", aliases=["n"], help=messages.arg_help_news_command
+    )
     n_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     n_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json

--- a/src/redi/cli/role_command.py
+++ b/src/redi/cli/role_command.py
@@ -6,7 +6,9 @@ from redi.api.role import list_roles, read_role
 
 
 def add_role_parser(subparsers: argparse._SubParsersAction) -> None:
-    role_parser = subparsers.add_parser("role", help=messages.arg_help_role_command)
+    role_parser = subparsers.add_parser(
+        "role", aliases=["r"], help=messages.arg_help_role_command
+    )
     role_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -6,7 +6,7 @@ from redi.i18n import messages
 
 def add_search_parser(subparsers: argparse._SubParsersAction) -> None:
     search_parser = subparsers.add_parser(
-        "search", help=messages.arg_help_search_command
+        "search", aliases=["s"], help=messages.arg_help_search_command
     )
     search_parser.add_argument("query", help=messages.arg_help_search_query)
     search_parser.add_argument("--limit", "-l", type=int, help=messages.arg_help_limit)

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -33,6 +33,7 @@ from redi.api.time_entry import (
 def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     time_entry_parser = subparsers.add_parser(
         "time_entry",
+        aliases=["te"],
         help=messages.arg_help_time_entry_command,
     )
     time_entry_parser.add_argument(


### PR DESCRIPTION
resolve #130 

## Summary
- issue で明示された `search→s` / `custom_field→cf` / `issue_status→is` / `time_entry_activity→tea` のエイリアスを追加
- 対象外 (`init` / `me` / `relation`) を除き、エイリアス未設定だった残りのコマンドにも 1〜3 文字のエイリアスを追加
  - `news→n` / `tracker→t` / `issue_priority→ip` / `document_category→dc`
  - `role→r` / `group→g` / `query→q` / `issue_category→ic`
  - `attachment→a` / `time_entry→te` / `file→f`
- `src/redi/cli/main.py` のディスパッチを `args.command in (..., alias)` 形式に拡張

## Test plan
- [x] `task check`(format/lint/typecheck/test) がすべてパスすること
- [x] `redi --help` の subparser 一覧で全エイリアスが表示されること
- [x] `redi s <query>` / `redi cf` / `redi is` / `redi tea` などで本体コマンドと同じ挙動になること