### PR TITLE
resolve #155 TUI のリソース操作キーを大文字化する

### DIFF
--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -443,7 +443,7 @@ def run_issue_tui(
             if target_id is not None:
                 TABS[state.tab].on_open_web_by_id(state, target_id)
 
-    for action_key in ("u", "c", "t"):
+    for action_key in ("U", "C", "T"):
 
         @kb.add(action_key, filter=normal_mode)
         def _(event, action_key=action_key):
@@ -458,10 +458,6 @@ def run_issue_tui(
         if state.search_query:
             _reset_preview_scroll()
             TABS[state.tab].on_search(state, state.search_query, forward=True)
-            return
-        result = TABS[state.tab].on_action_key(state, "n")
-        if result is not None:
-            event.app.exit(result=result)
 
     @kb.add("N", filter=normal_mode)
     def _(event):
@@ -469,6 +465,10 @@ def run_issue_tui(
         if state.search_query:
             _reset_preview_scroll()
             TABS[state.tab].on_search(state, state.search_query, forward=False)
+            return
+        result = TABS[state.tab].on_action_key(state, "N")
+        if result is not None:
+            event.app.exit(result=result)
 
     @kb.add("/", filter=normal_mode)
     def _(event):

--- a/src/redi/tui/issue_tab.py
+++ b/src/redi/tui/issue_tab.py
@@ -229,17 +229,17 @@ def _on_search(state: TuiState, query: str, forward: bool = True) -> None:
 
 
 def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
-    if key == "u":
+    if key == "U":
         if not state.issue_tab.issues:
             return None
         return _exit_result(state, "update")
-    if key == "c":
+    if key == "C":
         return _exit_result(state, "create", issue_id="")
-    if key == "n":
+    if key == "N":
         if not state.issue_tab.issues:
             return None
         return _exit_result(state, "comment")
-    if key == "t":
+    if key == "T":
         if not state.issue_tab.issues:
             return None
         return _exit_result(state, "create_time_entry")
@@ -263,9 +263,9 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  f", messages.tui_help_filter_status_assignee),
     (messages.tui_help_section_actions, ""),
     ("  Enter", messages.tui_help_issue_load_comments),
-    ("  c / u", messages.tui_help_issue_create_or_update),
-    ("  n", messages.tui_help_issue_add_comment),
-    ("  t", messages.tui_help_issue_create_time_entry),
+    ("  C / U", messages.tui_help_issue_create_or_update),
+    ("  N", messages.tui_help_issue_add_comment),
+    ("  T", messages.tui_help_issue_create_time_entry),
     ("  v / <N>V", messages.tui_help_issue_open_web_or_n),
     (messages.tui_help_section_other, ""),
     ("  ?", messages.tui_help_show_or_close),

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -111,7 +111,7 @@ def _status_hint(state: TuiState) -> str:
 
 
 def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
-    if key == "c":
+    if key == "C":
         entries = state.time_entry_tab.entries
         issue_id: str | None = None
         if entries:
@@ -125,7 +125,7 @@ def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
             issue_id=issue_id,
             position=TuiPosition(cursor=state.time_entry_tab.cursor),
         )
-    if key == "u":
+    if key == "U":
         entries = state.time_entry_tab.entries
         if not entries:
             return None
@@ -236,8 +236,8 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  /", messages.tui_help_start_search),
     ("  n / N", messages.tui_help_next_prev_match),
     (messages.tui_help_section_actions, ""),
-    ("  c", messages.tui_help_time_entry_create),
-    ("  u", messages.tui_help_time_entry_update),
+    ("  C", messages.tui_help_time_entry_create),
+    ("  U", messages.tui_help_time_entry_update),
     ("  D", messages.tui_help_time_entry_delete),
     ("  v", messages.tui_help_time_entry_open_web),
     (messages.tui_help_section_other, ""),

--- a/src/redi/tui/wiki_tab.py
+++ b/src/redi/tui/wiki_tab.py
@@ -155,12 +155,12 @@ def _on_enter(state: TuiState) -> None:
 
 
 def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
-    if key == "c":
+    if key == "C":
         parent = None
         if state.wiki_tab.pages:
             parent = state.wiki_tab.pages[state.wiki_tab.cursor].get("title")
         return _exit_result(state, "create", parent_wiki_title=parent)
-    if key == "u":
+    if key == "U":
         if not state.wiki_tab.pages:
             return None
         return _exit_result(state, "update")
@@ -209,8 +209,8 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  n / N", messages.tui_help_next_prev_match),
     (messages.tui_help_section_actions, ""),
     ("  Enter", messages.tui_help_wiki_load_text),
-    ("  c", messages.tui_help_wiki_create_child),
-    ("  u", messages.tui_help_wiki_update_page),
+    ("  C", messages.tui_help_wiki_create_child),
+    ("  U", messages.tui_help_wiki_update_page),
     ("  v", messages.tui_help_wiki_open_web),
     (messages.tui_help_section_other, ""),
     ("  ?", messages.tui_help_show_or_close),


### PR DESCRIPTION
resolve #155

## Summary
- TUI 各タブの作成・更新・コメント追加・時間記録作成のキー(`c`/`u`/`n`/`t`)を大文字(`C`/`U`/`N`/`T`)に変更し、移動や検索と比べて誤って押下しにくくしました
- 閲覧用の `v` は対象外として据え置きです
- `n` は前方検索専用に、`N` は検索クエリ未設定時に issue タブのコメント追加を担うよう統合しました(`n / N` の vim ライクな探索動作は維持)
- ヘルプ表示(`?`)の対応行も大文字に更新しました

## Test plan
- [ ] `task check` (format / lint / typecheck / test) がパスすること
- [ ] issue タブで `C` / `U` / `N` / `T` を押下するとそれぞれ作成・更新・コメント追加・時間記録作成に遷移すること(小文字では遷移しないこと)
- [ ] wiki タブで `C` / `U` を押下するとそれぞれ子ページ作成・更新に遷移すること
- [ ] time_entries タブで `C` / `U` を押下するとそれぞれ作成・更新に遷移すること
- [ ] `/` で検索後 `n` / `N` で前方/後方マッチ移動が機能すること
- [ ] 検索クエリ未設定時に issue タブで `N` を押下するとコメント追加に遷移すること
- [ ] `v` および `<N>V` は従来通り Web で開けること