### PR TITLE
wiki update(interactive) で version を指定して conflict を検知 (resolve #133 )

### DIFF
--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -1,12 +1,18 @@
 import json
 import webbrowser
 from collections import defaultdict
+from typing import NotRequired, TypedDict
 
 import requests
 
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+
+
+class WikiPageUpdateBody(TypedDict):
+    text: str
+    version: NotRequired[int]
 
 
 # redmineで空白文字を含んでwikiのpageを作成するとURLの都合か`_`に置き換えられている
@@ -117,7 +123,7 @@ def read_wiki(
 def update_wiki(
     project_id: str, page_title: str, text: str, version: int | None = None
 ) -> None:
-    body: dict = {"text": text}
+    body: WikiPageUpdateBody = {"text": text}
     if version is not None:
         body["version"] = version
     response = client.put(

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -15,6 +15,12 @@ class WikiPageUpdateBody(TypedDict):
     version: NotRequired[int]
 
 
+class WikiUpdateConflictException(Exception):
+    def __init__(self, title: str) -> None:
+        super().__init__(title)
+        self.title = title
+
+
 # redmineで空白文字を含んでwikiのpageを作成するとURLの都合か`_`に置き換えられている
 # 既存のwikiのタイトルの先頭文字が大文字になっている
 def normalize_title(t: str) -> str:
@@ -131,8 +137,7 @@ def update_wiki(
         json={"wiki_page": body},
     )
     if response.status_code == 409:
-        print(messages.wiki_page_update_conflict.format(title=page_title))
-        return
+        raise WikiUpdateConflictException(page_title)
     response.raise_for_status()
     url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
     print(messages.wiki_page_updated.format(url=url))

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -114,11 +114,19 @@ def read_wiki(
         print(wiki.get("text", ""))
 
 
-def update_wiki(project_id: str, page_title: str, text: str) -> None:
+def update_wiki(
+    project_id: str, page_title: str, text: str, version: int | None = None
+) -> None:
+    body: dict = {"text": text}
+    if version is not None:
+        body["version"] = version
     response = client.put(
         f"/projects/{project_id}/wiki/{page_title}.json",
-        json={"wiki_page": {"text": text}},
+        json={"wiki_page": body},
     )
+    if response.status_code == 409:
+        print(messages.wiki_page_update_conflict.format(title=page_title))
+        return
     response.raise_for_status()
     url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
     print(messages.wiki_page_updated.format(url=url))

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -129,6 +129,17 @@ def read_wiki(
 def update_wiki(
     project_id: str, page_title: str, text: str, version: int | None = None
 ) -> None:
+    """Wikiページを更新する
+
+    Args:
+        version: 更新対象の期待バージョン。
+                 指定するとRedmine 側のバージョンと一致しない場合に409 が返る。
+                 Noneの場合はバージョンチェックを行わない
+
+    Raises:
+        WikiUpdateConflictException: version がRedmine側の最新バージョンと一致せず、更新が競合した場合（HTTP 409）。
+        requests.exceptions.HTTPError: 409 以外の HTTP エラーが返った場合
+    """
     body: WikiPageUpdateBody = {"text": text}
     if version is not None:
         body["version"] = version

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -53,6 +53,7 @@ from redi.api.issue import add_note
 from redi.api.issue_status import list_issue_statuses
 from redi.api.query import list_queries
 from redi.api.tracker import list_trackers
+from redi.api.wiki import WikiUpdateConflictException
 from redi.i18n import messages
 from redi.tui import TuiState, run_issue_tui
 
@@ -201,15 +202,19 @@ def main() -> None:
                     )
                 )
             elif tui_result.action == "update" and tui_result.tab == "wiki":
-                handle_wiki(
-                    argparse.Namespace(
-                        wiki_command="update",
-                        project_id=None,
-                        full=False,
-                        page_title=tui_result.wiki_title,
-                        description=None,
+                try:
+                    handle_wiki(
+                        argparse.Namespace(
+                            wiki_command="update",
+                            project_id=None,
+                            full=False,
+                            page_title=tui_result.wiki_title,
+                            description=None,
+                        )
                     )
-                )
+                except WikiUpdateConflictException as e:
+                    print(messages.wiki_page_update_conflict.format(title=e.title))
+                    # TUI側にフィードバックをかける
             elif tui_result.action == "create_time_entry":
                 if not tui_result.issue_id:
                     continue
@@ -266,7 +271,11 @@ def main() -> None:
     elif args.command in ("version", "v"):
         handle_version(args)
     elif args.command in ("wiki", "w"):
-        handle_wiki(args)
+        try:
+            handle_wiki(args)
+        except WikiUpdateConflictException as e:
+            print(messages.wiki_page_update_conflict.format(title=e.title))
+            exit(1)
     elif args.command in ("user", "u"):
         handle_user(args)
     elif args.command == "me":

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -195,6 +195,7 @@ def handle_wiki(args: argparse.Namespace) -> None:
             print(
                 messages.edit_target_page.format(label=page_labels[page_title].strip())
             )
+        version: int | None = None
         if args.description and args.description != "":
             text = args.description
         else:
@@ -202,9 +203,10 @@ def handle_wiki(args: argparse.Namespace) -> None:
             if current is None:
                 print(messages.wiki_page_not_found.format(title=page_title))
                 exit(1)
+            version = current.get("version")
             text = open_editor(current.get("text") or "")
         if text:
-            update_wiki(project_id, page_title, text)
+            update_wiki(project_id, page_title, text, version=version)
         else:
             print(messages.canceled_empty_text)
     elif cmd == "list" or cmd is None:

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -221,6 +221,8 @@ class MessagesProto(Protocol):
     watcher_add_failed: str
     watcher_remove_failed: str
     wiki_page_delete_failed: str
+    wiki_page_update_conflict: str
+    """{title}"""
     membership_create_failed: str
     membership_update_failed: str
     membership_delete_failed: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -138,6 +138,9 @@ class En(MessagesProto):
     watcher_add_failed = "Failed to add watcher"
     watcher_remove_failed = "Failed to remove watcher"
     wiki_page_delete_failed = "Failed to delete wiki page"
+    wiki_page_update_conflict = (
+        "Failed to update wiki page because it was updated by another user: {title}"
+    )
     membership_create_failed = "Failed to create membership"
     membership_update_failed = "Failed to update membership"
     membership_delete_failed = "Failed to delete membership"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -142,6 +142,7 @@ class Ja(MessagesProto):
     watcher_add_failed = "ウォッチャーの追加に失敗しました"
     watcher_remove_failed = "ウォッチャーの削除に失敗しました"
     wiki_page_delete_failed = "Wikiページの削除に失敗しました"
+    wiki_page_update_conflict = "Wikiページが他のユーザーによって更新されているため更新できませんでした: {title}"
     membership_create_failed = "メンバーシップの作成に失敗しました"
     membership_update_failed = "メンバーシップの更新に失敗しました"
     membership_delete_failed = "メンバーシップの削除に失敗しました"


### PR DESCRIPTION
resolve #133

## Summary
- `update_wiki` に `version` パラメータを追加し、payload に `version` を含めて送信するようにした
- payload は `WikiPageUpdateBody` (TypedDict) で型付けした
- 409 Conflict が返った場合は `wiki_page_update_conflict` メッセージを表示して更新成功メッセージは出さないようにした
- interactive な `wiki update` フローでは `fetch_wiki` で取得した `version` を `update_wiki` に渡すようにし、読み取りから書き込みまでの間に他ユーザの更新があった場合に上書きを防げるようにした

## Test plan
- [x] `redi wiki update <title>` を対話モードで起動し、エディタを開いている間に別経由で同じページを更新 → 保存時に conflict メッセージが出ることを確認
- [x] 通常の更新フロー(他者の更新なし)で従来通り更新できることを確認
- [x] `--description` で text を直接渡したケース(version 未指定)が従来通り更新できることを確認