### PR TITLE
TUIでwiki更新がコンフリクトした時にモーダル表示

### DIFF
--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -215,8 +215,9 @@ def main() -> None:
                         )
                     )
                 except WikiUpdateConflictException as e:
-                    print(messages.wiki_page_update_conflict.format(title=e.title))
-                    # TUI側にフィードバックをかける
+                    tui_state.error_modal = messages.wiki_page_update_conflict.format(
+                        title=e.title
+                    )
             elif tui_result.action == "create_time_entry":
                 if not tui_result.issue_id:
                     continue

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -505,6 +505,7 @@ class MessagesProto(Protocol):
     tui_filter_title: str
     tui_help_title: str
     """{label}"""
+    tui_error_modal_title: str
     tui_status_hint_issues: str
     """{page_label}"""
     tui_status_hint_wiki: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -369,6 +369,7 @@ class En(MessagesProto):
     tui_filter_hint = "\nTab/h/l:column jk:move Enter:apply c:clear all Esc/f:close"
     tui_filter_title = "Filter (Esc/f to close)"
     tui_help_title = "Help - {label} tab (any key to close)"
+    tui_error_modal_title = "Error (q to close)"
     tui_status_hint_issues = " {page_label}  jk:move /:search f:filter c:create u:update v:web ?:help q:quit "
     tui_status_hint_wiki = " jk:move /:search c:create u:update v:web ?:help q:quit "
     tui_status_hint_time_entries = (

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -367,6 +367,7 @@ class Ja(MessagesProto):
     tui_filter_hint = "\nTab/h/l:列切替 jk:移動 Enter:適用 c:全クリア Esc/f:閉じる"
     tui_filter_title = "フィルタ (Esc/f で閉じる)"
     tui_help_title = "ヘルプ - {label} タブ (任意のキーで閉じる)"
+    tui_error_modal_title = "エラー (q で閉じる)"
     tui_status_hint_issues = (
         " {page_label}  jk:移動 /:検索 f:フィルタ c:作成 u:更新 v:web ?:ヘルプ q:終了 "
     )

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -238,6 +238,11 @@ def _render_help(state: TuiState) -> Renderable:
     return parts
 
 
+def _render_error_modal(state: TuiState) -> Renderable:
+    body = state.error_modal or ""
+    return [("fg:ansired", body)]
+
+
 def _render_status(state: TuiState) -> Renderable:
     if state.confirm_delete_prompt is not None:
         return [("reverse", f" {state.confirm_delete_prompt} ")]
@@ -302,12 +307,14 @@ def run_issue_tui(
             and state.confirm_delete_prompt is None
             and not state.show_help
             and not state.issue_tab.filter_modal.show
+            and state.error_modal is None
         )
     )
     search_mode = Condition(lambda: state.search_mode)
     confirm_delete_mode = Condition(lambda: state.confirm_delete_prompt is not None)
     help_mode = Condition(lambda: state.show_help)
     filter_mode = Condition(lambda: state.issue_tab.filter_modal.show)
+    error_modal_mode = Condition(lambda: state.error_modal is not None)
 
     def _clear_temporary_state() -> None:
         state.number_buffer = ""
@@ -507,6 +514,10 @@ def run_issue_tui(
     def _(event):
         state.show_help = False
 
+    @kb.add("q", filter=error_modal_mode)
+    def _(event):
+        state.error_modal = None
+
     def _open_filter_modal() -> None:
         modal = state.issue_tab.filter_modal
         modal.status_choices = _build_status_choices()
@@ -704,9 +715,32 @@ def run_issue_tui(
         ),
     )
 
+    error_float = Float(
+        content=ConditionalContainer(
+            content=VSplit(
+                [
+                    Window(width=1, char=" "),
+                    Frame(
+                        Window(
+                            FormattedTextControl(
+                                lambda: _render_error_modal(state), show_cursor=False
+                            ),
+                            wrap_lines=True,
+                        ),
+                        title=lambda: messages.tui_error_modal_title,
+                    ),
+                    Window(width=1, char=" "),
+                ]
+            ),
+            filter=error_modal_mode,
+        ),
+    )
+
     app = Application(
         layout=Layout(
-            FloatContainer(content=main_layout, floats=[help_float, filter_float])
+            FloatContainer(
+                content=main_layout, floats=[help_float, filter_float, error_float]
+            )
         ),
         key_bindings=kb,
         full_screen=True,

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -312,9 +312,9 @@ def run_issue_tui(
     )
     search_mode = Condition(lambda: state.search_mode)
     confirm_delete_mode = Condition(lambda: state.confirm_delete_prompt is not None)
-    help_mode = Condition(lambda: state.show_help)
-    filter_mode = Condition(lambda: state.issue_tab.filter_modal.show)
-    error_modal_mode = Condition(lambda: state.error_modal is not None)
+    show_help_modal = Condition(lambda: state.show_help)
+    show_filter_modal = Condition(lambda: state.issue_tab.filter_modal.show)
+    show_error_modal = Condition(lambda: state.error_modal is not None)
 
     def _clear_temporary_state() -> None:
         state.number_buffer = ""
@@ -510,11 +510,11 @@ def run_issue_tui(
         _clear_temporary_state()
         state.show_help = True
 
-    @kb.add("<any>", filter=help_mode)
+    @kb.add("<any>", filter=show_help_modal)
     def _(event):
         state.show_help = False
 
-    @kb.add("q", filter=error_modal_mode)
+    @kb.add("q", filter=show_error_modal)
     def _(event):
         state.error_modal = None
 
@@ -542,18 +542,18 @@ def run_issue_tui(
         _clear_temporary_state()
         _open_filter_modal()
 
-    @kb.add("tab", filter=filter_mode)
-    @kb.add("s-tab", filter=filter_mode)
-    @kb.add("h", filter=filter_mode)
-    @kb.add("l", filter=filter_mode)
-    @kb.add("left", filter=filter_mode)
-    @kb.add("right", filter=filter_mode)
+    @kb.add("tab", filter=show_filter_modal)
+    @kb.add("s-tab", filter=show_filter_modal)
+    @kb.add("h", filter=show_filter_modal)
+    @kb.add("l", filter=show_filter_modal)
+    @kb.add("left", filter=show_filter_modal)
+    @kb.add("right", filter=show_filter_modal)
     def _(event):
         modal = state.issue_tab.filter_modal
         modal.focus = "assignee" if modal.focus == "status" else "status"
 
-    @kb.add("j", filter=filter_mode)
-    @kb.add("down", filter=filter_mode)
+    @kb.add("j", filter=show_filter_modal)
+    @kb.add("down", filter=show_filter_modal)
     def _(event):
         modal = state.issue_tab.filter_modal
         if modal.focus == "status":
@@ -565,8 +565,8 @@ def run_issue_tui(
                 len(modal.assignee_choices) - 1, modal.assignee_cursor + 1
             )
 
-    @kb.add("k", filter=filter_mode)
-    @kb.add("up", filter=filter_mode)
+    @kb.add("k", filter=show_filter_modal)
+    @kb.add("up", filter=show_filter_modal)
     def _(event):
         modal = state.issue_tab.filter_modal
         if modal.focus == "status":
@@ -574,7 +574,7 @@ def run_issue_tui(
         else:
             modal.assignee_cursor = max(0, modal.assignee_cursor - 1)
 
-    @kb.add("enter", filter=filter_mode)
+    @kb.add("enter", filter=show_filter_modal)
     def _(event):
         modal = state.issue_tab.filter_modal
         if modal.focus == "status":
@@ -592,7 +592,7 @@ def run_issue_tui(
         _reset_preview_scroll()
         reload_with_filter(state)
 
-    @kb.add("c", filter=filter_mode)
+    @kb.add("c", filter=show_filter_modal)
     def _(event):
         state.issue_tab.filter = IssueFilter()
         modal = state.issue_tab.filter_modal
@@ -601,9 +601,9 @@ def run_issue_tui(
         _reset_preview_scroll()
         reload_with_filter(state)
 
-    @kb.add("escape", filter=filter_mode)
-    @kb.add("f", filter=filter_mode)
-    @kb.add("q", filter=filter_mode)
+    @kb.add("escape", filter=show_filter_modal)
+    @kb.add("f", filter=show_filter_modal)
+    @kb.add("q", filter=show_filter_modal)
     def _(event):
         state.issue_tab.filter_modal.show = False
 
@@ -689,11 +689,10 @@ def run_issue_tui(
                     Window(width=1, char=" "),
                 ]
             ),
-            filter=help_mode,
+            filter=show_help_modal,
         ),
     )
 
-    show_filter_cond = Condition(lambda: state.issue_tab.filter_modal.show)
     filter_float = Float(
         content=ConditionalContainer(
             content=VSplit(
@@ -711,7 +710,7 @@ def run_issue_tui(
                     Window(width=1, char=" "),
                 ]
             ),
-            filter=show_filter_cond,
+            filter=show_filter_modal,
         ),
     )
 
@@ -732,7 +731,7 @@ def run_issue_tui(
                     Window(width=1, char=" "),
                 ]
             ),
-            filter=error_modal_mode,
+            filter=show_error_modal,
         ),
     )
 

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -127,3 +127,5 @@ class TuiState:
     # 右ペイン (preview) のスクロール位置 (先頭からの行数)。
     # カーソル移動・タブ切り替え時に 0 に戻す。
     preview_scroll: int = 0
+    # API エラー等を Float で出すための本文
+    error_modal: str | None = None


### PR DESCRIPTION
- **[update] wikiの更新がconflictした時にモーダル(float,dialog)を表示**
- **[refactor] modal表示判定の Condition 変数名を show_*_modal に統一**

---

書き込み操作の成功に気づかずに作業が進むことは避けたいのでダイアログでユーザー操作をブロックする(ステータスラインへの表示では済ませない)

<img width="966" height="1020" alt="image" src="https://github.com/user-attachments/assets/20215d99-18da-41c8-adc7-81688ee6e02a" />

## 関連 #134 

