### PR TITLE
close #142 RedmineのAPIが422を返した場合のエラーをTUIで表示

### DIFF
--- a/src/redi/api/exceptions.py
+++ b/src/redi/api/exceptions.py
@@ -1,22 +1,34 @@
+from typing import Literal, Self
+
 import requests
-from typing import Self
+
+ValidationAction = Literal["create", "update"]
 
 
 class RedmineValidationException(Exception):
     """Redmine API がバリデーションエラー (HTTP 422) を返したときに送出する例外。
 
     - `errors` には Redmine がレスポンス JSON の `errors` 配列で返したメッセージを格納する
-    - `resource` 例: "time_entry"
+    - `resource` 例: "time_entry" / "wiki"
+    - `action` は API 呼び出し時の意図 ("create" or "update")
     - JSON 解析に仮に失敗した場合は生のレスポンス本文を 1 要素として保持する
     """
 
-    def __init__(self, resource: str, errors: list[str]) -> None:
+    def __init__(
+        self, resource: str, action: ValidationAction, errors: list[str]
+    ) -> None:
         super().__init__("; ".join(errors) if errors else "validation error")
         self.resource = resource
+        self.action: ValidationAction = action
         self.errors = errors
 
     @classmethod
-    def from_response(cls, resource: str, response: requests.Response) -> Self:
+    def from_response(
+        cls,
+        resource: str,
+        action: ValidationAction,
+        response: requests.Response,
+    ) -> Self:
         errors: list[str] = []
         try:
             body = response.json()
@@ -31,4 +43,4 @@ class RedmineValidationException(Exception):
             text = response.text.strip()
             if text:
                 errors = [text]
-        return cls(resource, errors)
+        return cls(resource, action, errors)

--- a/src/redi/api/exceptions.py
+++ b/src/redi/api/exceptions.py
@@ -1,0 +1,34 @@
+import requests
+from typing import Self
+
+
+class RedmineValidationException(Exception):
+    """Redmine API がバリデーションエラー (HTTP 422) を返したときに送出する例外。
+
+    - `errors` には Redmine がレスポンス JSON の `errors` 配列で返したメッセージを格納する
+    - `resource` 例: "time_entry"
+    - JSON 解析に仮に失敗した場合は生のレスポンス本文を 1 要素として保持する
+    """
+
+    def __init__(self, resource: str, errors: list[str]) -> None:
+        super().__init__("; ".join(errors) if errors else "validation error")
+        self.resource = resource
+        self.errors = errors
+
+    @classmethod
+    def from_response(cls, resource: str, response: requests.Response) -> Self:
+        errors: list[str] = []
+        try:
+            body = response.json()
+        except requests.exceptions.JSONDecodeError:
+            body = None
+        if isinstance(body, dict):
+            raw = body.get("errors")
+            if isinstance(raw, list):
+                errors = [str(e) for e in raw]
+        # 422 で想定している型でなかった場合
+        if not errors:
+            text = response.text.strip()
+            if text:
+                errors = [text]
+        return cls(resource, errors)

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -4,6 +4,7 @@ import webbrowser
 import requests
 
 from redi.api.attachment import upload_file
+from redi.api.exceptions import RedmineValidationException
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -250,6 +251,11 @@ def create_issue(
     assigned_to_id: str | None = None,
     custom_fields: str | None = None,
 ) -> None:
+    """イシューを作成する
+
+    Raises:
+        RedmineValidationException: Redmine がバリデーションエラー (HTTP 422) を返した場合
+    """
     issue_data: dict = {
         "project_id": project_id,
         "subject": subject,
@@ -265,6 +271,8 @@ def create_issue(
     if custom_fields:
         issue_data["custom_fields"] = parse_custom_fields(custom_fields)
     response = client.post("/issues.json", json={"issue": issue_data})
+    if response.status_code == 422:
+        raise RedmineValidationException.from_response("issue", "create", response)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
@@ -295,6 +303,11 @@ def update_issue(
     custom_fields: str | None = None,
     attachments: list[str] = [],
 ) -> None:
+    """イシューを更新する
+
+    Raises:
+        RedmineValidationException: Redmine がバリデーションエラー (HTTP 422) を返した場合
+    """
     issue_data: dict = {}
     if subject:
         issue_data["subject"] = subject
@@ -330,6 +343,8 @@ def update_issue(
         print(messages.update_canceled)
         exit()
     response = client.put(f"/issues/{issue_id}.json", json={"issue": issue_data})
+    if response.status_code == 422:
+        raise RedmineValidationException.from_response("issue", "update", response)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from redi.api.exceptions import RedmineValidationException
 from redi.api.project import resolve_project_id
 from redi.client import client
 from redi.i18n import messages
@@ -15,6 +16,11 @@ def create_time_entry(
     spent_on: str | None = None,
     comments: str | None = None,
 ) -> None:
+    """作業時間を作成する
+
+    Raises:
+        RedmineValidationException: Redmine がバリデーションエラー (HTTP 422) を返した場合
+    """
     if not issue_id and not project_id:
         print(messages.issue_or_project_id_required)
         exit(1)
@@ -34,6 +40,8 @@ def create_time_entry(
     if comments:
         data["comments"] = comments
     response = client.post("/time_entries.json", json={"time_entry": data})
+    if response.status_code == 422:
+        raise RedmineValidationException.from_response("time_entry", response)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
@@ -171,6 +179,11 @@ def update_time_entry(
     spent_on: str | None = None,
     comments: str | None = None,
 ) -> None:
+    """作業時間を更新する
+
+    Raises:
+        RedmineValidationException: Redmine がバリデーションエラー (HTTP 422) を返した場合
+    """
     # time_entries は他の API と異なり project_id に slug を受け付けず整数のみ許容
     # https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
     if project_id is not None:
@@ -194,6 +207,8 @@ def update_time_entry(
     response = client.put(
         f"/time_entries/{time_entry_id}.json", json={"time_entry": data}
     )
+    if response.status_code == 422:
+        raise RedmineValidationException.from_response("time_entry", response)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -41,7 +41,7 @@ def create_time_entry(
         data["comments"] = comments
     response = client.post("/time_entries.json", json={"time_entry": data})
     if response.status_code == 422:
-        raise RedmineValidationException.from_response("time_entry", response)
+        raise RedmineValidationException.from_response("time_entry", "create", response)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
@@ -208,7 +208,7 @@ def update_time_entry(
         f"/time_entries/{time_entry_id}.json", json={"time_entry": data}
     )
     if response.status_code == 422:
-        raise RedmineValidationException.from_response("time_entry", response)
+        raise RedmineValidationException.from_response("time_entry", "update", response)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -158,7 +158,7 @@ def update_wiki(
     if response.status_code == 409:
         raise WikiUpdateConflictException(page_title)
     if response.status_code == 422:
-        raise RedmineValidationException.from_response("wiki", response)
+        raise RedmineValidationException.from_response("wiki", "update", response)
     response.raise_for_status()
     url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
     print(messages.wiki_page_updated.format(url=url))
@@ -212,7 +212,7 @@ def create_wiki(
         json={"wiki_page": body},
     )
     if response.status_code == 422:
-        raise RedmineValidationException.from_response("wiki", response)
+        raise RedmineValidationException.from_response("wiki", "create", response)
     response.raise_for_status()
     url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
     if exists:

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -5,6 +5,7 @@ from typing import NotRequired, TypedDict
 
 import requests
 
+from redi.api.exceptions import RedmineValidationException
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -144,7 +145,8 @@ def update_wiki(
 
     Raises:
         WikiUpdateConflictException: version がRedmine側の最新バージョンと一致せず、更新が競合した場合（HTTP 409）。
-        requests.exceptions.HTTPError: 409 以外の HTTP エラーが返った場合
+        RedmineValidationException: Redmine がバリデーションエラー (HTTP 422) を返した場合
+        requests.exceptions.HTTPError: 409 / 422 以外の HTTP エラーが返った場合
     """
     body: WikiPageUpdateBody = {"text": text, "comments": comments}
     if version is not None:
@@ -155,6 +157,8 @@ def update_wiki(
     )
     if response.status_code == 409:
         raise WikiUpdateConflictException(page_title)
+    if response.status_code == 422:
+        raise RedmineValidationException.from_response("wiki", response)
     response.raise_for_status()
     url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
     print(messages.wiki_page_updated.format(url=url))
@@ -182,6 +186,11 @@ def create_wiki(
     parent_title: str | None = None,
     comments: str = "",
 ) -> None:
+    """Wikiページを作成する
+
+    Raises:
+        RedmineValidationException: Redmine がバリデーションエラー (HTTP 422) を返した場合
+    """
     if parent_title:
         parent_exists = (
             client.get(f"/projects/{project_id}/wiki/{parent_title}.json").status_code
@@ -202,6 +211,8 @@ def create_wiki(
         f"/projects/{project_id}/wiki/{page_title}.json",
         json={"wiki_page": body},
     )
+    if response.status_code == 422:
+        raise RedmineValidationException.from_response("wiki", response)
     response.raise_for_status()
     url = f"{redmine_url}/projects/{project_id}/wiki/{page_title}"
     if exists:

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -49,6 +49,7 @@ from redi.api.enumeration import (
     list_issue_priorities,
     list_time_entry_activities,
 )
+from redi.api.exceptions import RedmineValidationException
 from redi.api.issue import add_note
 from redi.api.issue_status import list_issue_statuses
 from redi.api.query import list_queries
@@ -221,51 +222,72 @@ def main() -> None:
             elif tui_result.action == "create_time_entry":
                 if not tui_result.issue_id:
                     continue
-                handle_time_entry(
-                    argparse.Namespace(
-                        time_entry_command="create",
-                        project_id=None,
-                        user_id=None,
-                        full=False,
-                        hours=None,
-                        issue_id=tui_result.issue_id,
-                        activity_id=None,
-                        spent_on=None,
-                        comments=None,
+                try:
+                    handle_time_entry(
+                        argparse.Namespace(
+                            time_entry_command="create",
+                            project_id=None,
+                            user_id=None,
+                            full=False,
+                            hours=None,
+                            issue_id=tui_result.issue_id,
+                            activity_id=None,
+                            spent_on=None,
+                            comments=None,
+                        )
                     )
-                )
+                except RedmineValidationException as e:
+                    tui_state.error_modal = (
+                        messages.time_entry_create_validation_failed.format(
+                            errors="\n".join(f"- {err}" for err in e.errors)
+                        )
+                    )
             elif tui_result.action == "create" and tui_result.tab == "time_entries":
-                handle_time_entry(
-                    argparse.Namespace(
-                        time_entry_command="create",
-                        project_id=None,
-                        user_id=None,
-                        full=False,
-                        hours=None,
-                        issue_id=None,
-                        default_issue_id=tui_result.issue_id,
-                        activity_id=None,
-                        spent_on=None,
-                        comments=None,
+                try:
+                    handle_time_entry(
+                        argparse.Namespace(
+                            time_entry_command="create",
+                            project_id=None,
+                            user_id=None,
+                            full=False,
+                            hours=None,
+                            issue_id=None,
+                            default_issue_id=tui_result.issue_id,
+                            activity_id=None,
+                            spent_on=None,
+                            comments=None,
+                        )
                     )
-                )
+                except RedmineValidationException as e:
+                    tui_state.error_modal = (
+                        messages.time_entry_create_validation_failed.format(
+                            errors="\n".join(f"- {err}" for err in e.errors)
+                        )
+                    )
             elif tui_result.action == "update" and tui_result.tab == "time_entries":
                 if tui_result.time_entry_id is None:
                     continue
-                handle_time_entry(
-                    argparse.Namespace(
-                        time_entry_command="update",
-                        time_entry_id=tui_result.time_entry_id,
-                        project_id=None,
-                        user_id=None,
-                        full=False,
-                        hours=None,
-                        issue_id=None,
-                        activity_id=None,
-                        spent_on=None,
-                        comments=None,
+                try:
+                    handle_time_entry(
+                        argparse.Namespace(
+                            time_entry_command="update",
+                            time_entry_id=tui_result.time_entry_id,
+                            project_id=None,
+                            user_id=None,
+                            full=False,
+                            hours=None,
+                            issue_id=None,
+                            activity_id=None,
+                            spent_on=None,
+                            comments=None,
+                        )
                     )
-                )
+                except RedmineValidationException as e:
+                    tui_state.error_modal = (
+                        messages.time_entry_update_validation_failed.format(
+                            errors="\n".join(f"- {err}" for err in e.errors)
+                        )
+                    )
 
     if args.command in ("project", "p"):
         handle_project(args)
@@ -314,7 +336,18 @@ def main() -> None:
     elif args.command == "relation":
         handle_relation(args)
     elif args.command in ("time_entry", "te"):
-        handle_time_entry(args)
+        try:
+            handle_time_entry(args)
+        except RedmineValidationException as e:
+            operation = getattr(args, "time_entry_command", None)
+            if operation in ("create", "c"):
+                template = messages.time_entry_create_validation_failed
+            elif operation in ("update", "u"):
+                template = messages.time_entry_update_validation_failed
+            else:
+                raise AssertionError("unreachable")
+            print(template.format(errors="\n".join(f"- {err}" for err in e.errors)))
+            exit(1)
     elif args.command in ("file", "f"):
         handle_file(args)
     else:

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -18,7 +18,7 @@ from redi.cli.enumerations_command import (
     add_time_entry_activity_parser,
     add_tracker_parser,
 )
-from redi.cli._common import open_editor
+from redi.cli._common import open_editor, resolve_alias
 from redi.cli.group_command import add_group_parser, handle_group
 from redi.cli.init_command import add_init_parser, handle_init
 from redi.cli.issue_category_command import (
@@ -192,17 +192,24 @@ def main() -> None:
                 if notes:
                     add_note(tui_result.issue_id, notes)
             elif tui_result.action == "create" and tui_result.tab == "wiki":
-                handle_wiki(
-                    argparse.Namespace(
-                        wiki_command="create",
-                        project_id=None,
-                        full=False,
-                        page_title=None,
-                        parent_title=tui_result.parent_wiki_title,
-                        description=None,
-                        comments="",
+                try:
+                    handle_wiki(
+                        argparse.Namespace(
+                            wiki_command="create",
+                            project_id=None,
+                            full=False,
+                            page_title=None,
+                            parent_title=tui_result.parent_wiki_title,
+                            description=None,
+                            comments="",
+                        )
                     )
-                )
+                except RedmineValidationException as e:
+                    tui_state.error_modal = (
+                        messages.wiki_create_validation_failed.format(
+                            errors="\n".join(f"- {err}" for err in e.errors)
+                        )
+                    )
             elif tui_result.action == "update" and tui_result.tab == "wiki":
                 try:
                     handle_wiki(
@@ -218,6 +225,12 @@ def main() -> None:
                 except WikiUpdateConflictException as e:
                     tui_state.error_modal = messages.wiki_page_update_conflict.format(
                         title=e.title
+                    )
+                except RedmineValidationException as e:
+                    tui_state.error_modal = (
+                        messages.wiki_update_validation_failed.format(
+                            errors="\n".join(f"- {err}" for err in e.errors)
+                        )
                     )
             elif tui_result.action == "create_time_entry":
                 if not tui_result.issue_id:
@@ -300,6 +313,16 @@ def main() -> None:
             handle_wiki(args)
         except WikiUpdateConflictException as e:
             print(messages.wiki_page_update_conflict.format(title=e.title))
+            exit(1)
+        except RedmineValidationException as e:
+            operation = resolve_alias(getattr(args, "wiki_command", None))
+            if operation == "create":
+                template = messages.wiki_create_validation_failed
+            elif operation == "update":
+                template = messages.wiki_update_validation_failed
+            else:
+                raise AssertionError("unreachable")
+            print(template.format(errors="\n".join(f"- {err}" for err in e.errors)))
             exit(1)
     elif args.command in ("user", "u"):
         handle_user(args)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -18,7 +18,7 @@ from redi.cli.enumerations_command import (
     add_time_entry_activity_parser,
     add_tracker_parser,
 )
-from redi.cli._common import open_editor, resolve_alias
+from redi.cli._common import open_editor
 from redi.cli.group_command import add_group_parser, handle_group
 from redi.cli.init_command import add_init_parser, handle_init
 from redi.cli.issue_category_command import (
@@ -57,6 +57,20 @@ from redi.api.tracker import list_trackers
 from redi.api.wiki import WikiUpdateConflictException
 from redi.i18n import messages
 from redi.tui import TuiState, run_issue_tui
+
+
+# (resource, action) → 表示テンプレート。新しいリソースで 422 を扱うときはここに 1 行足す。
+_VALIDATION_TEMPLATES = {
+    ("wiki", "create"): messages.wiki_create_validation_failed,
+    ("wiki", "update"): messages.wiki_update_validation_failed,
+    ("time_entry", "create"): messages.time_entry_create_validation_failed,
+    ("time_entry", "update"): messages.time_entry_update_validation_failed,
+}
+
+
+def _format_validation_error(e: RedmineValidationException) -> str:
+    template = _VALIDATION_TEMPLATES[(e.resource, e.action)]
+    return template.format(errors="\n".join(f"- {err}" for err in e.errors))
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -145,54 +159,56 @@ def main() -> None:
             if tui_result is None:
                 return
             tui_state = TuiState(last_result=tui_result)
-            if tui_result.action == "update" and tui_result.tab == "issues":
-                update_args = argparse.Namespace(
-                    issue_id=tui_result.issue_id,
-                    subject=None,
-                    description=None,
-                    tracker_id=None,
-                    status_id=None,
-                    priority_id=None,
-                    assigned_to_id=None,
-                    fixed_version_id=None,
-                    parent_issue_id=None,
-                    start_date=None,
-                    due_date=None,
-                    done_ratio=None,
-                    estimated_hours=None,
-                    notes=None,
-                    custom_fields=None,
-                    relate=None,
-                    relate_to=None,
-                    delete_relation=False,
-                    attach=None,
-                    hours=None,
-                    activity_id=None,
-                    spent_on=None,
-                    time_comments=None,
-                    add_watcher_ids=None,
-                    remove_watcher_ids=None,
-                )
-                handle_issue_update(update_args)
-            elif tui_result.action == "create" and tui_result.tab == "issues":
-                create_args = argparse.Namespace(
-                    subject=None,
-                    project_id=None,
-                    tracker_id=None,
-                    priority_id=None,
-                    assigned_to_id=None,
-                    description=None,
-                    custom_fields=None,
-                )
-                handle_issue_create(create_args)
-            elif tui_result.action == "comment":
-                if tui_result.issue_id is None:
-                    continue
-                notes = open_editor()
-                if notes:
-                    add_note(tui_result.issue_id, notes)
-            elif tui_result.action == "create" and tui_result.tab == "wiki":
-                try:
+            try:
+                if tui_result.action == "update" and tui_result.tab == "issues":
+                    handle_issue_update(
+                        argparse.Namespace(
+                            issue_id=tui_result.issue_id,
+                            subject=None,
+                            description=None,
+                            tracker_id=None,
+                            status_id=None,
+                            priority_id=None,
+                            assigned_to_id=None,
+                            fixed_version_id=None,
+                            parent_issue_id=None,
+                            start_date=None,
+                            due_date=None,
+                            done_ratio=None,
+                            estimated_hours=None,
+                            notes=None,
+                            custom_fields=None,
+                            relate=None,
+                            relate_to=None,
+                            delete_relation=False,
+                            attach=None,
+                            hours=None,
+                            activity_id=None,
+                            spent_on=None,
+                            time_comments=None,
+                            add_watcher_ids=None,
+                            remove_watcher_ids=None,
+                        )
+                    )
+                elif tui_result.action == "create" and tui_result.tab == "issues":
+                    handle_issue_create(
+                        argparse.Namespace(
+                            subject=None,
+                            project_id=None,
+                            tracker_id=None,
+                            priority_id=None,
+                            assigned_to_id=None,
+                            description=None,
+                            custom_fields=None,
+                        )
+                    )
+                elif tui_result.action == "comment":
+                    if tui_result.issue_id is None:
+                        continue
+                    notes = open_editor()
+                    if notes:
+                        add_note(tui_result.issue_id, notes)
+                elif tui_result.action == "create" and tui_result.tab == "wiki":
                     handle_wiki(
                         argparse.Namespace(
                             wiki_command="create",
@@ -204,14 +220,7 @@ def main() -> None:
                             comments="",
                         )
                     )
-                except RedmineValidationException as e:
-                    tui_state.error_modal = (
-                        messages.wiki_create_validation_failed.format(
-                            errors="\n".join(f"- {err}" for err in e.errors)
-                        )
-                    )
-            elif tui_result.action == "update" and tui_result.tab == "wiki":
-                try:
+                elif tui_result.action == "update" and tui_result.tab == "wiki":
                     handle_wiki(
                         argparse.Namespace(
                             wiki_command="update",
@@ -222,20 +231,9 @@ def main() -> None:
                             comments="",
                         )
                     )
-                except WikiUpdateConflictException as e:
-                    tui_state.error_modal = messages.wiki_page_update_conflict.format(
-                        title=e.title
-                    )
-                except RedmineValidationException as e:
-                    tui_state.error_modal = (
-                        messages.wiki_update_validation_failed.format(
-                            errors="\n".join(f"- {err}" for err in e.errors)
-                        )
-                    )
-            elif tui_result.action == "create_time_entry":
-                if not tui_result.issue_id:
-                    continue
-                try:
+                elif tui_result.action == "create_time_entry":
+                    if not tui_result.issue_id:
+                        continue
                     handle_time_entry(
                         argparse.Namespace(
                             time_entry_command="create",
@@ -249,14 +247,7 @@ def main() -> None:
                             comments=None,
                         )
                     )
-                except RedmineValidationException as e:
-                    tui_state.error_modal = (
-                        messages.time_entry_create_validation_failed.format(
-                            errors="\n".join(f"- {err}" for err in e.errors)
-                        )
-                    )
-            elif tui_result.action == "create" and tui_result.tab == "time_entries":
-                try:
+                elif tui_result.action == "create" and tui_result.tab == "time_entries":
                     handle_time_entry(
                         argparse.Namespace(
                             time_entry_command="create",
@@ -271,16 +262,9 @@ def main() -> None:
                             comments=None,
                         )
                     )
-                except RedmineValidationException as e:
-                    tui_state.error_modal = (
-                        messages.time_entry_create_validation_failed.format(
-                            errors="\n".join(f"- {err}" for err in e.errors)
-                        )
-                    )
-            elif tui_result.action == "update" and tui_result.tab == "time_entries":
-                if tui_result.time_entry_id is None:
-                    continue
-                try:
+                elif tui_result.action == "update" and tui_result.tab == "time_entries":
+                    if tui_result.time_entry_id is None:
+                        continue
                     handle_time_entry(
                         argparse.Namespace(
                             time_entry_command="update",
@@ -295,12 +279,12 @@ def main() -> None:
                             comments=None,
                         )
                     )
-                except RedmineValidationException as e:
-                    tui_state.error_modal = (
-                        messages.time_entry_update_validation_failed.format(
-                            errors="\n".join(f"- {err}" for err in e.errors)
-                        )
-                    )
+            except RedmineValidationException as e:
+                tui_state.error_modal = _format_validation_error(e)
+            except WikiUpdateConflictException as e:
+                tui_state.error_modal = messages.wiki_page_update_conflict.format(
+                    title=e.title
+                )
 
     if args.command in ("project", "p"):
         handle_project(args)
@@ -315,14 +299,7 @@ def main() -> None:
             print(messages.wiki_page_update_conflict.format(title=e.title))
             exit(1)
         except RedmineValidationException as e:
-            operation = resolve_alias(getattr(args, "wiki_command", None))
-            if operation == "create":
-                template = messages.wiki_create_validation_failed
-            elif operation == "update":
-                template = messages.wiki_update_validation_failed
-            else:
-                raise AssertionError("unreachable")
-            print(template.format(errors="\n".join(f"- {err}" for err in e.errors)))
+            print(_format_validation_error(e))
             exit(1)
     elif args.command in ("user", "u"):
         handle_user(args)
@@ -362,14 +339,7 @@ def main() -> None:
         try:
             handle_time_entry(args)
         except RedmineValidationException as e:
-            operation = getattr(args, "time_entry_command", None)
-            if operation in ("create", "c"):
-                template = messages.time_entry_create_validation_failed
-            elif operation in ("update", "u"):
-                template = messages.time_entry_update_validation_failed
-            else:
-                raise AssertionError("unreachable")
-            print(template.format(errors="\n".join(f"- {err}" for err in e.errors)))
+            print(_format_validation_error(e))
             exit(1)
     elif args.command in ("file", "f"):
         handle_file(args)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -59,18 +59,12 @@ from redi.i18n import messages
 from redi.tui import TuiState, run_issue_tui
 
 
-# (resource, action) → 表示テンプレート。新しいリソースで 422 を扱うときはここに 1 行足す。
-_VALIDATION_TEMPLATES = {
-    ("wiki", "create"): messages.wiki_create_validation_failed,
-    ("wiki", "update"): messages.wiki_update_validation_failed,
-    ("time_entry", "create"): messages.time_entry_create_validation_failed,
-    ("time_entry", "update"): messages.time_entry_update_validation_failed,
-}
-
-
 def _format_validation_error(e: RedmineValidationException) -> str:
-    template = _VALIDATION_TEMPLATES[(e.resource, e.action)]
-    return template.format(errors="\n".join(f"- {err}" for err in e.errors))
+    return messages.validation_failed.format(
+        resource=e.resource,
+        action=e.action,
+        errors="\n".join(f"- {err}" for err in e.errors),
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -289,7 +283,11 @@ def main() -> None:
     if args.command in ("project", "p"):
         handle_project(args)
     elif args.command in ("issue", "i"):
-        handle_issue(args)
+        try:
+            handle_issue(args)
+        except RedmineValidationException as e:
+            print(_format_validation_error(e))
+            exit(1)
     elif args.command in ("version", "v"):
         handle_version(args)
     elif args.command in ("wiki", "w"):

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -60,9 +60,13 @@ from redi.tui import TuiState, run_issue_tui
 
 
 def _format_validation_error(e: RedmineValidationException) -> str:
+    action_label = {
+        "create": messages.action_create,
+        "update": messages.action_update,
+    }[e.action]
     return messages.validation_failed.format(
         resource=e.resource,
-        action=e.action,
+        action=action_label,
         errors="\n".join(f"- {err}" for err in e.errors),
     )
 

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -239,6 +239,10 @@ class MessagesProto(Protocol):
     time_entry_create_failed: str
     time_entry_update_failed: str
     time_entry_delete_failed: str
+    time_entry_create_validation_failed: str
+    """{errors}"""
+    time_entry_update_validation_failed: str
+    """{errors}"""
     attachment_delete_failed: str
     attachment_update_failed: str
     group_create_failed: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -225,6 +225,10 @@ class MessagesProto(Protocol):
     """{title}"""
     validation_failed: str
     """{resource} {action} {errors}"""
+    action_create: str
+    """validation_failed の {action} に埋め込む語 (en: create / ja: 作成)"""
+    action_update: str
+    """validation_failed の {action} に埋め込む語 (en: update / ja: 更新)"""
     membership_create_failed: str
     membership_update_failed: str
     membership_delete_failed: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -223,10 +223,8 @@ class MessagesProto(Protocol):
     wiki_page_delete_failed: str
     wiki_page_update_conflict: str
     """{title}"""
-    wiki_create_validation_failed: str
-    """{errors}"""
-    wiki_update_validation_failed: str
-    """{errors}"""
+    validation_failed: str
+    """{resource} {action} {errors}"""
     membership_create_failed: str
     membership_update_failed: str
     membership_delete_failed: str
@@ -243,10 +241,6 @@ class MessagesProto(Protocol):
     time_entry_create_failed: str
     time_entry_update_failed: str
     time_entry_delete_failed: str
-    time_entry_create_validation_failed: str
-    """{errors}"""
-    time_entry_update_validation_failed: str
-    """{errors}"""
     attachment_delete_failed: str
     attachment_update_failed: str
     group_create_failed: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -223,6 +223,10 @@ class MessagesProto(Protocol):
     wiki_page_delete_failed: str
     wiki_page_update_conflict: str
     """{title}"""
+    wiki_create_validation_failed: str
+    """{errors}"""
+    wiki_update_validation_failed: str
+    """{errors}"""
     membership_create_failed: str
     membership_update_failed: str
     membership_delete_failed: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -142,6 +142,8 @@ class En(MessagesProto):
         "Failed to update wiki page because it was updated by another user: {title}"
     )
     validation_failed = "Failed to {action} {resource} (validation error):\n{errors}"
+    action_create = "create"
+    action_update = "update"
     membership_create_failed = "Failed to create membership"
     membership_update_failed = "Failed to update membership"
     membership_delete_failed = "Failed to delete membership"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -141,6 +141,12 @@ class En(MessagesProto):
     wiki_page_update_conflict = (
         "Failed to update wiki page because it was updated by another user: {title}"
     )
+    wiki_create_validation_failed = (
+        "Failed to create wiki page (validation error):\n{errors}"
+    )
+    wiki_update_validation_failed = (
+        "Failed to update wiki page (validation error):\n{errors}"
+    )
     membership_create_failed = "Failed to create membership"
     membership_update_failed = "Failed to update membership"
     membership_delete_failed = "Failed to delete membership"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -141,12 +141,7 @@ class En(MessagesProto):
     wiki_page_update_conflict = (
         "Failed to update wiki page because it was updated by another user: {title}"
     )
-    wiki_create_validation_failed = (
-        "Failed to create wiki page (validation error):\n{errors}"
-    )
-    wiki_update_validation_failed = (
-        "Failed to update wiki page (validation error):\n{errors}"
-    )
+    validation_failed = "Failed to {action} {resource} (validation error):\n{errors}"
     membership_create_failed = "Failed to create membership"
     membership_update_failed = "Failed to update membership"
     membership_delete_failed = "Failed to delete membership"
@@ -161,12 +156,6 @@ class En(MessagesProto):
     time_entry_create_failed = "Failed to create time entry"
     time_entry_update_failed = "Failed to update time entry"
     time_entry_delete_failed = "Failed to delete time entry"
-    time_entry_create_validation_failed = (
-        "Failed to create time entry (validation error):\n{errors}"
-    )
-    time_entry_update_validation_failed = (
-        "Failed to update time entry (validation error):\n{errors}"
-    )
     attachment_delete_failed = "Failed to delete attachment"
     attachment_update_failed = "Failed to update attachment"
     group_create_failed = "Failed to create group"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -155,6 +155,12 @@ class En(MessagesProto):
     time_entry_create_failed = "Failed to create time entry"
     time_entry_update_failed = "Failed to update time entry"
     time_entry_delete_failed = "Failed to delete time entry"
+    time_entry_create_validation_failed = (
+        "Failed to create time entry (validation error):\n{errors}"
+    )
+    time_entry_update_validation_failed = (
+        "Failed to update time entry (validation error):\n{errors}"
+    )
     attachment_delete_failed = "Failed to delete attachment"
     attachment_update_failed = "Failed to update attachment"
     group_create_failed = "Failed to create group"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -143,6 +143,12 @@ class Ja(MessagesProto):
     watcher_remove_failed = "ウォッチャーの削除に失敗しました"
     wiki_page_delete_failed = "Wikiページの削除に失敗しました"
     wiki_page_update_conflict = "Wikiページが他のユーザーによって更新されているため更新できませんでした: {title}"
+    wiki_create_validation_failed = (
+        "Wikiページの作成に失敗しました (入力エラー):\n{errors}"
+    )
+    wiki_update_validation_failed = (
+        "Wikiページの更新に失敗しました (入力エラー):\n{errors}"
+    )
     membership_create_failed = "メンバーシップの作成に失敗しました"
     membership_update_failed = "メンバーシップの更新に失敗しました"
     membership_delete_failed = "メンバーシップの削除に失敗しました"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -143,12 +143,7 @@ class Ja(MessagesProto):
     watcher_remove_failed = "ウォッチャーの削除に失敗しました"
     wiki_page_delete_failed = "Wikiページの削除に失敗しました"
     wiki_page_update_conflict = "Wikiページが他のユーザーによって更新されているため更新できませんでした: {title}"
-    wiki_create_validation_failed = (
-        "Wikiページの作成に失敗しました (入力エラー):\n{errors}"
-    )
-    wiki_update_validation_failed = (
-        "Wikiページの更新に失敗しました (入力エラー):\n{errors}"
-    )
+    validation_failed = "{resource}の{action}に失敗しました(入力エラー):\n{errors}"
     membership_create_failed = "メンバーシップの作成に失敗しました"
     membership_update_failed = "メンバーシップの更新に失敗しました"
     membership_delete_failed = "メンバーシップの削除に失敗しました"
@@ -163,12 +158,6 @@ class Ja(MessagesProto):
     time_entry_create_failed = "作業時間の登録に失敗しました"
     time_entry_update_failed = "作業時間の更新に失敗しました"
     time_entry_delete_failed = "作業時間の削除に失敗しました"
-    time_entry_create_validation_failed = (
-        "作業時間の登録に失敗しました (入力エラー):\n{errors}"
-    )
-    time_entry_update_validation_failed = (
-        "作業時間の更新に失敗しました (入力エラー):\n{errors}"
-    )
     attachment_delete_failed = "添付ファイルの削除に失敗しました"
     attachment_update_failed = "添付ファイルの更新に失敗しました"
     group_create_failed = "グループの作成に失敗しました"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -144,6 +144,8 @@ class Ja(MessagesProto):
     wiki_page_delete_failed = "Wikiページの削除に失敗しました"
     wiki_page_update_conflict = "Wikiページが他のユーザーによって更新されているため更新できませんでした: {title}"
     validation_failed = "{resource}の{action}に失敗しました(入力エラー):\n{errors}"
+    action_create = "作成"
+    action_update = "更新"
     membership_create_failed = "メンバーシップの作成に失敗しました"
     membership_update_failed = "メンバーシップの更新に失敗しました"
     membership_delete_failed = "メンバーシップの削除に失敗しました"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -157,6 +157,12 @@ class Ja(MessagesProto):
     time_entry_create_failed = "作業時間の登録に失敗しました"
     time_entry_update_failed = "作業時間の更新に失敗しました"
     time_entry_delete_failed = "作業時間の削除に失敗しました"
+    time_entry_create_validation_failed = (
+        "作業時間の登録に失敗しました (入力エラー):\n{errors}"
+    )
+    time_entry_update_validation_failed = (
+        "作業時間の更新に失敗しました (入力エラー):\n{errors}"
+    )
     attachment_delete_failed = "添付ファイルの削除に失敗しました"
     attachment_update_failed = "添付ファイルの更新に失敗しました"
     group_create_failed = "グループの作成に失敗しました"


### PR DESCRIPTION
## Summary
- Redmine の create/update が 422 (バリデーションエラー) を返したとき、TUI ではモーダルで、CLI ではメッセージを出すよう統一
- 対象リソース: time_entry / wiki / issue
- バリデーションエラーは `RedmineValidationException` (新設) として送出し、TUI ループ・CLI ディスパッチでそれぞれ 1 箇所に集約して catch

## Test plan
- [x] TUI で issue / wiki / time_entry の create/update を空欄など不正値で実行してエラーモーダルが表示されること
    - time_entryを作成時に日付をYYYY-MM-DD形式にしない場合にエラーモーダル表示
    - `redi i c "test"`
        - カスタムフィールドが必須な場合の作成時
    - `redi i u "test"`
        - カスタムフィールドが必須な場合の更新時
    - `redi w c "wiki" -d " "`
    - `redi w u "wiki" -d " "`

- [x] CLI (`redi i c` 等) で 422 が返るケースで標準出力に「{resource}の{作成|更新}に失敗しました(入力エラー):」が表示され exit 1 すること
- [x] 日本語ロケール (`redi config update --language ja`) と英語ロケールでメッセージがそれぞれ整形されること
- [x] `task check` (format / lint / typecheck / pytest) がローカルで通ること