### PR TITLE
[issue create] カスタムフィールドでキーバリューリスト、バージョン、ユーザーに対応

### DIFF
--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -1,4 +1,5 @@
 import json
+from typing import NotRequired, TypedDict, cast
 
 from redi import cache
 from redi.client import client
@@ -7,10 +8,31 @@ from redi.i18n import messages
 CACHE_KEY = "custom_fields"
 
 
-def fetch_custom_fields() -> list[dict] | None:
+class CustomField(TypedDict):
+    id: int
+    name: str
+    description: str
+    customized_type: str  # ex. issue
+    field_format: str  # ex. enumeration, list, etc...
+    regexp: str
+    min_length: int | None
+    max_length: int | None
+    is_required: bool
+    is_filter: bool
+    searchable: bool
+    multiple: bool
+    default_value: str | None
+    visible: bool
+    editable: bool
+    possible_values: NotRequired[list[dict]]
+    trackers: list[dict]
+    roles: list[dict]
+
+
+def fetch_custom_fields() -> list[CustomField] | None:
     cached = cache.load(CACHE_KEY)
     if cached is not None:
-        return cached
+        return cast(list[CustomField], cached)
     response = client.get("/custom_fields.json")
     if response.status_code == 403:
         # https://www.redmine.org/projects/redmine/wiki/Rest_CustomFields
@@ -19,7 +41,7 @@ def fetch_custom_fields() -> list[dict] | None:
     response.raise_for_status()
     data = response.json()["custom_fields"]
     cache.save(CACHE_KEY, data)
-    return data
+    return cast(list[CustomField], data)
 
 
 def list_custom_fields(full: bool = False) -> None:
@@ -46,10 +68,10 @@ def fetch_project_issue_custom_field_ids(project_id: str) -> set[int]:
 
 
 def filter_required_issue_custom_fields(
-    custom_fields: list[dict],
+    custom_fields: list[CustomField],
     project_cf_ids: set[int],
     tracker_id: str | None,
-) -> list[dict]:
+) -> list[CustomField]:
     """
     入力必須・初期値なし・プロジェクト/トラッカーに該当する
     イシュー用カスタムフィールドを抽出する。

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -1,5 +1,6 @@
 import json
 import webbrowser
+from collections import defaultdict
 
 import requests
 
@@ -234,12 +235,19 @@ def read_issue(
 
 
 def parse_custom_fields(custom_fields_str: str) -> list[dict]:
-    result = []
+    """`id=value` をカンマ区切りでパースする。同一 id が複数回出現した場合は
+    値をリスト化する（複数選択カスタムフィールド対応）。"""
+    by_id: defaultdict[int, list[str]] = defaultdict(list)
     for pair in custom_fields_str.split(","):
         key, _, value = pair.partition("=")
-        if key:
-            result.append({"id": int(key.strip()), "value": value.strip()})
-    return result
+        if not key:
+            continue
+        cf_id = int(key.strip())
+        by_id[cf_id].append(value.strip())
+    return [
+        {"id": cf_id, "value": values if len(values) > 1 else values[0]}
+        for cf_id, values in by_id.items()
+    ]
 
 
 def create_issue(

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -39,6 +39,7 @@ from redi.api.version import fetch_versions
 from redi.i18n import messages
 
 from redi.api.custom_field import (
+    CustomField,
     fetch_custom_fields,
     fetch_project_issue_custom_field_ids,
     filter_required_issue_custom_fields,
@@ -476,9 +477,9 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         exit(1)
 
 
-def _prompt_custom_field_value(custom_field: dict) -> str | None:
-    name = custom_field.get("name", "")
-    field_format = custom_field.get("field_format", "string")
+def _prompt_custom_field_value(custom_field: CustomField) -> str | None:
+    name = custom_field["name"]
+    field_format = custom_field["field_format"]
     label = messages.prompt_required_field.format(name=name)
 
     # not support All formats

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -476,13 +476,33 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         exit(1)
 
 
-def _prompt_custom_field_value(cf: dict) -> str | None:
-    name = cf.get("name", "")
-    fmt = cf.get("field_format", "string")
+def _prompt_custom_field_value(custom_field: dict) -> str | None:
+    name = custom_field.get("name", "")
+    field_format = custom_field.get("field_format", "string")
     label = messages.prompt_required_field.format(name=name)
+
     # not support All formats
-    if fmt == "list":
-        possible = cf.get("possible_values") or []
+    # キーバリューリスト
+    if field_format == "enumeration":
+        possible_values = custom_field.get("possible_values") or []
+        options: list[tuple[str, str]] = [
+            (str(pv.get("value", "")), str(pv.get("label", "")))
+            for pv in possible_values
+            if pv.get("value", "") != ""
+        ]
+        if not options:
+            return None
+        try:
+            key = inline_choice(label, options)
+        except KeyboardInterrupt:
+            return None
+        display = dict(options)[key]
+        print(messages.prompt_field_value.format(name=name, value=display))
+        return key
+
+    # リスト
+    if field_format == "list":
+        possible = custom_field.get("possible_values") or []
         options: list[tuple[str, str]] = [
             (str(pv.get("value", "")), str(pv.get("value", "")))
             for pv in possible
@@ -495,6 +515,7 @@ def _prompt_custom_field_value(cf: dict) -> str | None:
                 return None
             print(messages.prompt_field_value.format(name=name, value=value))
             return value
+    # 自由入力
     try:
         return (
             prompt(messages.prompt_custom_field_label.format(name=label)).strip()

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -517,6 +517,27 @@ def _prompt_custom_field_value(
         print(messages.prompt_field_value.format(name=name, value=label_map[key]))
         return key
 
+    # ユーザー
+    if field_format == "user":
+        users = fetch_project_users(project_id)
+        options = [(str(u["id"]), u.get("name", "")) for u in users]
+        if not options:
+            return None
+        label_map = dict(options)
+        try:
+            if multiple:
+                checked = inline_checkbox(label, options)
+                if not checked:
+                    return None
+                display = ", ".join(label_map[k] for k in checked)
+                print(messages.prompt_field_value.format(name=name, value=display))
+                return checked
+            key = inline_choice(label, options)
+        except KeyboardInterrupt:
+            return None
+        print(messages.prompt_field_value.format(name=name, value=label_map[key]))
+        return key
+
     # バージョン
     if field_format == "version":
         versions = fetch_versions(project_id)

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -262,7 +262,12 @@ def _build_create_issue_url(
         params.append(("issue[assigned_to_id]", assigned_to_id))
     if custom_fields:
         for cf in parse_custom_fields(custom_fields):
-            params.append((f"issue[custom_field_values][{cf['id']}]", str(cf["value"])))
+            value = cf["value"]
+            if isinstance(value, list):
+                for v in value:
+                    params.append((f"issue[custom_field_values][{cf['id']}][]", str(v)))
+            else:
+                params.append((f"issue[custom_field_values][{cf['id']}]", str(value)))
     base = f"{redmine_url}/projects/{project_id}/issues/new"
     if not params:
         return base
@@ -477,9 +482,12 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         exit(1)
 
 
-def _prompt_custom_field_value(custom_field: CustomField) -> str | None:
+def _prompt_custom_field_value(
+    custom_field: CustomField,
+) -> str | list[str] | None:
     name = custom_field["name"]
     field_format = custom_field["field_format"]
+    multiple = custom_field["multiple"]
     label = messages.prompt_required_field.format(name=name)
 
     # not support All formats
@@ -493,12 +501,19 @@ def _prompt_custom_field_value(custom_field: CustomField) -> str | None:
         ]
         if not options:
             return None
+        label_map = dict(options)
         try:
+            if multiple:
+                checked = inline_checkbox(label, options)
+                if not checked:
+                    return None
+                display = ", ".join(label_map[k] for k in checked)
+                print(messages.prompt_field_value.format(name=name, value=display))
+                return checked
             key = inline_choice(label, options)
         except KeyboardInterrupt:
             return None
-        display = dict(options)[key]
-        print(messages.prompt_field_value.format(name=name, value=display))
+        print(messages.prompt_field_value.format(name=name, value=label_map[key]))
         return key
 
     # リスト
@@ -511,6 +526,16 @@ def _prompt_custom_field_value(custom_field: CustomField) -> str | None:
         ]
         if options:
             try:
+                if multiple:
+                    checked = inline_checkbox(label, options)
+                    if not checked:
+                        return None
+                    print(
+                        messages.prompt_field_value.format(
+                            name=name, value=", ".join(checked)
+                        )
+                    )
+                    return checked
                 value = inline_choice(label, options)
             except KeyboardInterrupt:
                 return None
@@ -554,7 +579,11 @@ def _interactive_fill_required_custom_fields(
         if value is None:
             print(messages.canceled)
             exit(1)
-        added.append(f"{cf['id']}={value}")
+        if isinstance(value, list):
+            for v in value:
+                added.append(f"{cf['id']}={v}")
+        else:
+            added.append(f"{cf['id']}={value}")
     if not added:
         return existing
     if existing:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -484,6 +484,7 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
 
 def _prompt_custom_field_value(
     custom_field: CustomField,
+    project_id: str,
 ) -> str | list[str] | None:
     name = custom_field["name"]
     field_format = custom_field["field_format"]
@@ -499,6 +500,27 @@ def _prompt_custom_field_value(
             for pv in possible_values
             if pv.get("value", "") != ""
         ]
+        if not options:
+            return None
+        label_map = dict(options)
+        try:
+            if multiple:
+                checked = inline_checkbox(label, options)
+                if not checked:
+                    return None
+                display = ", ".join(label_map[k] for k in checked)
+                print(messages.prompt_field_value.format(name=name, value=display))
+                return checked
+            key = inline_choice(label, options)
+        except KeyboardInterrupt:
+            return None
+        print(messages.prompt_field_value.format(name=name, value=label_map[key]))
+        return key
+
+    # バージョン
+    if field_format == "version":
+        versions = fetch_versions(project_id)
+        options = [(str(v["id"]), v["name"]) for v in versions]
         if not options:
             return None
         label_map = dict(options)
@@ -575,7 +597,7 @@ def _interactive_fill_required_custom_fields(
     for cf in required:
         if cf["id"] in existing_ids:
             continue
-        value = _prompt_custom_field_value(cf)
+        value = _prompt_custom_field_value(cf, project_id)
         if value is None:
             print(messages.canceled)
             exit(1)


### PR DESCRIPTION
#153 

- **[add] issue create でキーバリューリスト形式のカスタムフィールドに対応**
- **[refactor] CustomFieldの型を定義**
- **[update] 複数選択可能な場合に対応出来るようにした**
- **[update] custom_fieldの形式でバージョンに対応させた**
- **[update] custom_fieldの形式でuser に対応させた**

## 対応していない

- ファイル
- リンク
- 少数
- 整数
- 日付
- 真偽値
- 進捗バー
- 長いテキスト

