### PR TITLE
TUI: R キーで現在のタブを再読込する操作を追加

### DIFF
--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -516,6 +516,7 @@ class MessagesProto(Protocol):
     """{page_label}"""
     tui_status_hint_wiki: str
     tui_status_hint_time_entries: str
+    tui_flash_reloaded: str
     tui_filter_status_open_default: str
     tui_filter_status_all: str
     tui_filter_status_closed_only: str
@@ -864,6 +865,7 @@ class MessagesProto(Protocol):
     tui_help_start_search: str
     tui_help_next_prev_match: str
     tui_help_filter_status_assignee: str
+    tui_help_reload: str
     tui_help_show_or_close: str
     tui_help_quit: str
 

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -378,6 +378,7 @@ class En(MessagesProto):
     tui_status_hint_time_entries = (
         " jk:move /:search c:create u:update v:web ?:help q:quit "
     )
+    tui_flash_reloaded = "Reloaded"
     tui_filter_status_open_default = "open (default)"
     tui_filter_status_all = "all (open + closed)"
     tui_filter_status_closed_only = "closed only"
@@ -736,6 +737,7 @@ class En(MessagesProto):
     tui_help_start_search = "Start search"
     tui_help_next_prev_match = "Next / previous match"
     tui_help_filter_status_assignee = "Filter by status/assignee (floating)"
+    tui_help_reload = "Reload the current tab"
     tui_help_show_or_close = "Show / close this help"
     tui_help_quit = "Quit"
 

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -378,6 +378,7 @@ class Ja(MessagesProto):
     tui_status_hint_time_entries = (
         " jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
     )
+    tui_flash_reloaded = "再読込しました"
     tui_filter_status_open_default = "open (デフォルト)"
     tui_filter_status_all = "全て (open + closed)"
     tui_filter_status_closed_only = "closed のみ"
@@ -742,6 +743,7 @@ class Ja(MessagesProto):
     tui_help_start_search = "検索開始"
     tui_help_next_prev_match = "次 / 前の検索結果"
     tui_help_filter_status_assignee = "ステータス/担当者でフィルタ (フローティング)"
+    tui_help_reload = "現在のタブを再読込"
     tui_help_show_or_close = "このヘルプを表示 / 閉じる"
     tui_help_quit = "終了"
 

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -485,6 +485,13 @@ def run_issue_tui(
         if prompt is not None:
             state.confirm_delete_prompt = prompt
 
+    @kb.add("R", filter=normal_mode)
+    def _(event):
+        _clear_temporary_state()
+        _reset_preview_scroll()
+        TABS[state.tab].on_reload(state)
+        state.flash_message = messages.tui_flash_reloaded
+
     @kb.add("y", filter=confirm_delete_mode)
     @kb.add("Y", filter=confirm_delete_mode)
     def _(event):

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -183,6 +183,20 @@ def reload_with_filter(state: TuiState) -> None:
     _apply_page(state, fetch_issues_with_filter(state, 0), 0)
 
 
+def _on_reload(state: TuiState) -> None:
+    """現在のフィルタ・ページのまま再取得する。カーソル位置はクランプして保持する。"""
+    prev_cursor = state.issue_tab.cursor
+    page = fetch_issues_with_filter(state, state.issue_tab.offset)
+    state.issue_tab.issues = page["issues"]
+    state.issue_tab.total_count = page.get("total_count", len(page["issues"]))
+    if state.issue_tab.issues:
+        state.issue_tab.cursor = max(
+            0, min(prev_cursor, len(state.issue_tab.issues) - 1)
+        )
+    else:
+        state.issue_tab.cursor = 0
+
+
 def _on_page_forward(state: TuiState) -> None:
     next_offset = state.issue_tab.offset + state.page_size
     page = fetch_issues_with_filter(state, next_offset)
@@ -267,6 +281,7 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  n", messages.tui_help_issue_add_comment),
     ("  t", messages.tui_help_issue_create_time_entry),
     ("  v / <N>V", messages.tui_help_issue_open_web_or_n),
+    ("  R", messages.tui_help_reload),
     (messages.tui_help_section_other, ""),
     ("  ?", messages.tui_help_show_or_close),
     ("  q / Esc / Ctrl+C", messages.tui_help_quit),
@@ -289,6 +304,7 @@ ISSUE_TAB = TabView(
     on_open_web=_on_open_web,
     on_open_web_by_id=_on_open_web_by_id,
     on_activate=noop,
+    on_reload=_on_reload,
     on_action_key=_on_action_key,
     on_search=_on_search,
     get_cursor_y=lambda state: state.issue_tab.cursor,

--- a/src/redi/tui/tab.py
+++ b/src/redi/tui/tab.py
@@ -21,6 +21,7 @@ class TabView:
     on_open_web: Callable[[TuiState], None]
     on_open_web_by_id: Callable[[TuiState, int], None]
     on_activate: Callable[[TuiState], None]
+    on_reload: Callable[[TuiState], None]
     on_action_key: Callable[[TuiState, str], TuiResult | None]
     on_search: Callable[..., None]
     # 一覧内でのカーソル行 (0-indexed)。prompt_toolkit の Window 自動スクロールに使う。

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -212,6 +212,28 @@ def confirm_delete(state: TuiState) -> None:
         state.time_entry_tab.cursor = max(0, len(entries) - 1)
 
 
+def _on_reload(state: TuiState) -> None:
+    """time_entry 一覧を取り直す。
+
+    `loaded` を立てたままだと `_load_time_entries` が早期 return するので
+    一度倒す。既存のカーソル位置は entry id 一致で復元を試み、無ければ先頭に戻る。
+    """
+    prev_id: int | None = None
+    if state.time_entry_tab.entries:
+        prev_id = state.time_entry_tab.entries[state.time_entry_tab.cursor].get("id")
+    state.time_entry_tab.loaded = False
+    state.time_entry_tab.error = None
+    state.time_entry_tab.entries = []
+    state.time_entry_tab.issue_subjects = {}
+    state.time_entry_tab.cursor = 0
+    _load_time_entries(state)
+    if prev_id is not None:
+        for i, te in enumerate(state.time_entry_tab.entries):
+            if te.get("id") == prev_id:
+                state.time_entry_tab.cursor = i
+                return
+
+
 def _on_open_web(state: TuiState) -> None:
     entries = state.time_entry_tab.entries
     if not entries:
@@ -240,6 +262,7 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  u", messages.tui_help_time_entry_update),
     ("  D", messages.tui_help_time_entry_delete),
     ("  v", messages.tui_help_time_entry_open_web),
+    ("  R", messages.tui_help_reload),
     (messages.tui_help_section_other, ""),
     ("  ?", messages.tui_help_show_or_close),
     ("  q / Esc / Ctrl+C", messages.tui_help_quit),
@@ -262,6 +285,7 @@ TIME_ENTRY_TAB = TabView(
     on_open_web=_on_open_web,
     on_open_web_by_id=noop_jump,
     on_activate=_load_time_entries,
+    on_reload=_on_reload,
     on_action_key=_on_action_key,
     on_search=_on_search,
     get_cursor_y=lambda state: state.time_entry_tab.cursor,

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -185,6 +185,29 @@ def _on_search(state: TuiState, query: str, forward: bool = True) -> None:
             return
 
 
+def _on_reload(state: TuiState) -> None:
+    """Wiki ページ一覧と読込済み本文をクリアして取り直す。
+
+    `loaded` を立てたままだと `_load_wikis` が早期 return するので一度倒す。
+    既存のカーソル位置はタイトル一致で復元を試み、無ければ先頭に戻る。
+    """
+    prev_title: str | None = None
+    if state.wiki_tab.pages:
+        prev_title = state.wiki_tab.pages[state.wiki_tab.cursor].get("title")
+    state.wiki_tab.loaded = False
+    state.wiki_tab.error = None
+    state.wiki_tab.pages = []
+    state.wiki_tab.labels = []
+    state.wiki_tab.texts = {}
+    state.wiki_tab.cursor = 0
+    _load_wikis(state)
+    if prev_title is not None:
+        for i, page in enumerate(state.wiki_tab.pages):
+            if page.get("title") == prev_title:
+                state.wiki_tab.cursor = i
+                return
+
+
 def _on_open_web(state: TuiState) -> None:
     if not state.wiki_tab.pages:
         return
@@ -212,6 +235,7 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  c", messages.tui_help_wiki_create_child),
     ("  u", messages.tui_help_wiki_update_page),
     ("  v", messages.tui_help_wiki_open_web),
+    ("  R", messages.tui_help_reload),
     (messages.tui_help_section_other, ""),
     ("  ?", messages.tui_help_show_or_close),
     ("  q / Esc / Ctrl+C", messages.tui_help_quit),
@@ -234,6 +258,7 @@ WIKI_TAB = TabView(
     on_open_web=_on_open_web,
     on_open_web_by_id=noop_jump,
     on_activate=_load_wikis,
+    on_reload=_on_reload,
     on_action_key=_on_action_key,
     on_search=_on_search,
     get_cursor_y=lambda state: state.wiki_tab.cursor,

--- a/tests/unit/test_tab_reload.py
+++ b/tests/unit/test_tab_reload.py
@@ -1,0 +1,183 @@
+"""TUI タブの再読込 (R キー) 挙動の単体テスト。"""
+
+import pytest
+
+from redi.tui import issue_tab, time_entry_tab, wiki_tab
+from redi.tui.state import TuiState
+
+
+class TestIssueReload:
+    """issue タブの _on_reload() は現在のページを再取得する"""
+
+    def test_preserves_offset_and_cursor_within_bounds(self, monkeypatch):
+        """再取得後も offset は変えず、cursor は新しい一覧の範囲内に保たれる"""
+        state = TuiState()
+        state.page_size = 5
+        state.issue_tab.offset = 10
+        state.issue_tab.cursor = 2
+        state.issue_tab.issues = [
+            {"id": i, "subject": f"old-{i}"} for i in range(11, 16)
+        ]
+        state.issue_tab.total_count = 30
+
+        new_issues = [{"id": i, "subject": f"new-{i}"} for i in range(11, 16)]
+
+        def fake_fetch(state, offset):
+            assert offset == 10
+            return {"issues": new_issues, "total_count": 30}
+
+        monkeypatch.setattr(issue_tab, "fetch_issues_with_filter", fake_fetch)
+
+        issue_tab._on_reload(state)
+
+        assert state.issue_tab.offset == 10
+        assert state.issue_tab.cursor == 2
+        assert state.issue_tab.issues == new_issues
+        assert state.issue_tab.total_count == 30
+
+    def test_clamps_cursor_when_new_page_is_shorter(self, monkeypatch):
+        """再取得結果の件数が減ったら cursor は末尾にクランプされる"""
+        state = TuiState()
+        state.page_size = 5
+        state.issue_tab.offset = 0
+        state.issue_tab.cursor = 4
+        state.issue_tab.issues = [{"id": i, "subject": f"old-{i}"} for i in range(1, 6)]
+        state.issue_tab.total_count = 5
+
+        new_issues = [{"id": 1, "subject": "only"}]
+        monkeypatch.setattr(
+            issue_tab,
+            "fetch_issues_with_filter",
+            lambda state, offset: {"issues": new_issues, "total_count": 1},
+        )
+
+        issue_tab._on_reload(state)
+
+        assert state.issue_tab.cursor == 0
+        assert state.issue_tab.issues == new_issues
+
+    def test_empty_result_resets_cursor(self, monkeypatch):
+        """再取得結果が空でも例外を投げず cursor=0 になる"""
+        state = TuiState()
+        state.page_size = 5
+        state.issue_tab.cursor = 3
+        state.issue_tab.issues = [{"id": 1, "subject": "x"}]
+        monkeypatch.setattr(
+            issue_tab,
+            "fetch_issues_with_filter",
+            lambda state, offset: {"issues": [], "total_count": 0},
+        )
+
+        issue_tab._on_reload(state)
+
+        assert state.issue_tab.cursor == 0
+        assert state.issue_tab.issues == []
+        assert state.issue_tab.total_count == 0
+
+
+class TestWikiReload:
+    """wiki タブの _on_reload() は loaded を倒して取り直す"""
+
+    def test_resets_loaded_and_restores_cursor_by_title(self, monkeypatch):
+        """同じタイトルが残っていれば cursor をその位置に復元する"""
+        state = TuiState()
+        state.wiki_tab.loaded = True
+        state.wiki_tab.pages = [
+            {"title": "A"},
+            {"title": "B"},
+            {"title": "C"},
+        ]
+        state.wiki_tab.labels = ["A", "B", "C"]
+        state.wiki_tab.cursor = 1  # B にいる
+        state.wiki_tab.texts = {"A": "cached"}
+
+        def fake_load(state):
+            # loaded フラグが下りた状態で呼ばれること
+            assert state.wiki_tab.loaded is False
+            state.wiki_tab.loaded = True
+            state.wiki_tab.pages = [
+                {"title": "Z"},
+                {"title": "B"},
+            ]
+            state.wiki_tab.labels = ["Z", "B"]
+            state.wiki_tab.cursor = 0
+
+        monkeypatch.setattr(wiki_tab, "_load_wikis", fake_load)
+
+        wiki_tab._on_reload(state)
+
+        # B は新一覧の index=1 なので復元される
+        assert state.wiki_tab.cursor == 1
+        # texts キャッシュはクリアされる (再読込後の本文は最新を取り直す)
+        assert state.wiki_tab.texts == {}
+
+    def test_falls_back_to_top_when_title_missing(self, monkeypatch):
+        """前回のタイトルが新一覧に無ければ cursor=0 のまま"""
+        state = TuiState()
+        state.wiki_tab.loaded = True
+        state.wiki_tab.pages = [{"title": "deleted"}]
+        state.wiki_tab.cursor = 0
+
+        def fake_load(state):
+            state.wiki_tab.loaded = True
+            state.wiki_tab.pages = [{"title": "new1"}, {"title": "new2"}]
+            state.wiki_tab.cursor = 0
+
+        monkeypatch.setattr(wiki_tab, "_load_wikis", fake_load)
+
+        wiki_tab._on_reload(state)
+
+        assert state.wiki_tab.cursor == 0
+
+
+class TestTimeEntryReload:
+    """time_entry タブの _on_reload() は loaded を倒して取り直す"""
+
+    def test_restores_cursor_by_id(self, monkeypatch):
+        """同じ id の entry が残っていれば cursor をその位置に復元する"""
+        state = TuiState()
+        state.time_entry_tab.loaded = True
+        state.time_entry_tab.entries = [
+            {"id": 100},
+            {"id": 200},
+            {"id": 300},
+        ]
+        state.time_entry_tab.cursor = 1  # id=200 にいる
+
+        def fake_load(state):
+            assert state.time_entry_tab.loaded is False
+            state.time_entry_tab.loaded = True
+            # 200 は残っているが順序が変わる
+            state.time_entry_tab.entries = [
+                {"id": 400},
+                {"id": 200},
+            ]
+            state.time_entry_tab.cursor = 0
+
+        monkeypatch.setattr(time_entry_tab, "_load_time_entries", fake_load)
+
+        time_entry_tab._on_reload(state)
+
+        assert state.time_entry_tab.cursor == 1
+
+    def test_falls_back_to_top_when_id_missing(self, monkeypatch):
+        """前回の id が新一覧に無ければ cursor=0 のまま"""
+        state = TuiState()
+        state.time_entry_tab.loaded = True
+        state.time_entry_tab.entries = [{"id": 999}]
+        state.time_entry_tab.cursor = 0
+
+        def fake_load(state):
+            state.time_entry_tab.loaded = True
+            state.time_entry_tab.entries = [{"id": 111}, {"id": 222}]
+            state.time_entry_tab.cursor = 0
+
+        monkeypatch.setattr(time_entry_tab, "_load_time_entries", fake_load)
+
+        time_entry_tab._on_reload(state)
+
+        assert state.time_entry_tab.cursor == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_tab_reload.py
+++ b/tests/unit/test_tab_reload.py
@@ -1,7 +1,5 @@
 """TUI タブの再読込 (R キー) 挙動の単体テスト。"""
 
-import pytest
-
 from redi.tui import issue_tab, time_entry_tab, wiki_tab
 from redi.tui.state import TuiState
 
@@ -177,7 +175,3 @@ class TestTimeEntryReload:
         time_entry_tab._on_reload(state)
 
         assert state.time_entry_tab.cursor == 0
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])


### PR DESCRIPTION
resolve #149 

## Summary
- TUI のノーマルモードで `R` を押すと現在のタブを再読込するキーバインドを追加
- issue タブは現在のページ・フィルタを保ったまま再取得し、cursor は新しい一覧の範囲にクランプ
- wiki / time_entry タブは `loaded` フラグを倒して取り直したうえで、タイトル / entry id 一致でカーソルを復元
- ヘルプ (`?`) 各タブに `R` の説明を追記し、再読込時はステータスバーに flash メッセージを表示

## Test plan
- [x] `uv run task check` がすべてパスする
- [x] redmine 上で issue を別経路 (例: ブラウザ) で作成 → TUI で `R` を押すと一覧に反映される
- [x] wiki / time_entry でも `R` で一覧が更新される
- [x] フィルタ・ページを設定した状態で `R` を押しても fitler/offset が維持される
- [x] `?` ヘルプに `R` の項目が表示される