### PR TITLE
[update] --profile オプションをサブコマンドの後ろに置けるようにする

### DIFF
--- a/src/redi/cli/attachment_command.py
+++ b/src/redi/cli/attachment_command.py
@@ -10,14 +10,19 @@ from redi.cli._common import confirm_delete, resolve_alias
 from redi.i18n import messages
 
 
-def add_attachment_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_attachment_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     a_parser = subparsers.add_parser(
-        "attachment", aliases=["a"], help=messages.arg_help_attachment_command
+        "attachment",
+        aliases=["a"],
+        help=messages.arg_help_attachment_command,
+        parents=parents,
     )
     a_subparsers = a_parser.add_subparsers(dest="attachment_command")
     a_parser.set_defaults(_print_help=a_parser.print_help)
     a_view_parser = a_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_attachment_view
+        "view", aliases=["v"], help=messages.arg_help_attachment_view, parents=parents
     )
     a_view_parser.add_argument(
         "attachment_id", help=messages.arg_help_attachment_view_id
@@ -26,7 +31,10 @@ def add_attachment_parser(subparsers: argparse._SubParsersAction) -> None:
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     a_update_parser = a_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_attachment_update
+        "update",
+        aliases=["u"],
+        help=messages.arg_help_attachment_update,
+        parents=parents,
     )
     a_update_parser.add_argument(
         "attachment_id", help=messages.arg_help_attachment_update_id
@@ -38,7 +46,10 @@ def add_attachment_parser(subparsers: argparse._SubParsersAction) -> None:
         "--description", "-d", help=messages.arg_help_attachment_description
     )
     a_delete_parser = a_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_attachment_delete
+        "delete",
+        aliases=["d"],
+        help=messages.arg_help_attachment_delete,
+        parents=parents,
     )
     a_delete_parser.add_argument(
         "attachment_id", help=messages.arg_help_attachment_delete_id

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -11,16 +11,18 @@ from redi.config import (
 from redi.i18n import messages, select_messages
 
 
-def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_config_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     c_parser = subparsers.add_parser(
-        "config", aliases=["c"], help=messages.arg_help_config_command
+        "config", aliases=["c"], help=messages.arg_help_config_command, parents=parents
     )
     c_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_profiles
     )
     c_subparsers = c_parser.add_subparsers(dest="config_command")
     c_update_parser = c_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_config_update
+        "update", aliases=["u"], help=messages.arg_help_config_update, parents=parents
     )
     c_update_parser.add_argument(
         "profile_name",
@@ -45,7 +47,7 @@ def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
         "--default_profile", help=messages.arg_help_config_set_default_profile
     )
     c_create_parser = c_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_config_create
+        "create", aliases=["c"], help=messages.arg_help_config_create, parents=parents
     )
     c_create_parser.add_argument(
         "profile_name", help=messages.arg_help_config_create_profile_name

--- a/src/redi/cli/enumerations_command.py
+++ b/src/redi/cli/enumerations_command.py
@@ -3,67 +3,95 @@ import argparse
 from redi.i18n import messages
 
 
-def add_tracker_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_tracker_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     tracker_parser = subparsers.add_parser(
-        "tracker", aliases=["t"], help=messages.arg_help_tracker_command
+        "tracker",
+        aliases=["t"],
+        help=messages.arg_help_tracker_command,
+        parents=parents,
     )
     tracker_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
 
 
-def add_issue_status_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_issue_status_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     issue_status_parser = subparsers.add_parser(
-        "issue_status", aliases=["is"], help=messages.arg_help_issue_status_command
+        "issue_status",
+        aliases=["is"],
+        help=messages.arg_help_issue_status_command,
+        parents=parents,
     )
     issue_status_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
 
 
-def add_issue_priority_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_issue_priority_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     ip_parser = subparsers.add_parser(
-        "issue_priority", aliases=["ip"], help=messages.arg_help_issue_priority_command
+        "issue_priority",
+        aliases=["ip"],
+        help=messages.arg_help_issue_priority_command,
+        parents=parents,
     )
     ip_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
 
 
-def add_time_entry_activity_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_time_entry_activity_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     tea_parser = subparsers.add_parser(
         "time_entry_activity",
         aliases=["tea"],
         help=messages.arg_help_time_entry_activity_command,
+        parents=parents,
     )
     tea_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
 
 
-def add_document_category_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_document_category_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     dc_parser = subparsers.add_parser(
         "document_category",
         aliases=["dc"],
         help=messages.arg_help_document_category_command,
+        parents=parents,
     )
     dc_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
 
 
-def add_query_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_query_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     query_parser = subparsers.add_parser(
-        "query", aliases=["q"], help=messages.arg_help_query_command
+        "query", aliases=["q"], help=messages.arg_help_query_command, parents=parents
     )
     query_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
 
 
-def add_custom_field_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_custom_field_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     cf_parser = subparsers.add_parser(
-        "custom_field", aliases=["cf"], help=messages.arg_help_custom_field_command
+        "custom_field",
+        aliases=["cf"],
+        help=messages.arg_help_custom_field_command,
+        parents=parents,
     )
     cf_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json

--- a/src/redi/cli/file_command.py
+++ b/src/redi/cli/file_command.py
@@ -6,18 +6,22 @@ from redi.config import default_project_id
 from redi.i18n import messages
 
 
-def add_file_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_file_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     f_parser = subparsers.add_parser(
-        "file", aliases=["f"], help=messages.arg_help_file_command
+        "file", aliases=["f"], help=messages.arg_help_file_command, parents=parents
     )
     f_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     f_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     f_subparsers = f_parser.add_subparsers(dest="file_command")
-    f_subparsers.add_parser("list", aliases=["l"], help=messages.arg_help_file_list)
+    f_subparsers.add_parser(
+        "list", aliases=["l"], help=messages.arg_help_file_list, parents=parents
+    )
     f_create_parser = f_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_file_create
+        "create", aliases=["c"], help=messages.arg_help_file_create, parents=parents
     )
     f_create_parser.add_argument("file_path", help=messages.arg_help_file_path)
     f_create_parser.add_argument(

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -14,28 +14,31 @@ from redi.api.group import (
 )
 
 
-def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_group_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     group_parser = subparsers.add_parser(
         "group",
         aliases=["g"],
         help=messages.arg_help_group_command,
+        parents=parents,
     )
     group_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     group_subparsers = group_parser.add_subparsers(dest="group_command")
     group_subparsers.add_parser(
-        "list", aliases=["l"], help=messages.arg_help_group_list
+        "list", aliases=["l"], help=messages.arg_help_group_list, parents=parents
     )
     g_view_parser = group_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_group_view
+        "view", aliases=["v"], help=messages.arg_help_group_view, parents=parents
     )
     g_view_parser.add_argument("group_id", help=messages.arg_help_group_view_id)
     g_view_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     g_create_parser = group_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_group_create
+        "create", aliases=["c"], help=messages.arg_help_group_create, parents=parents
     )
     g_create_parser.add_argument("name", help=messages.arg_help_group_name)
     g_create_parser.add_argument(
@@ -46,7 +49,7 @@ def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
         help=messages.arg_help_group_user_id,
     )
     g_update_parser = group_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_group_update
+        "update", aliases=["u"], help=messages.arg_help_group_update, parents=parents
     )
     g_update_parser.add_argument("group_id", help=messages.arg_help_group_update_id)
     g_update_parser.add_argument("--name", "-n", help=messages.arg_help_group_name_opt)
@@ -72,7 +75,7 @@ def add_group_parser(subparsers: argparse._SubParsersAction) -> None:
         help=messages.arg_help_group_remove_user,
     )
     g_delete_parser = group_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_group_delete
+        "delete", aliases=["d"], help=messages.arg_help_group_delete, parents=parents
     )
     g_delete_parser.add_argument("group_id", help=messages.arg_help_group_delete_id)
     g_delete_parser.add_argument(

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -13,10 +13,13 @@ from redi.i18n import messages
 PROFILE_NAME = "default"
 
 
-def add_init_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_init_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     subparsers.add_parser(
         "init",
         help=messages.arg_help_init_command,
+        parents=parents,
     )
 
 

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -13,13 +13,11 @@ from redi.i18n import messages
 PROFILE_NAME = "default"
 
 
-def add_init_parser(
-    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
-) -> None:
+def add_init_parser(subparsers: argparse._SubParsersAction) -> None:
+    # init は新規プロファイル作成専用で --profile は意味を持たないため parents を受けない
     subparsers.add_parser(
         "init",
         help=messages.arg_help_init_command,
-        parents=parents,
     )
 
 

--- a/src/redi/cli/issue_category_command.py
+++ b/src/redi/cli/issue_category_command.py
@@ -13,11 +13,14 @@ from redi.api.issue_category import (
 )
 
 
-def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_issue_category_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     ic_parser = subparsers.add_parser(
         "issue_category",
         aliases=["ic"],
         help=messages.arg_help_issue_category_command,
+        parents=parents,
     )
     ic_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     ic_parser.add_argument(
@@ -25,11 +28,17 @@ def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     ic_subparsers = ic_parser.add_subparsers(dest="issue_category_command")
     ic_subparsers.add_parser(
-        "list", aliases=["l"], help=messages.arg_help_issue_category_list
+        "list",
+        aliases=["l"],
+        help=messages.arg_help_issue_category_list,
+        parents=parents,
     )
 
     ic_view_parser = ic_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_issue_category_view
+        "view",
+        aliases=["v"],
+        help=messages.arg_help_issue_category_view,
+        parents=parents,
     )
     ic_view_parser.add_argument(
         "category_id", help=messages.arg_help_issue_category_view_id
@@ -39,7 +48,10 @@ def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     ic_create_parser = ic_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_issue_category_create
+        "create",
+        aliases=["c"],
+        help=messages.arg_help_issue_category_create,
+        parents=parents,
     )
     ic_create_parser.add_argument("name", help=messages.arg_help_issue_category_name)
     ic_create_parser.add_argument(
@@ -52,7 +64,10 @@ def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     ic_update_parser = ic_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_issue_category_update
+        "update",
+        aliases=["u"],
+        help=messages.arg_help_issue_category_update,
+        parents=parents,
     )
     ic_update_parser.add_argument(
         "category_id", help=messages.arg_help_issue_category_update_id
@@ -67,7 +82,10 @@ def add_issue_category_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     ic_delete_parser = ic_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_issue_category_delete
+        "delete",
+        aliases=["d"],
+        help=messages.arg_help_issue_category_delete,
+        parents=parents,
     )
     ic_delete_parser.add_argument(
         "category_id", help=messages.arg_help_issue_category_delete_id

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -42,11 +42,14 @@ from redi.api.custom_field import (
 )
 
 
-def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_issue_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     i_parser = subparsers.add_parser(
         "issue",
         aliases=["i"],
         help=messages.arg_help_issue_command,
+        parents=parents,
     )
     i_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
@@ -81,9 +84,11 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
     i_parser.add_argument("--limit", "-l", type=int, help=messages.arg_help_limit)
     i_parser.add_argument("--offset", "-o", type=int, help=messages.arg_help_offset)
     i_subparsers = i_parser.add_subparsers(dest="issue_command")
-    i_subparsers.add_parser("list", aliases=["l"], help=messages.arg_help_issue_list)
+    i_subparsers.add_parser(
+        "list", aliases=["l"], help=messages.arg_help_issue_list, parents=parents
+    )
     i_view_parser = i_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_issue_view
+        "view", aliases=["v"], help=messages.arg_help_issue_view, parents=parents
     )
     i_view_parser.add_argument("issue_id", help=messages.arg_help_issue_view_id)
     i_view_parser.add_argument(
@@ -97,7 +102,7 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
         "--web", "-w", action="store_true", help=messages.arg_help_open_web
     )
     i_create_parser = i_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_issue_create
+        "create", aliases=["c"], help=messages.arg_help_issue_create, parents=parents
     )
     i_create_parser.add_argument(
         "subject", nargs="?", help=messages.arg_help_issue_subject_arg
@@ -127,7 +132,7 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
         help=messages.arg_help_custom_fields,
     )
     i_update_parser = i_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_issue_update
+        "update", aliases=["u"], help=messages.arg_help_issue_update, parents=parents
     )
     i_update_parser.add_argument(
         "issue_id", nargs="?", help=messages.arg_help_issue_update_id
@@ -216,14 +221,14 @@ def add_issue_parser(subparsers: argparse._SubParsersAction) -> None:
         help=messages.arg_help_issue_remove_watcher,
     )
     i_comment_parser = i_subparsers.add_parser(
-        "comment", aliases=["co"], help=messages.arg_help_issue_comment
+        "comment", aliases=["co"], help=messages.arg_help_issue_comment, parents=parents
     )
     i_comment_parser.add_argument("issue_id", help=messages.arg_help_issue_view_id)
     i_comment_parser.add_argument(
         "notes", nargs="?", default="", help=messages.arg_help_issue_comment_notes
     )
     i_delete_parser = i_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_issue_delete
+        "delete", aliases=["d"], help=messages.arg_help_issue_delete, parents=parents
     )
     i_delete_parser.add_argument("issue_id", help=messages.arg_help_issue_view_id)
     i_delete_parser.add_argument(

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -71,18 +71,19 @@ def _format_validation_error(e: RedmineValidationException) -> str:
     )
 
 
-def _make_profile_parent() -> argparse.ArgumentParser:
-    """各サブパーサが parents=[] で継承するための --profile 専用パーサ。
-
-    add_help=False にしないと子パーサと -h/--help が衝突する。default=SUPPRESS は、
-    --profile を指定しなかったネストされたサブパーサが args.profile を None で
-    上書きしてしまうのを避けるため（親で設定された値を子パーサが潰さないように）。
-    """
-    p = argparse.ArgumentParser(add_help=False)
-    p.add_argument(
-        "--profile", default=argparse.SUPPRESS, help=messages.arg_help_profile
+def _profile_parser() -> argparse.ArgumentParser:
+    """--profile を後置するためのパーサ"""
+    parser = argparse.ArgumentParser(
+        # 親子でヘルプを衝突させない
+        add_help=False,
     )
-    return p
+    parser.add_argument(
+        "--profile",
+        # 下流のパーサでprofileが未指定の場合に上流パーサの値を上書きするのを防ぐ
+        default=argparse.SUPPRESS,
+        help=messages.arg_help_profile,
+    )
+    return parser
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -99,10 +100,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--profile",
-        default=argparse.SUPPRESS,
         help=messages.arg_help_profile,
     )
-    parents = [_make_profile_parent()]
+    parents = [_profile_parser()]
     subparsers = parser.add_subparsers(dest="command")
     add_project_parser(subparsers, parents)
     add_issue_parser(subparsers, parents)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -86,7 +86,7 @@ def _profile_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def build_redi_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=messages.arg_help_root_description)
     parser.add_argument(
         "-V", "--version", action="version", version=f"redi {version('redtile')}"
@@ -133,7 +133,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
-    parser = _build_parser()
+    parser = build_redi_parser()
     argcomplete.autocomplete(parser)
     args = parser.parse_args()
 

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -109,7 +109,7 @@ def build_redi_parser() -> argparse.ArgumentParser:
     add_version_parser(subparsers, parents)
     add_wiki_parser(subparsers, parents)
     add_config_parser(subparsers, parents)
-    add_init_parser(subparsers, parents)
+    add_init_parser(subparsers)
     add_user_parser(subparsers, parents)
     add_me_parser(subparsers, parents)
     add_membership_parser(subparsers, parents)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -71,6 +71,20 @@ def _format_validation_error(e: RedmineValidationException) -> str:
     )
 
 
+def _make_profile_parent() -> argparse.ArgumentParser:
+    """各サブパーサが parents=[] で継承するための --profile 専用パーサ。
+
+    add_help=False にしないと子パーサと -h/--help が衝突する。default=SUPPRESS は、
+    --profile を指定しなかったネストされたサブパーサが args.profile を None で
+    上書きしてしまうのを避けるため（親で設定された値を子パーサが潰さないように）。
+    """
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument(
+        "--profile", default=argparse.SUPPRESS, help=messages.arg_help_profile
+    )
+    return p
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=messages.arg_help_root_description)
     parser.add_argument(
@@ -85,34 +99,36 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--profile",
+        default=argparse.SUPPRESS,
         help=messages.arg_help_profile,
     )
+    parents = [_make_profile_parent()]
     subparsers = parser.add_subparsers(dest="command")
-    add_project_parser(subparsers)
-    add_issue_parser(subparsers)
-    add_version_parser(subparsers)
-    add_wiki_parser(subparsers)
-    add_config_parser(subparsers)
-    add_init_parser(subparsers)
-    add_user_parser(subparsers)
-    add_me_parser(subparsers)
-    add_membership_parser(subparsers)
-    add_news_parser(subparsers)
-    add_tracker_parser(subparsers)
-    add_issue_status_parser(subparsers)
-    add_issue_priority_parser(subparsers)
-    add_time_entry_activity_parser(subparsers)
-    add_document_category_parser(subparsers)
-    add_role_parser(subparsers)
-    add_group_parser(subparsers)
-    add_query_parser(subparsers)
-    add_custom_field_parser(subparsers)
-    add_issue_category_parser(subparsers)
-    add_search_parser(subparsers)
-    add_attachment_parser(subparsers)
-    add_relation_parser(subparsers)
-    add_time_entry_parser(subparsers)
-    add_file_parser(subparsers)
+    add_project_parser(subparsers, parents)
+    add_issue_parser(subparsers, parents)
+    add_version_parser(subparsers, parents)
+    add_wiki_parser(subparsers, parents)
+    add_config_parser(subparsers, parents)
+    add_init_parser(subparsers, parents)
+    add_user_parser(subparsers, parents)
+    add_me_parser(subparsers, parents)
+    add_membership_parser(subparsers, parents)
+    add_news_parser(subparsers, parents)
+    add_tracker_parser(subparsers, parents)
+    add_issue_status_parser(subparsers, parents)
+    add_issue_priority_parser(subparsers, parents)
+    add_time_entry_activity_parser(subparsers, parents)
+    add_document_category_parser(subparsers, parents)
+    add_role_parser(subparsers, parents)
+    add_group_parser(subparsers, parents)
+    add_query_parser(subparsers, parents)
+    add_custom_field_parser(subparsers, parents)
+    add_issue_category_parser(subparsers, parents)
+    add_search_parser(subparsers, parents)
+    add_attachment_parser(subparsers, parents)
+    add_relation_parser(subparsers, parents)
+    add_time_entry_parser(subparsers, parents)
+    add_file_parser(subparsers, parents)
     return parser
 
 

--- a/src/redi/cli/me_command.py
+++ b/src/redi/cli/me_command.py
@@ -5,15 +5,19 @@ from redi.i18n import messages
 from redi.api.me import read_my_account, update_my_account
 
 
-def add_me_parser(subparsers: argparse._SubParsersAction) -> None:
-    me_parser = subparsers.add_parser("me", help=messages.arg_help_me_command)
+def add_me_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
+    me_parser = subparsers.add_parser(
+        "me", help=messages.arg_help_me_command, parents=parents
+    )
     me_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     me_subparsers = me_parser.add_subparsers(dest="me_command")
 
     me_update_parser = me_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_me_update
+        "update", aliases=["u"], help=messages.arg_help_me_update, parents=parents
     )
     me_update_parser.add_argument(
         "--firstname", "-f", help=messages.arg_help_user_firstname

--- a/src/redi/cli/membership_command.py
+++ b/src/redi/cli/membership_command.py
@@ -17,11 +17,14 @@ def _parse_role_ids(value: str) -> list[int]:
     return [int(v) for v in value.split(",") if v.strip()]
 
 
-def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_membership_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     m_parser = subparsers.add_parser(
         "membership",
         aliases=["m"],
         help=messages.arg_help_membership_command,
+        parents=parents,
     )
     m_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     m_parser.add_argument(
@@ -29,11 +32,11 @@ def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     m_subparsers = m_parser.add_subparsers(dest="membership_command")
     m_subparsers.add_parser(
-        "list", aliases=["l"], help=messages.arg_help_membership_list
+        "list", aliases=["l"], help=messages.arg_help_membership_list, parents=parents
     )
 
     m_view_parser = m_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_membership_view
+        "view", aliases=["v"], help=messages.arg_help_membership_view, parents=parents
     )
     m_view_parser.add_argument(
         "membership_id", help=messages.arg_help_membership_view_id
@@ -43,7 +46,10 @@ def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     m_create_parser = m_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_membership_create
+        "create",
+        aliases=["c"],
+        help=messages.arg_help_membership_create,
+        parents=parents,
     )
     m_create_parser.add_argument(
         "--project_id", "-p", help=messages.arg_help_project_id
@@ -62,7 +68,10 @@ def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     m_update_parser = m_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_membership_update
+        "update",
+        aliases=["u"],
+        help=messages.arg_help_membership_update,
+        parents=parents,
     )
     m_update_parser.add_argument(
         "membership_id", help=messages.arg_help_membership_update_id
@@ -75,7 +84,10 @@ def add_membership_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     m_delete_parser = m_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_membership_delete
+        "delete",
+        aliases=["d"],
+        help=messages.arg_help_membership_delete,
+        parents=parents,
     )
     m_delete_parser.add_argument(
         "membership_id", help=messages.arg_help_membership_delete_id

--- a/src/redi/cli/news_command.py
+++ b/src/redi/cli/news_command.py
@@ -5,9 +5,11 @@ from redi.i18n import messages
 from redi.api.news import list_news
 
 
-def add_news_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_news_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     n_parser = subparsers.add_parser(
-        "news", aliases=["n"], help=messages.arg_help_news_command
+        "news", aliases=["n"], help=messages.arg_help_news_command, parents=parents
     )
     n_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     n_parser.add_argument(

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -14,19 +14,24 @@ from redi.api.project import (
 )
 
 
-def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_project_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     p_parser = subparsers.add_parser(
         "project",
         aliases=["p"],
         help=messages.arg_help_project_command,
+        parents=parents,
     )
     p_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     p_subparsers = p_parser.add_subparsers(dest="project_command")
-    p_subparsers.add_parser("list", aliases=["l"], help=messages.arg_help_project_list)
+    p_subparsers.add_parser(
+        "list", aliases=["l"], help=messages.arg_help_project_list, parents=parents
+    )
     p_view_parser = p_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_project_view
+        "view", aliases=["v"], help=messages.arg_help_project_view, parents=parents
     )
     p_view_parser.add_argument("project_id", help=messages.arg_help_project_view_id)
     p_view_parser.add_argument(
@@ -40,7 +45,7 @@ def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
         "--web", "-w", action="store_true", help=messages.arg_help_open_web
     )
     p_create_parser = p_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_project_create
+        "create", aliases=["c"], help=messages.arg_help_project_create, parents=parents
     )
     p_create_parser.add_argument("name", help=messages.arg_help_project_name)
     p_create_parser.add_argument(
@@ -57,14 +62,14 @@ def add_project_parser(subparsers: argparse._SubParsersAction) -> None:
     p_create_parser.add_argument("--parent_id", help=messages.arg_help_parent_id)
     p_create_parser.add_argument("--tracker_ids", help=messages.arg_help_tracker_ids)
     p_delete_parser = p_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_project_delete
+        "delete", aliases=["d"], help=messages.arg_help_project_delete, parents=parents
     )
     p_delete_parser.add_argument("project_id", help=messages.arg_help_project_delete_id)
     p_delete_parser.add_argument(
         "-y", "--yes", action="store_true", help=messages.arg_help_skip_confirm
     )
     p_update_parser = p_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_project_update
+        "update", aliases=["u"], help=messages.arg_help_project_update, parents=parents
     )
     p_update_parser.add_argument("project_id", help=messages.arg_help_project_update_id)
     p_update_parser.add_argument("--name", "-n", help=messages.arg_help_project_name)

--- a/src/redi/cli/relation_command.py
+++ b/src/redi/cli/relation_command.py
@@ -5,9 +5,11 @@ from redi.cli._common import resolve_alias
 from redi.i18n import messages
 
 
-def add_relation_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_relation_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     r_parser = subparsers.add_parser(
-        "relation", help=messages.arg_help_relation_command
+        "relation", help=messages.arg_help_relation_command, parents=parents
     )
     r_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
@@ -15,7 +17,7 @@ def add_relation_parser(subparsers: argparse._SubParsersAction) -> None:
     r_subparsers = r_parser.add_subparsers(dest="relation_command")
     r_parser.set_defaults(_print_help=r_parser.print_help)
     r_view_parser = r_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_relation_view
+        "view", aliases=["v"], help=messages.arg_help_relation_view, parents=parents
     )
     r_view_parser.add_argument("relation_id", help=messages.arg_help_relation_view_id)
     r_view_parser.add_argument(

--- a/src/redi/cli/role_command.py
+++ b/src/redi/cli/role_command.py
@@ -5,17 +5,21 @@ from redi.i18n import messages
 from redi.api.role import list_roles, read_role
 
 
-def add_role_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_role_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     role_parser = subparsers.add_parser(
-        "role", aliases=["r"], help=messages.arg_help_role_command
+        "role", aliases=["r"], help=messages.arg_help_role_command, parents=parents
     )
     role_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     role_subparsers = role_parser.add_subparsers(dest="role_command")
-    role_subparsers.add_parser("list", aliases=["l"], help=messages.arg_help_role_list)
+    role_subparsers.add_parser(
+        "list", aliases=["l"], help=messages.arg_help_role_list, parents=parents
+    )
     role_view_parser = role_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_role_view
+        "view", aliases=["v"], help=messages.arg_help_role_view, parents=parents
     )
     role_view_parser.add_argument("role_id", help=messages.arg_help_role_view_id)
     role_view_parser.add_argument(

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -4,9 +4,11 @@ from redi.api.search import search
 from redi.i18n import messages
 
 
-def add_search_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_search_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     search_parser = subparsers.add_parser(
-        "search", aliases=["s"], help=messages.arg_help_search_command
+        "search", aliases=["s"], help=messages.arg_help_search_command, parents=parents
     )
     search_parser.add_argument("query", help=messages.arg_help_search_query)
     search_parser.add_argument("--limit", "-l", type=int, help=messages.arg_help_limit)

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -30,11 +30,14 @@ from redi.api.time_entry import (
 )
 
 
-def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_time_entry_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     time_entry_parser = subparsers.add_parser(
         "time_entry",
         aliases=["te"],
         help=messages.arg_help_time_entry_command,
+        parents=parents,
     )
     time_entry_parser.add_argument(
         "--project_id", "-p", help=messages.arg_help_project_id
@@ -47,10 +50,13 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     te_subparsers = time_entry_parser.add_subparsers(dest="time_entry_command")
     te_subparsers.add_parser(
-        "list", aliases=["l"], help=messages.arg_help_time_entry_list
+        "list", aliases=["l"], help=messages.arg_help_time_entry_list, parents=parents
     )
     te_create_parser = te_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_time_entry_create
+        "create",
+        aliases=["c"],
+        help=messages.arg_help_time_entry_create,
+        parents=parents,
     )
     te_create_parser.add_argument(
         "hours", type=float, nargs="?", help=messages.arg_help_time_entry_hours
@@ -71,7 +77,7 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
         "--comments", "-c", help=messages.arg_help_time_entry_comments
     )
     te_view_parser = te_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_time_entry_view
+        "view", aliases=["v"], help=messages.arg_help_time_entry_view, parents=parents
     )
     te_view_parser.add_argument(
         "time_entry_id", help=messages.arg_help_time_entry_view_id
@@ -80,7 +86,10 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     te_update_parser = te_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_time_entry_update
+        "update",
+        aliases=["u"],
+        help=messages.arg_help_time_entry_update,
+        parents=parents,
     )
     te_update_parser.add_argument(
         "time_entry_id", help=messages.arg_help_time_entry_update_id
@@ -104,7 +113,10 @@ def add_time_entry_parser(subparsers: argparse._SubParsersAction) -> None:
         "--comments", "-c", help=messages.arg_help_time_entry_comments
     )
     te_delete_parser = te_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_time_entry_delete
+        "delete",
+        aliases=["d"],
+        help=messages.arg_help_time_entry_delete,
+        parents=parents,
     )
     te_delete_parser.add_argument(
         "time_entry_id", help=messages.arg_help_time_entry_delete_id

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -22,19 +22,24 @@ MAIL_NOTIFICATION_CHOICES = [
 ]
 
 
-def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_user_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     u_parser = subparsers.add_parser(
         "user",
         aliases=["u"],
         help=messages.arg_help_user_command,
+        parents=parents,
     )
     u_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     u_subparsers = u_parser.add_subparsers(dest="user_command")
-    u_subparsers.add_parser("list", aliases=["l"], help=messages.arg_help_user_list)
+    u_subparsers.add_parser(
+        "list", aliases=["l"], help=messages.arg_help_user_list, parents=parents
+    )
     u_create_parser = u_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_user_create
+        "create", aliases=["c"], help=messages.arg_help_user_create, parents=parents
     )
     u_create_parser.add_argument("login", help=messages.arg_help_user_login)
     u_create_parser.add_argument(
@@ -70,7 +75,7 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     u_view_parser = u_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_user_view
+        "view", aliases=["v"], help=messages.arg_help_user_view, parents=parents
     )
     u_view_parser.add_argument("user_id", help=messages.arg_help_user_view_id)
     u_view_parser.add_argument(
@@ -78,7 +83,7 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     u_update_parser = u_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_user_update
+        "update", aliases=["u"], help=messages.arg_help_user_update, parents=parents
     )
     u_update_parser.add_argument("user_id", help=messages.arg_help_user_update_id)
     u_update_parser.add_argument("--login", help=messages.arg_help_user_login)
@@ -112,7 +117,7 @@ def add_user_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
     u_delete_parser = u_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_user_delete
+        "delete", aliases=["d"], help=messages.arg_help_user_delete, parents=parents
     )
     u_delete_parser.add_argument("user_id", help=messages.arg_help_user_delete_id)
     u_delete_parser.add_argument(

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -26,20 +26,25 @@ from redi.api.version import (
 )
 
 
-def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_version_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     v_parser = subparsers.add_parser(
         "version",
         aliases=["v"],
         help=messages.arg_help_version_command,
+        parents=parents,
     )
     v_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     v_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     v_subparsers = v_parser.add_subparsers(dest="version_command")
-    v_subparsers.add_parser("list", aliases=["l"], help=messages.arg_help_version_list)
+    v_subparsers.add_parser(
+        "list", aliases=["l"], help=messages.arg_help_version_list, parents=parents
+    )
     v_view_parser = v_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_version_view
+        "view", aliases=["v"], help=messages.arg_help_version_view, parents=parents
     )
     v_view_parser.add_argument("version_id", help=messages.arg_help_version_view_id)
     v_view_parser.add_argument(
@@ -49,7 +54,7 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
         "--web", "-w", action="store_true", help=messages.arg_help_open_web
     )
     v_create_parser = v_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_version_create
+        "create", aliases=["c"], help=messages.arg_help_version_create, parents=parents
     )
     v_create_parser.add_argument(
         "name", nargs="?", default=None, help=messages.arg_help_version_name_arg
@@ -72,14 +77,14 @@ def add_version_parser(subparsers: argparse._SubParsersAction) -> None:
         help=messages.arg_help_version_sharing,
     )
     v_delete_parser = v_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_version_delete
+        "delete", aliases=["d"], help=messages.arg_help_version_delete, parents=parents
     )
     v_delete_parser.add_argument("version_id", help=messages.arg_help_version_delete_id)
     v_delete_parser.add_argument(
         "-y", "--yes", action="store_true", help=messages.arg_help_skip_confirm
     )
     v_update_parser = v_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_version_update
+        "update", aliases=["u"], help=messages.arg_help_version_update, parents=parents
     )
     v_update_parser.add_argument(
         "version_id", nargs="?", help=messages.arg_help_version_update_id

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -41,20 +41,25 @@ def build_wiki_tree_choices(pages: list[dict]) -> list[tuple[str, str]]:
     return options
 
 
-def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
+def add_wiki_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
     w_parser = subparsers.add_parser(
         "wiki",
         aliases=["w"],
         help=messages.arg_help_wiki_command,
+        parents=parents,
     )
     w_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
     w_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     w_subparsers = w_parser.add_subparsers(dest="wiki_command")
-    w_subparsers.add_parser("list", aliases=["l"], help=messages.arg_help_wiki_list)
+    w_subparsers.add_parser(
+        "list", aliases=["l"], help=messages.arg_help_wiki_list, parents=parents
+    )
     w_view_parser = w_subparsers.add_parser(
-        "view", aliases=["v"], help=messages.arg_help_wiki_view
+        "view", aliases=["v"], help=messages.arg_help_wiki_view, parents=parents
     )
     w_view_parser.add_argument("page_title", help=messages.arg_help_wiki_page_title)
     w_view_parser.add_argument(
@@ -67,7 +72,7 @@ def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
         "--version", type=int, help=messages.arg_help_wiki_version
     )
     w_create_parser = w_subparsers.add_parser(
-        "create", aliases=["c"], help=messages.arg_help_wiki_create
+        "create", aliases=["c"], help=messages.arg_help_wiki_create, parents=parents
     )
     w_create_parser.add_argument(
         "page_title", nargs="?", help=messages.arg_help_wiki_create_title
@@ -89,14 +94,14 @@ def add_wiki_parser(subparsers: argparse._SubParsersAction) -> None:
         help=messages.arg_help_wiki_comments,
     )
     w_delete_parser = w_subparsers.add_parser(
-        "delete", aliases=["d"], help=messages.arg_help_wiki_delete
+        "delete", aliases=["d"], help=messages.arg_help_wiki_delete, parents=parents
     )
     w_delete_parser.add_argument("page_title", help=messages.arg_help_wiki_page_title)
     w_delete_parser.add_argument(
         "-y", "--yes", action="store_true", help=messages.arg_help_skip_confirm
     )
     w_update_parser = w_subparsers.add_parser(
-        "update", aliases=["u"], help=messages.arg_help_wiki_update
+        "update", aliases=["u"], help=messages.arg_help_wiki_update, parents=parents
     )
     w_update_parser.add_argument(
         "page_title", nargs="?", help=messages.arg_help_wiki_update_title

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -16,6 +16,7 @@ class TestProfileFlagPlacement:
         """ルート直後の `--profile foo issue list` を受け付ける"""
         args = parser.parse_args(["--profile", "foo", "issue", "list"])
 
+        assert args.profile == "foo"
         assert args.command == "issue"
         assert args.issue_command == "list"
 
@@ -44,8 +45,8 @@ class TestProfileFlagPlacement:
         assert args.profile == "foo"
 
     def test_after_resource_only_subcommand(self, parser):
-        """ネストの無い `tracker --profile foo` のような呼び出しも受け付ける"""
-        args = parser.parse_args(["tracker", "--profile", "foo"])
+        """ネストの無い `me --profile foo` のような呼び出しも受け付ける"""
+        args = parser.parse_args(["me", "--profile", "foo"])
 
-        assert args.command == "tracker"
+        assert args.command == "me"
         assert args.profile == "foo"

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -50,3 +50,11 @@ class TestProfileFlagPlacement:
 
         assert args.command == "me"
         assert args.profile == "foo"
+
+    def test_with_tui_flag(self, parser):
+        """サブコマンド無しで `--tui --profile foo` の組み合わせも受け付ける"""
+        args = parser.parse_args(["--tui", "--profile", "foo"])
+
+        assert args.tui is True
+        assert args.profile == "foo"
+        assert args.command is None

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -2,7 +2,7 @@ import argparse
 
 import pytest
 
-from redi.cli.main import _build_parser
+from redi.cli.main import build_redi_parser
 
 
 class TestProfileFlagPlacement:
@@ -10,7 +10,7 @@ class TestProfileFlagPlacement:
 
     @pytest.fixture
     def parser(self) -> argparse.ArgumentParser:
-        return _build_parser()
+        return build_redi_parser()
 
     def test_before_subcommand(self, parser):
         """ルート直後の `--profile foo issue list` を受け付ける"""

--- a/tests/unit/test_cli_main.py
+++ b/tests/unit/test_cli_main.py
@@ -1,0 +1,51 @@
+import argparse
+
+import pytest
+
+from redi.cli.main import _build_parser
+
+
+class TestProfileFlagPlacement:
+    """--profile はサブコマンドの前後どちらに置いても受け付けられる"""
+
+    @pytest.fixture
+    def parser(self) -> argparse.ArgumentParser:
+        return _build_parser()
+
+    def test_before_subcommand(self, parser):
+        """ルート直後の `--profile foo issue list` を受け付ける"""
+        args = parser.parse_args(["--profile", "foo", "issue", "list"])
+
+        assert args.command == "issue"
+        assert args.issue_command == "list"
+
+    def test_after_top_level_subcommand(self, parser):
+        """1階層目のサブコマンドの後ろの `issue --profile foo list` を受け付ける"""
+        args = parser.parse_args(["issue", "--profile", "foo", "list"])
+
+        assert args.command == "issue"
+        assert args.issue_command == "list"
+        assert args.profile == "foo"
+
+    def test_after_nested_subcommand(self, parser):
+        """ネストされたサブコマンドの後ろの `issue list --profile foo` を受け付ける"""
+        args = parser.parse_args(["issue", "list", "--profile", "foo"])
+
+        assert args.command == "issue"
+        assert args.issue_command == "list"
+        assert args.profile == "foo"
+
+    def test_after_nested_subcommand_with_equals(self, parser):
+        """`--profile=foo` 形式もサブコマンド後ろで受け付ける"""
+        args = parser.parse_args(["issue", "create", "--profile=foo"])
+
+        assert args.command == "issue"
+        assert args.issue_command == "create"
+        assert args.profile == "foo"
+
+    def test_after_resource_only_subcommand(self, parser):
+        """ネストの無い `tracker --profile foo` のような呼び出しも受け付ける"""
+        args = parser.parse_args(["tracker", "--profile", "foo"])
+
+        assert args.command == "tracker"
+        assert args.profile == "foo"


### PR DESCRIPTION
resolve #146 

## Summary
- `--profile` をサブコマンドの後ろ (`redi issue list --profile foo` や `redi issue --profile foo list`) に置けるようにした
- 共通の親パーサ `_make_profile_parent()` を作り、各 `add_*_parser` に `parents` 引数を追加してサブパーサ (ネスト含む) で継承する
- `default=argparse.SUPPRESS` を指定し、子サブパーサが親で設定された `args.profile` を `None` で上書きしないようにした
- 各サブコマンドの `--help` にも `--profile` が表示されるようになった

## Test plan
- [x] `redi --profile foo issue list` (従来通り) で profile が解決されること
- [x] `redi issue --profile foo list` (1階層目の後ろ) で profile が解決されること
- [x] `redi issue list --profile foo` (ネストの後ろ) で profile が解決されること
- [x] `redi issue create --profile=foo` (`=` 形式) で profile が解決されること
- [x] `redi tracker --profile foo` (ネスト無いサブコマンド) で profile が解決されること
- [x] `redi issue list --help` に `--profile` が表示されること
- [x] `task check` がパスすること