### PR TITLE
[update] config update でプロファイル切替を対話的に行えるようにする

### DIFF
--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -1,9 +1,11 @@
 import argparse
 
-from redi.cli._common import resolve_alias
+from redi.cli._common import inline_choice, resolve_alias
 from redi.config import (
     SUPPORTED_LANGUAGES,
     create_profile,
+    get_default_profile,
+    list_profile_names,
     set_default_profile,
     show_config,
     update_config,
@@ -71,6 +73,26 @@ def add_config_parser(subparsers: argparse._SubParsersAction) -> None:
     )
 
 
+def _interactive_select_default_profile() -> None:
+    profile_names = list_profile_names()
+    if not profile_names:
+        print(messages.no_profiles_available)
+        exit(1)
+    current_default = get_default_profile()
+    options: list[tuple[str, str]] = [(name, name) for name in profile_names]
+    try:
+        selected = inline_choice(
+            messages.prompt_select_default_profile_to_set,
+            options,
+            default=current_default,
+        )
+    except KeyboardInterrupt:
+        print(messages.canceled)
+        exit(1)
+    if set_default_profile(selected):
+        print(messages.default_profile_set.format(name=selected))
+
+
 def handle_config(args: argparse.Namespace) -> None:
     cmd = resolve_alias(args.config_command)
     if cmd == "create":
@@ -93,6 +115,19 @@ def handle_config(args: argparse.Namespace) -> None:
         return
     if cmd != "update":
         show_config(full=args.full)
+        return
+    no_args_provided = not (
+        args.profile_name
+        or args.project_id
+        or args.wiki_project_id
+        or args.editor
+        or args.language
+        or args.api_key
+        or args.url
+        or args.default_profile
+    )
+    if no_args_provided:
+        _interactive_select_default_profile()
         return
     updated = False
     profile = args.profile_name

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -79,7 +79,10 @@ def _interactive_select_default_profile() -> None:
         print(messages.no_profiles_available)
         exit(1)
     current_default = get_default_profile()
-    options: list[tuple[str, str]] = [(name, name) for name in profile_names]
+    options: list[tuple[str, str]] = [
+        (name, f"{name} (default)" if name == current_default else name)
+        for name in profile_names
+    ]
     try:
         selected = inline_choice(
             messages.prompt_select_default_profile_to_set,

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -189,6 +189,25 @@ def set_default_profile(profile_name: str, config_path: Path | None = None) -> b
     return True
 
 
+def list_profile_names(config_path: Path | None = None) -> list[str]:
+    path = config_path or CONFIG_PATH
+    if not path.exists():
+        return []
+    with open(path) as f:
+        doc = tomlkit.load(f)
+    return [k for k, v in doc.items() if isinstance(v, Table)]
+
+
+def get_default_profile(config_path: Path | None = None) -> str | None:
+    path = config_path or CONFIG_PATH
+    if not path.exists():
+        return None
+    with open(path) as f:
+        doc = tomlkit.load(f)
+    value = doc.get("default_profile")
+    return str(value) if value is not None else None
+
+
 def show_config(full: bool = False, config_path: Path | None = None) -> None:
     if full:
         show_all_profiles(config_path=config_path)

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -113,6 +113,8 @@ class MessagesProto(Protocol):
     """選択可能なバージョンがない"""
     no_issues_available: str
     """選択可能なイシューがない"""
+    no_profiles_available: str
+    """選択可能なプロファイルがない"""
     no_project_skip_project_id: str
     """プロジェクトが存在しないため設定スキップ"""
 
@@ -329,6 +331,8 @@ class MessagesProto(Protocol):
     prompt_select_sharing: str
     prompt_select_version_to_update: str
     prompt_select_issue_to_update: str
+    prompt_select_default_profile_to_set: str
+    """デフォルトプロファイルとして設定するプロファイルを選択"""
     prompt_start_date: str
     prompt_due_date: str
     prompt_estimated_hours: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -62,6 +62,7 @@ class En(MessagesProto):
     issue_not_found_simple = "Issue not found"
     no_versions_available = "No versions available"
     no_issues_available = "No issues available"
+    no_profiles_available = "No profiles available"
     no_project_skip_project_id = "No projects exist; skipping project_id setup"
 
     # ---- admin / permission required ----
@@ -222,6 +223,7 @@ class En(MessagesProto):
     prompt_select_sharing = "Sharing"
     prompt_select_version_to_update = "Select version to update"
     prompt_select_issue_to_update = "Select issue to update"
+    prompt_select_default_profile_to_set = "Select profile to set as default"
     prompt_start_date = "Start date (YYYY-MM-DD, empty to clear): "
     prompt_due_date = "Due date (YYYY-MM-DD, empty to clear): "
     prompt_estimated_hours = "Estimated hours (e.g. 1.5 (h)): "

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -62,7 +62,9 @@ class En(MessagesProto):
     issue_not_found_simple = "Issue not found"
     no_versions_available = "No versions available"
     no_issues_available = "No issues available"
-    no_profiles_available = "No profiles available"
+    no_profiles_available = (
+        "No profiles available. To create first profile, run `redi init`"
+    )
     no_project_skip_project_id = "No projects exist; skipping project_id setup"
 
     # ---- admin / permission required ----

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -66,7 +66,9 @@ class Ja(MessagesProto):
     issue_not_found_simple = "イシューが見つかりません"
     no_versions_available = "選択可能なバージョンがありません"
     no_issues_available = "選択可能なイシューがありません"
-    no_profiles_available = "選択可能なプロファイルがありません"
+    no_profiles_available = (
+        "選択可能なプロファイルがありません。redi init を実行してください"
+    )
     no_project_skip_project_id = (
         "プロジェクトが存在しないため project_id の設定をスキップします"
     )

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -66,6 +66,7 @@ class Ja(MessagesProto):
     issue_not_found_simple = "イシューが見つかりません"
     no_versions_available = "選択可能なバージョンがありません"
     no_issues_available = "選択可能なイシューがありません"
+    no_profiles_available = "選択可能なプロファイルがありません"
     no_project_skip_project_id = (
         "プロジェクトが存在しないため project_id の設定をスキップします"
     )
@@ -224,6 +225,9 @@ class Ja(MessagesProto):
     prompt_select_sharing = "共有設定"
     prompt_select_version_to_update = "更新するバージョンを選択"
     prompt_select_issue_to_update = "更新するイシューを選択"
+    prompt_select_default_profile_to_set = (
+        "デフォルトプロファイルとして設定するプロファイルを選択"
+    )
     prompt_start_date = "開始日（YYYY-MM-DD、空文字でクリア）: "
     prompt_due_date = "期日（YYYY-MM-DD、空文字でクリア）: "
     prompt_estimated_hours = "予定工数（例: 1.5 (h)）: "

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -360,6 +360,65 @@ class TestResolveProfileName:
         assert explicit is False
 
 
+class TestListProfileNames:
+    """list_profile_names()はconfig.tomlの[section]名一覧を返す"""
+
+    def test_returns_profile_names_in_file_order(self, tmp_path):
+        """テーブルセクションの名前のみをファイル記載順で返す"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://redmine.example.com/main"
+
+            [sub]
+            redmine_url = "https://redmine.example.com/sub"
+        """)
+        )
+
+        assert config.list_profile_names(config_path=config_path) == ["main", "sub"]
+
+    def test_returns_empty_list_when_missing(self, tmp_path):
+        """ファイルが存在しない場合は空リストを返す"""
+        assert config.list_profile_names(config_path=tmp_path / "missing.toml") == []
+
+
+class TestGetDefaultProfile:
+    """get_default_profile()はconfig.tomlのdefault_profileを返す"""
+
+    def test_returns_default_profile_value(self, tmp_path):
+        """default_profileの値を文字列で返す"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            textwrap.dedent("""\
+            default_profile = "main"
+
+            [main]
+            redmine_url = "https://redmine.example.com"
+        """)
+        )
+
+        assert config.get_default_profile(config_path=config_path) == "main"
+
+    def test_returns_none_when_unset(self, tmp_path):
+        """default_profileが設定されていない場合はNoneを返す"""
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            textwrap.dedent("""\
+            [main]
+            redmine_url = "https://redmine.example.com"
+        """)
+        )
+
+        assert config.get_default_profile(config_path=config_path) is None
+
+    def test_returns_none_when_file_missing(self, tmp_path):
+        """ファイルが存在しない場合はNoneを返す"""
+        assert config.get_default_profile(config_path=tmp_path / "missing.toml") is None
+
+
 class TestShowAllProfiles:
     """show_all_profiles()はconfig_path指定時にそのファイルの全プロファイルを表示する"""
 


### PR DESCRIPTION
resolve #156

## Summary
- `redi config update` を引数なしで実行した場合に、登録済みプロファイル一覧から選択して `default_profile` を切り替える対話モードを追加
- 既存の `--default_profile <name>` による明示指定や、フィールド更新フラグを伴う `update` の挙動はそのまま
- 補助関数として `list_profile_names()` と `get_default_profile()` を `config.py` に追加

## Test plan
- [x] `redi config update` を実行してプロファイル選択 → 選んだプロファイルが `default_profile` に設定される
- [x] `redi config update --default_profile <name>` 既存の挙動が変わらない
- [x] `redi config update <profile_name> --xxx` の更新フローが動く
- [x] プロファイル未登録時に `redi config update` を実行 → "選択可能なプロファイルがありません" を表示して exit 1