### PR TITLE
close #148  issue create でブラウザに値を引き継いで開く選択肢を追加

### DIFF
--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -1,5 +1,7 @@
 import argparse
 import re
+import urllib.parse
+import webbrowser
 from datetime import date
 
 from prompt_toolkit import prompt
@@ -13,7 +15,7 @@ from redi.cli._common import (
     resolve_alias,
 )
 from redi.cli.prompt_util import DueDateValidator, HourValidator
-from redi.config import default_project_id
+from redi.config import default_project_id, redmine_url
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
     add_note,
@@ -23,6 +25,7 @@ from redi.api.issue import (
     fetch_issue,
     fetch_issues,
     list_issues,
+    parse_custom_fields,
     read_issue,
     remove_watcher,
     update_issue,
@@ -234,6 +237,35 @@ def add_issue_parser(
     i_delete_parser.add_argument(
         "-y", "--yes", action="store_true", help=messages.arg_help_skip_confirm
     )
+
+
+def _build_create_issue_url(
+    project_id: str,
+    subject: str = "",
+    description: str = "",
+    tracker_id: str | None = None,
+    priority_id: str | None = None,
+    assigned_to_id: str | None = None,
+    custom_fields: str | None = None,
+) -> str:
+    params: list[tuple[str, str]] = []
+    if subject:
+        params.append(("issue[subject]", subject))
+    if description:
+        params.append(("issue[description]", description))
+    if tracker_id:
+        params.append(("issue[tracker_id]", tracker_id))
+    if priority_id:
+        params.append(("issue[priority_id]", priority_id))
+    if assigned_to_id:
+        params.append(("issue[assigned_to_id]", assigned_to_id))
+    if custom_fields:
+        for cf in parse_custom_fields(custom_fields):
+            params.append((f"issue[custom_field_values][{cf['id']}]", str(cf["value"])))
+    base = f"{redmine_url}/projects/{project_id}/issues/new"
+    if not params:
+        return base
+    return f"{base}?{urllib.parse.urlencode(params)}"
 
 
 def _interactive_select_issue_id() -> str:
@@ -516,6 +548,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
     subject = args.subject
     tracker_id = args.tracker_id
     custom_fields = args.custom_fields
+    interactive = subject is None or args.description is None
     if subject is None:
         if tracker_id is None:
             trackers = fetch_trackers()
@@ -549,6 +582,28 @@ def handle_issue_create(args: argparse.Namespace) -> None:
         description = open_editor()
     else:
         description = args.description
+    if interactive:
+        action_options: list[tuple[str, str]] = [
+            ("submit", messages.action_submit),
+            ("browser", messages.action_continue_in_browser),
+        ]
+        try:
+            action = inline_choice(messages.prompt_what_next, action_options)
+        except KeyboardInterrupt:
+            print(messages.canceled)
+            exit(1)
+        if action == "browser":
+            url = _build_create_issue_url(
+                project_id=project_id,
+                subject=subject,
+                description=description,
+                tracker_id=tracker_id,
+                priority_id=args.priority_id,
+                assigned_to_id=args.assigned_to_id,
+                custom_fields=custom_fields,
+            )
+            webbrowser.open(url)
+            return
     create_issue(
         project_id=project_id,
         subject=subject,

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -354,6 +354,12 @@ class MessagesProto(Protocol):
     """{name}, {value}"""
     prompt_custom_field_label: str
     """{name}"""
+    prompt_what_next: str
+    """イシュー作成時に次のアクションを選ばせるメニューのタイトル"""
+    action_submit: str
+    """prompt_what_next の選択肢: そのまま送信"""
+    action_continue_in_browser: str
+    """prompt_what_next の選択肢: ブラウザで続きを編集"""
 
     # ---- prompt validators ----
     error_input_required: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -246,6 +246,9 @@ class En(MessagesProto):
     prompt_required_field = "{name} (required)"
     prompt_field_value = "{name}: {value}"
     prompt_custom_field_label = "{name}: "
+    prompt_what_next = "What's next?"
+    action_submit = "Submit"
+    action_continue_in_browser = "Continue in browser"
 
     # ---- prompt validators ----
     error_input_required = "Required"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -248,6 +248,9 @@ class Ja(MessagesProto):
     prompt_required_field = "{name}（必須）"
     prompt_field_value = "{name}: {value}"
     prompt_custom_field_label = "{name}: "
+    prompt_what_next = "次のアクションを選択してください"
+    action_submit = "送信する"
+    action_continue_in_browser = "ブラウザで編集する"
 
     # ---- prompt validators ----
     error_input_required = "入力してください"


### PR DESCRIPTION
## Summary
- `redi issue create` の対話モードで subject / description を入力した後に「送信する / ブラウザで編集する」の2択メニューを表示する
- 「ブラウザで編集する」を選ぶと `{redmine_url}/projects/{project_id}/issues/new?issue[subject]=...&issue[description]=...&issue[tracker_id]=...` の形で入力済みの値をクエリパラメータに乗せてブラウザを開く
- カスタムフィールドの定義を取得できない非管理者がカスタムフィールド必須なイシュー作成を完結する手段になる / プレビュー・添付ファイル操作はブラウザ側で行いたいケースの回避策になる

## Test plan
- [x] `redi issue create` で対話モードに入り、subject と description を入れた後にメニューが出ること
- [x] 「送信する」を選ぶと従来通り API 経由でイシューが作成されること
- [x] 「ブラウザで編集する」を選ぶと subject / description / tracker / priority / assignee がプリセットされた新規イシュー画面がブラウザで開くこと
- [x] `redi issue create foo -d bar` のように subject / description を両方 CLI 引数で渡したときはメニューが出ず即送信されること