### PR TITLE
close #144 issueの存在しないprojectでTUIが即終了する問題を修正

### DIFF
--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -274,9 +274,6 @@ def run_issue_tui(
     state.issue_tab.total_count = initial_page.get(
         "total_count", len(state.issue_tab.issues)
     )
-    if state.tab == "issues" and not state.issue_tab.issues:
-        print(messages.issue_not_found_simple)
-        return None
     if state.issue_tab.issues:
         state.issue_tab.cursor = max(
             0, min(position.cursor, len(state.issue_tab.issues) - 1)

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -29,6 +29,8 @@ def _exit_result(
 
 
 def _render_list(state: TuiState) -> Renderable:
+    if not state.issue_tab.issues:
+        return [("", messages.issue_not_found_simple)]
     result: Renderable = []
     query = state.search_query
     for i, issue in enumerate(state.issue_tab.issues):
@@ -125,6 +127,8 @@ def _on_up(state: TuiState) -> None:
 
 
 def _on_down(state: TuiState) -> None:
+    if not state.issue_tab.issues:
+        return
     state.issue_tab.cursor = min(
         len(state.issue_tab.issues) - 1, state.issue_tab.cursor + 1
     )
@@ -226,10 +230,14 @@ def _on_search(state: TuiState, query: str, forward: bool = True) -> None:
 
 def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
     if key == "u":
+        if not state.issue_tab.issues:
+            return None
         return _exit_result(state, "update")
     if key == "c":
         return _exit_result(state, "create", issue_id="")
     if key == "n":
+        if not state.issue_tab.issues:
+            return None
         return _exit_result(state, "comment")
     if key == "t":
         if not state.issue_tab.issues:


### PR DESCRIPTION
## Summary
- issue が空のプロジェクトでも `redi --tui` が即終了せず起動するよう修正
- 空のときはリスト枠にメッセージを表示するだけにし、Tab で wiki / time_entries タブに切り替え可能
- 空状態で `u` (update) / `n` (comment) が押された場合は何もしないようガード ( `c` (create) と `t` (create_time_entry) は従来通り)

## Test plan
- [x] issue が 1 件もない project に切り替えて `redi --tui` が起動 → 即終了しない
- [x] その状態から Tab で wiki / time_entries タブに切り替えて操作できる
- [x] その状態で `c` を押すと issue 作成フローに入る
- [x] その状態で `u` / `n` を押しても TUI が落ちない / 何も起きない
- [x] issue がある project では従来通りの一覧 / カーソル操作になる