### PR TITLE
[issue create] attachmentを除くカスタムフィールドに対応

### DIFF
--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -1,5 +1,5 @@
 import json
-from typing import NotRequired, TypedDict, cast
+from typing import NotRequired, TypedDict, cast, Literal
 
 from redi import cache
 from redi.client import client
@@ -13,7 +13,23 @@ class CustomField(TypedDict):
     name: str
     description: str
     customized_type: str  # ex. issue
-    field_format: str  # ex. enumeration, list, etc...
+    field_format: Literal[
+        # キーバリューリスト
+        "enumeration",
+        # テキスト
+        "string",
+        "version",
+        "attachment",
+        "user",
+        "list",
+        "link",
+        "float",
+        "int",
+        "date",
+        "progressbar",
+        # 長いテキスト
+        "text",
+    ]
     regexp: str
     min_length: int | None
     max_length: int | None

--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -89,16 +89,13 @@ def filter_required_issue_custom_fields(
     tracker_id: str | None,
 ) -> list[CustomField]:
     """
-    入力必須・初期値なし・プロジェクト/トラッカーに該当する
-    イシュー用カスタムフィールドを抽出する。
+    入力必須・プロジェクト/トラッカーに該当するイシュー用カスタムフィールドを抽出する。
     """
     result = []
     for cf in custom_fields:
         if cf.get("customized_type") != "issue":
             continue
         if not cf.get("is_required"):
-            continue
-        if cf.get("default_value"):
             continue
         if cf["id"] not in project_cf_ids:
             continue

--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -25,6 +25,7 @@ class CustomField(TypedDict):
         "link",
         "float",
         "int",
+        "bool",
         "date",
         "progressbar",
         # 長いテキスト

--- a/src/redi/cli/_common.py
+++ b/src/redi/cli/_common.py
@@ -61,10 +61,11 @@ def inline_checkbox(
     message: str,
     values: list[tuple[str, str]],
     initial_value: str | None = None,
+    initial_checked: list[str] | None = None,
 ) -> list[str]:
     keys = [v for v, _ in values]
     cursor = keys.index(initial_value) if initial_value in keys else 0
-    checked: set[str] = set()
+    checked: set[str] = {v for v in (initial_checked or []) if v in keys}
 
     def render():
         fragments = []

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -493,6 +493,14 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
 _SKIP_UNSUPPORTED_FIELD = object()
 
 
+def _shorten_to_oneline(text: str, max_len: int = 80) -> str:
+    """改行をスペースに畳んで 1 行化し、長すぎたら省略する。"""
+    one_line = " ".join(text.splitlines())
+    if len(one_line) > max_len:
+        return one_line[: max_len - 1] + "…"
+    return one_line
+
+
 def _prompt_custom_field_value(
     custom_field: CustomField,
     project_id: str,
@@ -597,6 +605,11 @@ def _prompt_custom_field_value(
             except (KeyboardInterrupt, EOFError):
                 return None
             if value:
+                print(
+                    messages.prompt_field_value.format(
+                        name=name, value=_shorten_to_oneline(value)
+                    )
+                )
                 return value
 
     # 日付
@@ -608,9 +621,6 @@ def _prompt_custom_field_value(
             ).strip()
         except (KeyboardInterrupt, EOFError):
             return None
-        if not value:
-            return None
-        print(messages.prompt_field_value.format(name=name, value=value))
         return value
 
     # 進捗 (0-100% の 10% 刻み)
@@ -634,9 +644,6 @@ def _prompt_custom_field_value(
             ).strip()
         except (KeyboardInterrupt, EOFError):
             return None
-        if not value:
-            return None
-        print(messages.prompt_field_value.format(name=name, value=value))
         return value
 
     # 小数
@@ -648,9 +655,6 @@ def _prompt_custom_field_value(
             ).strip()
         except (KeyboardInterrupt, EOFError):
             return None
-        if not value:
-            return None
-        print(messages.prompt_field_value.format(name=name, value=value))
         return value
 
     # リスト
@@ -781,6 +785,13 @@ def handle_issue_create(args: argparse.Namespace) -> None:
         )
     if args.description is None:
         description = open_editor()
+        if description:
+            print(
+                messages.prompt_field_value.format(
+                    name=messages.field_description,
+                    value=_shorten_to_oneline(description),
+                )
+            )
     else:
         description = args.description
     if interactive:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -579,6 +579,16 @@ def _prompt_custom_field_value(
         print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
         return key
 
+    # 長いテキスト
+    if field_format == "text":
+        try:
+            value = open_editor()
+        except (KeyboardInterrupt, EOFError):
+            return None
+        if not value:
+            return None
+        return value
+
     # 日付
     if field_format == "date":
         try:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -511,139 +511,142 @@ def _prompt_custom_field_value(
     label = messages.prompt_required_field.format(name=name)
     default_value = custom_field.get("default_value") or ""
 
-    # attachment はブラウザに委ねる
-    # キーバリューリスト
-    if field_format == "enumeration":
-        possible_values = custom_field.get("possible_values") or []
-        options: list[tuple[str, str]] = [
-            (str(pv.get("value", "")), str(pv.get("label", "")))
-            for pv in possible_values
-            if pv.get("value", "") != ""
-        ]
-        if not options:
-            return _SKIP_UNSUPPORTED_FIELD
-        label_map = dict(options)
-        if multiple:
-            # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
-            while True:
-                checked = inline_checkbox(
-                    label,
-                    options,
-                    initial_checked=[default_value] if default_value else None,
-                )
-                if checked:
-                    break
-            display = ", ".join(label_map[k] for k in checked)
-            print(messages.prompt_field_value.format(name=name, value=display))
-            return checked
-        key = inline_choice(label, options, default=default_value or None)
-        print(messages.prompt_field_value.format(name=name, value=label_map[key]))
-        return key
-
-    # ユーザー
-    if field_format == "user":
-        users = fetch_project_users(project_id)
-        options = [(str(u["id"]), u.get("name", "")) for u in users]
-        if not options:
-            return _SKIP_UNSUPPORTED_FIELD
-        label_map = dict(options)
-        if multiple:
-            while True:
-                checked = inline_checkbox(label, options)
-                if checked:
-                    break
-            display = ", ".join(label_map[k] for k in checked)
-            print(messages.prompt_field_value.format(name=name, value=display))
-            return checked
-        key = inline_choice(label, options)
-        print(messages.prompt_field_value.format(name=name, value=label_map[key]))
-        return key
-
-    # バージョン
-    if field_format == "version":
-        versions = fetch_versions(project_id)
-        options = [(str(v["id"]), v["name"]) for v in versions]
-        if not options:
-            return _SKIP_UNSUPPORTED_FIELD
-        label_map = dict(options)
-        if multiple:
-            while True:
-                checked = inline_checkbox(label, options)
-                if checked:
-                    break
-            display = ", ".join(label_map[k] for k in checked)
-            print(messages.prompt_field_value.format(name=name, value=display))
-            return checked
-        key = inline_choice(label, options)
-        print(messages.prompt_field_value.format(name=name, value=label_map[key]))
-        return key
-
-    # 真偽値
-    if field_format == "bool":
-        bool_options: list[tuple[str, str]] = [
-            ("1", messages.label_bool_true),
-            ("0", messages.label_bool_false),
-        ]
-        bool_label_map = dict(bool_options)
-        key = inline_choice(label, bool_options, default=default_value or None)
-        print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
-        return key
-
-    # 長いテキスト
-    if field_format == "text":
-        # 空のまま閉じられたらエディタを開き直す
-        while True:
-            value = open_editor(initial_text=default_value)
-            if value:
-                print(
-                    messages.prompt_field_value.format(
-                        name=name, value=_shorten_to_oneline(value)
+    match field_format:
+        # キーバリューリスト
+        case "enumeration":
+            possible_values = custom_field.get("possible_values") or []
+            options: list[tuple[str, str]] = [
+                (str(pv.get("value", "")), str(pv.get("label", "")))
+                for pv in possible_values
+                if pv.get("value", "") != ""
+            ]
+            if not options:
+                return _SKIP_UNSUPPORTED_FIELD
+            label_map = dict(options)
+            if multiple:
+                # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
+                while True:
+                    checked = inline_checkbox(
+                        label,
+                        options,
+                        initial_checked=[default_value] if default_value else None,
                     )
-                )
-                return value
+                    if checked:
+                        break
+                display = ", ".join(label_map[k] for k in checked)
+                print(messages.prompt_field_value.format(name=name, value=display))
+                return checked
+            key = inline_choice(label, options, default=default_value or None)
+            print(messages.prompt_field_value.format(name=name, value=label_map[key]))
+            return key
 
-    # 日付
-    if field_format == "date":
-        return prompt(
-            messages.prompt_custom_field_label.format(name=label),
-            validator=DateValidator(),
-            default=default_value,
-        ).strip()
+        # ユーザー
+        case "user":
+            users = fetch_project_users(project_id)
+            options = [(str(u["id"]), u.get("name", "")) for u in users]
+            if not options:
+                return _SKIP_UNSUPPORTED_FIELD
+            label_map = dict(options)
+            if multiple:
+                while True:
+                    checked = inline_checkbox(label, options)
+                    if checked:
+                        break
+                display = ", ".join(label_map[k] for k in checked)
+                print(messages.prompt_field_value.format(name=name, value=display))
+                return checked
+            key = inline_choice(label, options)
+            print(messages.prompt_field_value.format(name=name, value=label_map[key]))
+            return key
 
-    # 進捗 (0-100% の 10% 刻み)
-    if field_format == "progressbar":
-        progress_options: list[tuple[str, str]] = [
-            (str(r), f"{r}%") for r in range(0, 101, 10)
-        ]
-        value = inline_choice(label, progress_options)
-        print(messages.prompt_field_value.format(name=name, value=f"{value}%"))
-        return value
+        # バージョン
+        case "version":
+            versions = fetch_versions(project_id)
+            options = [(str(v["id"]), v["name"]) for v in versions]
+            if not options:
+                return _SKIP_UNSUPPORTED_FIELD
+            label_map = dict(options)
+            if multiple:
+                while True:
+                    checked = inline_checkbox(label, options)
+                    if checked:
+                        break
+                display = ", ".join(label_map[k] for k in checked)
+                print(messages.prompt_field_value.format(name=name, value=display))
+                return checked
+            key = inline_choice(label, options)
+            print(messages.prompt_field_value.format(name=name, value=label_map[key]))
+            return key
 
-    # 整数
-    if field_format == "int":
-        return prompt(
-            messages.prompt_custom_field_label.format(name=label),
-            validator=IntValidator(),
-            default=default_value,
-        ).strip()
+        # 真偽値
+        case "bool":
+            bool_options: list[tuple[str, str]] = [
+                ("1", messages.label_bool_true),
+                ("0", messages.label_bool_false),
+            ]
+            bool_label_map = dict(bool_options)
+            key = inline_choice(label, bool_options, default=default_value or None)
+            print(
+                messages.prompt_field_value.format(name=name, value=bool_label_map[key])
+            )
+            return key
 
-    # 小数
-    if field_format == "float":
-        return prompt(
-            messages.prompt_custom_field_label.format(name=label),
-            validator=FloatValidator(),
-            default=default_value,
-        ).strip()
+        # 長いテキスト
+        case "text":
+            # 空のまま閉じられたらエディタを開き直す
+            while True:
+                value = open_editor(initial_text=default_value)
+                if value:
+                    print(
+                        messages.prompt_field_value.format(
+                            name=name, value=_shorten_to_oneline(value)
+                        )
+                    )
+                    return value
 
-    # リスト
-    if field_format == "list":
-        possible = custom_field.get("possible_values") or []
-        options: list[tuple[str, str]] = [
-            (str(pv.get("value", "")), str(pv.get("value", "")))
-            for pv in possible
-            if pv.get("value", "") != ""
-        ]
-        if options:
+        # 日付
+        case "date":
+            return prompt(
+                messages.prompt_custom_field_label.format(name=label),
+                validator=DateValidator(),
+                default=default_value,
+            ).strip()
+
+        # 進捗 (0-100% の 10% 刻み)
+        case "progressbar":
+            progress_options: list[tuple[str, str]] = [
+                (str(r), f"{r}%") for r in range(0, 101, 10)
+            ]
+            value = inline_choice(label, progress_options)
+            print(messages.prompt_field_value.format(name=name, value=f"{value}%"))
+            return value
+
+        # 整数
+        case "int":
+            return prompt(
+                messages.prompt_custom_field_label.format(name=label),
+                validator=IntValidator(),
+                default=default_value,
+            ).strip()
+
+        # 小数
+        case "float":
+            return prompt(
+                messages.prompt_custom_field_label.format(name=label),
+                validator=FloatValidator(),
+                default=default_value,
+            ).strip()
+
+        # リスト
+        case "list":
+            possible = custom_field.get("possible_values") or []
+            options = [
+                (str(pv.get("value", "")), str(pv.get("value", "")))
+                for pv in possible
+                if pv.get("value", "") != ""
+            ]
+            if not options:
+                return _SKIP_UNSUPPORTED_FIELD
             if multiple:
                 while True:
                     checked = inline_checkbox(
@@ -663,17 +666,18 @@ def _prompt_custom_field_value(
             print(messages.prompt_field_value.format(name=name, value=value))
             return value
 
-    # ファイル添付は redi 側で対応していないため、呼び出し側に「ブラウザで編集」を強制させる
-    if field_format == "attachment":
-        print(messages.attachment_field_unsupported_notice.format(name=name))
-        return _SKIP_UNSUPPORTED_FIELD
+        # ファイル添付は redi 側で対応していないため、呼び出し側に「ブラウザで編集」を強制させる
+        case "attachment":
+            print(messages.attachment_field_unsupported_notice.format(name=name))
+            return _SKIP_UNSUPPORTED_FIELD
 
-    # 自由入力(string,link)
-    return prompt(
-        messages.prompt_custom_field_label.format(name=label),
-        validator=RequiredValidator(),
-        default=default_value,
-    ).strip()
+        # 自由入力(string,link)。未知のフォーマット
+        case _:
+            return prompt(
+                messages.prompt_custom_field_label.format(name=label),
+                validator=RequiredValidator(),
+                default=default_value,
+            ).strip()
 
 
 def _interactive_fill_required_custom_fields(

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -14,7 +14,7 @@ from redi.cli._common import (
     open_editor,
     resolve_alias,
 )
-from redi.cli.prompt_util import DueDateValidator, HourValidator
+from redi.cli.prompt_util import DueDateValidator, FloatValidator, HourValidator
 from redi.config import default_project_id, redmine_url
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
@@ -572,6 +572,20 @@ def _prompt_custom_field_value(
             return None
         print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
         return key
+
+    # 小数
+    if field_format == "float":
+        try:
+            value = prompt(
+                messages.prompt_custom_field_label.format(name=label),
+                validator=FloatValidator(),
+            ).strip()
+        except (KeyboardInterrupt, EOFError):
+            return None
+        if not value:
+            return None
+        print(messages.prompt_field_value.format(name=name, value=value))
+        return value
 
     # リスト
     if field_format == "list":

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -559,6 +559,20 @@ def _prompt_custom_field_value(
         print(messages.prompt_field_value.format(name=name, value=label_map[key]))
         return key
 
+    # 真偽値
+    if field_format == "bool":
+        bool_options: list[tuple[str, str]] = [
+            ("1", messages.label_bool_true),
+            ("0", messages.label_bool_false),
+        ]
+        bool_label_map = dict(bool_options)
+        try:
+            key = inline_choice(label, bool_options)
+        except KeyboardInterrupt:
+            return None
+        print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
+        return key
+
     # リスト
     if field_format == "list":
         possible = custom_field.get("possible_values") or []

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -15,6 +15,7 @@ from redi.cli._common import (
     resolve_alias,
 )
 from redi.cli.prompt_util import (
+    DateValidator,
     DueDateValidator,
     FloatValidator,
     HourValidator,
@@ -577,6 +578,20 @@ def _prompt_custom_field_value(
             return None
         print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
         return key
+
+    # 日付
+    if field_format == "date":
+        try:
+            value = prompt(
+                messages.prompt_custom_field_label.format(name=label),
+                validator=DateValidator(),
+            ).strip()
+        except (KeyboardInterrupt, EOFError):
+            return None
+        if not value:
+            return None
+        print(messages.prompt_field_value.format(name=name, value=value))
+        return value
 
     # 進捗 (0-100% の 10% 刻み)
     if field_format == "progressbar":

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -668,7 +668,12 @@ def _prompt_custom_field_value(
                 return None
             print(messages.prompt_field_value.format(name=name, value=value))
             return value
-    # 自由入力
+
+    # ファイル is not supported
+    if field_format == "attachment":
+        return
+
+    # 自由入力(string,link)
     try:
         return (
             prompt(messages.prompt_custom_field_label.format(name=label)).strip()

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -509,6 +509,7 @@ def _prompt_custom_field_value(
     field_format = custom_field["field_format"]
     multiple = custom_field["multiple"]
     label = messages.prompt_required_field.format(name=name)
+    default_value = custom_field.get("default_value") or ""
 
     # attachment はブラウザに委ねる
     # キーバリューリスト
@@ -525,13 +526,17 @@ def _prompt_custom_field_value(
         if multiple:
             # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
             while True:
-                checked = inline_checkbox(label, options)
+                checked = inline_checkbox(
+                    label,
+                    options,
+                    initial_checked=[default_value] if default_value else None,
+                )
                 if checked:
                     break
             display = ", ".join(label_map[k] for k in checked)
             print(messages.prompt_field_value.format(name=name, value=display))
             return checked
-        key = inline_choice(label, options)
+        key = inline_choice(label, options, default=default_value or None)
         print(messages.prompt_field_value.format(name=name, value=label_map[key]))
         return key
 
@@ -580,7 +585,7 @@ def _prompt_custom_field_value(
             ("0", messages.label_bool_false),
         ]
         bool_label_map = dict(bool_options)
-        key = inline_choice(label, bool_options)
+        key = inline_choice(label, bool_options, default=default_value or None)
         print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
         return key
 
@@ -588,7 +593,7 @@ def _prompt_custom_field_value(
     if field_format == "text":
         # 空のまま閉じられたらエディタを開き直す
         while True:
-            value = open_editor()
+            value = open_editor(initial_text=default_value)
             if value:
                 print(
                     messages.prompt_field_value.format(
@@ -602,6 +607,7 @@ def _prompt_custom_field_value(
         return prompt(
             messages.prompt_custom_field_label.format(name=label),
             validator=DateValidator(),
+            default=default_value,
         ).strip()
 
     # 進捗 (0-100% の 10% 刻み)
@@ -618,6 +624,7 @@ def _prompt_custom_field_value(
         return prompt(
             messages.prompt_custom_field_label.format(name=label),
             validator=IntValidator(),
+            default=default_value,
         ).strip()
 
     # 小数
@@ -625,6 +632,7 @@ def _prompt_custom_field_value(
         return prompt(
             messages.prompt_custom_field_label.format(name=label),
             validator=FloatValidator(),
+            default=default_value,
         ).strip()
 
     # リスト
@@ -638,7 +646,11 @@ def _prompt_custom_field_value(
         if options:
             if multiple:
                 while True:
-                    checked = inline_checkbox(label, options)
+                    checked = inline_checkbox(
+                        label,
+                        options,
+                        initial_checked=[default_value] if default_value else None,
+                    )
                     if checked:
                         break
                 print(
@@ -647,7 +659,7 @@ def _prompt_custom_field_value(
                     )
                 )
                 return checked
-            value = inline_choice(label, options)
+            value = inline_choice(label, options, default=default_value or None)
             print(messages.prompt_field_value.format(name=name, value=value))
             return value
 
@@ -660,6 +672,7 @@ def _prompt_custom_field_value(
     return prompt(
         messages.prompt_custom_field_label.format(name=label),
         validator=RequiredValidator(),
+        default=default_value,
     ).strip()
 
 

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -578,6 +578,18 @@ def _prompt_custom_field_value(
         print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
         return key
 
+    # 進捗 (0-100% の 10% 刻み)
+    if field_format == "progressbar":
+        progress_options: list[tuple[str, str]] = [
+            (str(r), f"{r}%") for r in range(0, 101, 10)
+        ]
+        try:
+            value = inline_choice(label, progress_options)
+        except KeyboardInterrupt:
+            return None
+        print(messages.prompt_field_value.format(name=name, value=f"{value}%"))
+        return value
+
     # 整数
     if field_format == "int":
         try:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -501,6 +501,35 @@ def _shorten_to_oneline(text: str, max_len: int = 80) -> str:
     return one_line
 
 
+def _choose_from_options(
+    name: str,
+    label: str,
+    options: list[tuple[str, str]],
+    multiple: bool,
+    default_value: str,
+) -> str | list[str] | object:
+    """選択肢からの入力を取得する共通処理。空オプションは _SKIP_UNSUPPORTED_FIELD を返す。"""
+    if not options:
+        return _SKIP_UNSUPPORTED_FIELD
+    label_map = dict(options)
+    if multiple:
+        # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
+        while True:
+            checked = inline_checkbox(
+                label,
+                options,
+                initial_checked=[default_value] if default_value else None,
+            )
+            if checked:
+                break
+        display = ", ".join(label_map[k] for k in checked)
+        print(messages.prompt_field_value.format(name=name, value=display))
+        return checked
+    key = inline_choice(label, options, default=default_value or None)
+    print(messages.prompt_field_value.format(name=name, value=label_map[key]))
+    return key
+
+
 def _prompt_custom_field_value(
     custom_field: CustomField,
     project_id: str,
@@ -520,63 +549,29 @@ def _prompt_custom_field_value(
                 for pv in possible_values
                 if pv.get("value", "") != ""
             ]
-            if not options:
-                return _SKIP_UNSUPPORTED_FIELD
-            label_map = dict(options)
-            if multiple:
-                # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
-                while True:
-                    checked = inline_checkbox(
-                        label,
-                        options,
-                        initial_checked=[default_value] if default_value else None,
-                    )
-                    if checked:
-                        break
-                display = ", ".join(label_map[k] for k in checked)
-                print(messages.prompt_field_value.format(name=name, value=display))
-                return checked
-            key = inline_choice(label, options, default=default_value or None)
-            print(messages.prompt_field_value.format(name=name, value=label_map[key]))
-            return key
+            return _choose_from_options(name, label, options, multiple, default_value)
+
+        # リスト
+        case "list":
+            possible = custom_field.get("possible_values") or []
+            options = [
+                (str(pv.get("value", "")), str(pv.get("value", "")))
+                for pv in possible
+                if pv.get("value", "") != ""
+            ]
+            return _choose_from_options(name, label, options, multiple, default_value)
 
         # ユーザー
         case "user":
             users = fetch_project_users(project_id)
             options = [(str(u["id"]), u.get("name", "")) for u in users]
-            if not options:
-                return _SKIP_UNSUPPORTED_FIELD
-            label_map = dict(options)
-            if multiple:
-                while True:
-                    checked = inline_checkbox(label, options)
-                    if checked:
-                        break
-                display = ", ".join(label_map[k] for k in checked)
-                print(messages.prompt_field_value.format(name=name, value=display))
-                return checked
-            key = inline_choice(label, options)
-            print(messages.prompt_field_value.format(name=name, value=label_map[key]))
-            return key
+            return _choose_from_options(name, label, options, multiple, default_value)
 
         # バージョン
         case "version":
             versions = fetch_versions(project_id)
             options = [(str(v["id"]), v["name"]) for v in versions]
-            if not options:
-                return _SKIP_UNSUPPORTED_FIELD
-            label_map = dict(options)
-            if multiple:
-                while True:
-                    checked = inline_checkbox(label, options)
-                    if checked:
-                        break
-                display = ", ".join(label_map[k] for k in checked)
-                print(messages.prompt_field_value.format(name=name, value=display))
-                return checked
-            key = inline_choice(label, options)
-            print(messages.prompt_field_value.format(name=name, value=label_map[key]))
-            return key
+            return _choose_from_options(name, label, options, multiple, default_value)
 
         # 真偽値
         case "bool":
@@ -636,35 +631,6 @@ def _prompt_custom_field_value(
                 validator=FloatValidator(),
                 default=default_value,
             ).strip()
-
-        # リスト
-        case "list":
-            possible = custom_field.get("possible_values") or []
-            options = [
-                (str(pv.get("value", "")), str(pv.get("value", "")))
-                for pv in possible
-                if pv.get("value", "") != ""
-            ]
-            if not options:
-                return _SKIP_UNSUPPORTED_FIELD
-            if multiple:
-                while True:
-                    checked = inline_checkbox(
-                        label,
-                        options,
-                        initial_checked=[default_value] if default_value else None,
-                    )
-                    if checked:
-                        break
-                print(
-                    messages.prompt_field_value.format(
-                        name=name, value=", ".join(checked)
-                    )
-                )
-                return checked
-            value = inline_choice(label, options, default=default_value or None)
-            print(messages.prompt_field_value.format(name=name, value=value))
-            return value
 
         # ファイル添付は redi 側で対応していないため、呼び出し側に「ブラウザで編集」を強制させる
         case "attachment":

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -504,7 +504,7 @@ def _shorten_to_oneline(text: str, max_len: int = 80) -> str:
 def _prompt_custom_field_value(
     custom_field: CustomField,
     project_id: str,
-) -> str | list[str] | object | None:
+) -> str | list[str] | object:
     name = custom_field["name"]
     field_format = custom_field["field_format"]
     multiple = custom_field["multiple"]
@@ -520,21 +520,18 @@ def _prompt_custom_field_value(
             if pv.get("value", "") != ""
         ]
         if not options:
-            return None
+            return _SKIP_UNSUPPORTED_FIELD
         label_map = dict(options)
-        try:
-            if multiple:
-                # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
-                while True:
-                    checked = inline_checkbox(label, options)
-                    if checked:
-                        break
-                display = ", ".join(label_map[k] for k in checked)
-                print(messages.prompt_field_value.format(name=name, value=display))
-                return checked
-            key = inline_choice(label, options)
-        except KeyboardInterrupt:
-            return None
+        if multiple:
+            # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
+            while True:
+                checked = inline_checkbox(label, options)
+                if checked:
+                    break
+            display = ", ".join(label_map[k] for k in checked)
+            print(messages.prompt_field_value.format(name=name, value=display))
+            return checked
+        key = inline_choice(label, options)
         print(messages.prompt_field_value.format(name=name, value=label_map[key]))
         return key
 
@@ -543,20 +540,17 @@ def _prompt_custom_field_value(
         users = fetch_project_users(project_id)
         options = [(str(u["id"]), u.get("name", "")) for u in users]
         if not options:
-            return None
+            return _SKIP_UNSUPPORTED_FIELD
         label_map = dict(options)
-        try:
-            if multiple:
-                while True:
-                    checked = inline_checkbox(label, options)
-                    if checked:
-                        break
-                display = ", ".join(label_map[k] for k in checked)
-                print(messages.prompt_field_value.format(name=name, value=display))
-                return checked
-            key = inline_choice(label, options)
-        except KeyboardInterrupt:
-            return None
+        if multiple:
+            while True:
+                checked = inline_checkbox(label, options)
+                if checked:
+                    break
+            display = ", ".join(label_map[k] for k in checked)
+            print(messages.prompt_field_value.format(name=name, value=display))
+            return checked
+        key = inline_choice(label, options)
         print(messages.prompt_field_value.format(name=name, value=label_map[key]))
         return key
 
@@ -565,20 +559,17 @@ def _prompt_custom_field_value(
         versions = fetch_versions(project_id)
         options = [(str(v["id"]), v["name"]) for v in versions]
         if not options:
-            return None
+            return _SKIP_UNSUPPORTED_FIELD
         label_map = dict(options)
-        try:
-            if multiple:
-                while True:
-                    checked = inline_checkbox(label, options)
-                    if checked:
-                        break
-                display = ", ".join(label_map[k] for k in checked)
-                print(messages.prompt_field_value.format(name=name, value=display))
-                return checked
-            key = inline_choice(label, options)
-        except KeyboardInterrupt:
-            return None
+        if multiple:
+            while True:
+                checked = inline_checkbox(label, options)
+                if checked:
+                    break
+            display = ", ".join(label_map[k] for k in checked)
+            print(messages.prompt_field_value.format(name=name, value=display))
+            return checked
+        key = inline_choice(label, options)
         print(messages.prompt_field_value.format(name=name, value=label_map[key]))
         return key
 
@@ -589,10 +580,7 @@ def _prompt_custom_field_value(
             ("0", messages.label_bool_false),
         ]
         bool_label_map = dict(bool_options)
-        try:
-            key = inline_choice(label, bool_options)
-        except KeyboardInterrupt:
-            return None
+        key = inline_choice(label, bool_options)
         print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
         return key
 
@@ -600,10 +588,7 @@ def _prompt_custom_field_value(
     if field_format == "text":
         # 空のまま閉じられたらエディタを開き直す
         while True:
-            try:
-                value = open_editor()
-            except (KeyboardInterrupt, EOFError):
-                return None
+            value = open_editor()
             if value:
                 print(
                     messages.prompt_field_value.format(
@@ -614,48 +599,33 @@ def _prompt_custom_field_value(
 
     # 日付
     if field_format == "date":
-        try:
-            value = prompt(
-                messages.prompt_custom_field_label.format(name=label),
-                validator=DateValidator(),
-            ).strip()
-        except (KeyboardInterrupt, EOFError):
-            return None
-        return value
+        return prompt(
+            messages.prompt_custom_field_label.format(name=label),
+            validator=DateValidator(),
+        ).strip()
 
     # 進捗 (0-100% の 10% 刻み)
     if field_format == "progressbar":
         progress_options: list[tuple[str, str]] = [
             (str(r), f"{r}%") for r in range(0, 101, 10)
         ]
-        try:
-            value = inline_choice(label, progress_options)
-        except KeyboardInterrupt:
-            return None
+        value = inline_choice(label, progress_options)
         print(messages.prompt_field_value.format(name=name, value=f"{value}%"))
         return value
 
     # 整数
     if field_format == "int":
-        try:
-            value = prompt(
-                messages.prompt_custom_field_label.format(name=label),
-                validator=IntValidator(),
-            ).strip()
-        except (KeyboardInterrupt, EOFError):
-            return None
-        return value
+        return prompt(
+            messages.prompt_custom_field_label.format(name=label),
+            validator=IntValidator(),
+        ).strip()
 
     # 小数
     if field_format == "float":
-        try:
-            value = prompt(
-                messages.prompt_custom_field_label.format(name=label),
-                validator=FloatValidator(),
-            ).strip()
-        except (KeyboardInterrupt, EOFError):
-            return None
-        return value
+        return prompt(
+            messages.prompt_custom_field_label.format(name=label),
+            validator=FloatValidator(),
+        ).strip()
 
     # リスト
     if field_format == "list":
@@ -666,21 +636,18 @@ def _prompt_custom_field_value(
             if pv.get("value", "") != ""
         ]
         if options:
-            try:
-                if multiple:
-                    while True:
-                        checked = inline_checkbox(label, options)
-                        if checked:
-                            break
-                    print(
-                        messages.prompt_field_value.format(
-                            name=name, value=", ".join(checked)
-                        )
+            if multiple:
+                while True:
+                    checked = inline_checkbox(label, options)
+                    if checked:
+                        break
+                print(
+                    messages.prompt_field_value.format(
+                        name=name, value=", ".join(checked)
                     )
-                    return checked
-                value = inline_choice(label, options)
-            except KeyboardInterrupt:
-                return None
+                )
+                return checked
+            value = inline_choice(label, options)
             print(messages.prompt_field_value.format(name=name, value=value))
             return value
 
@@ -690,13 +657,10 @@ def _prompt_custom_field_value(
         return _SKIP_UNSUPPORTED_FIELD
 
     # 自由入力(string,link)
-    try:
-        return prompt(
-            messages.prompt_custom_field_label.format(name=label),
-            validator=RequiredValidator(),
-        ).strip()
-    except (KeyboardInterrupt, EOFError):
-        return None
+    return prompt(
+        messages.prompt_custom_field_label.format(name=label),
+        validator=RequiredValidator(),
+    ).strip()
 
 
 def _interactive_fill_required_custom_fields(
@@ -725,13 +689,14 @@ def _interactive_fill_required_custom_fields(
     for cf in required:
         if cf["id"] in existing_ids:
             continue
-        value = _prompt_custom_field_value(cf, project_id)
+        try:
+            value = _prompt_custom_field_value(cf, project_id)
+        except (KeyboardInterrupt, EOFError):
+            print(messages.canceled)
+            exit(1)
         if value is _SKIP_UNSUPPORTED_FIELD:
             browser_only = True
             continue
-        if value is None:
-            print(messages.canceled)
-            exit(1)
         if isinstance(value, list):
             for v in value:
                 added.append(f"{cf['id']}={v}")

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -510,7 +510,7 @@ def _prompt_custom_field_value(
     multiple = custom_field["multiple"]
     label = messages.prompt_required_field.format(name=name)
 
-    # not support All formats
+    # attachment はブラウザに委ねる
     # キーバリューリスト
     if field_format == "enumeration":
         possible_values = custom_field.get("possible_values") or []

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -488,10 +488,14 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         exit(1)
 
 
+# attachment 型のような未対応フィールドで「スキップしてブラウザでの編集に倒す」ことを示すセンチネル
+_SKIP_UNSUPPORTED_FIELD = object()
+
+
 def _prompt_custom_field_value(
     custom_field: CustomField,
     project_id: str,
-) -> str | list[str] | None:
+) -> str | list[str] | object | None:
     name = custom_field["name"]
     field_format = custom_field["field_format"]
     multiple = custom_field["multiple"]
@@ -669,9 +673,10 @@ def _prompt_custom_field_value(
             print(messages.prompt_field_value.format(name=name, value=value))
             return value
 
-    # ファイル is not supported
+    # ファイル添付は redi 側で対応していないため、呼び出し側に「ブラウザで編集」を強制させる
     if field_format == "attachment":
-        return
+        print(messages.attachment_field_unsupported_notice.format(name=name))
+        return _SKIP_UNSUPPORTED_FIELD
 
     # 自由入力(string,link)
     try:
@@ -685,17 +690,18 @@ def _prompt_custom_field_value(
 
 def _interactive_fill_required_custom_fields(
     project_id: str, tracker_id: str | None, existing: str | None
-) -> str | None:
+) -> tuple[str | None, bool]:
+    """戻り値の bool は「未対応の必須フィールドが含まれていた = ブラウザ編集が必須」を示す。"""
     custom_fields = fetch_custom_fields()
     if custom_fields is None:
         # 非管理者はあらかじめ渡されているパラメータを使うしかない
-        return existing
+        return existing, False
     project_cf_ids = fetch_project_issue_custom_field_ids(project_id)
     required = filter_required_issue_custom_fields(
         custom_fields, project_cf_ids, tracker_id
     )
     if not required:
-        return existing
+        return existing, False
 
     existing_ids: set[int] = set()
     if existing:
@@ -704,10 +710,14 @@ def _interactive_fill_required_custom_fields(
             existing_ids.add(int(key))
 
     added: list[str] = []
+    browser_only = False
     for cf in required:
         if cf["id"] in existing_ids:
             continue
         value = _prompt_custom_field_value(cf, project_id)
+        if value is _SKIP_UNSUPPORTED_FIELD:
+            browser_only = True
+            continue
         if value is None:
             print(messages.canceled)
             exit(1)
@@ -717,10 +727,10 @@ def _interactive_fill_required_custom_fields(
         else:
             added.append(f"{cf['id']}={value}")
     if not added:
-        return existing
+        return existing, browser_only
     if existing:
-        return existing + "," + ",".join(added)
-    return ",".join(added)
+        return existing + "," + ",".join(added), browser_only
+    return ",".join(added), browser_only
 
 
 def handle_issue_create(args: argparse.Namespace) -> None:
@@ -732,6 +742,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
     tracker_id = args.tracker_id
     custom_fields = args.custom_fields
     interactive = subject is None or args.description is None
+    browser_only = False
     if subject is None:
         if tracker_id is None:
             trackers = fetch_trackers()
@@ -756,7 +767,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             print(messages.canceled_empty_subject)
             exit(1)
         # 必要なカスタムフィールドを対話的に入力
-        custom_fields = _interactive_fill_required_custom_fields(
+        custom_fields, browser_only = _interactive_fill_required_custom_fields(
             project_id=project_id,
             tracker_id=tracker_id,
             existing=args.custom_fields,
@@ -766,10 +777,15 @@ def handle_issue_create(args: argparse.Namespace) -> None:
     else:
         description = args.description
     if interactive:
-        action_options: list[tuple[str, str]] = [
-            ("submit", messages.action_submit),
-            ("browser", messages.action_continue_in_browser),
-        ]
+        # 添付ファイル必須など redi で送信できないケースは「ブラウザで編集」のみ提示する
+        action_options: list[tuple[str, str]] = (
+            [("browser", messages.action_continue_in_browser)]
+            if browser_only
+            else [
+                ("submit", messages.action_submit),
+                ("browser", messages.action_continue_in_browser),
+            ]
+        )
         try:
             action = inline_choice(messages.prompt_what_next, action_options)
         except KeyboardInterrupt:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -20,6 +20,7 @@ from redi.cli.prompt_util import (
     FloatValidator,
     HourValidator,
     IntValidator,
+    RequiredValidator,
 )
 from redi.config import default_project_id, redmine_url
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
@@ -515,9 +516,11 @@ def _prompt_custom_field_value(
         label_map = dict(options)
         try:
             if multiple:
-                checked = inline_checkbox(label, options)
-                if not checked:
-                    return None
+                # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
+                while True:
+                    checked = inline_checkbox(label, options)
+                    if checked:
+                        break
                 display = ", ".join(label_map[k] for k in checked)
                 print(messages.prompt_field_value.format(name=name, value=display))
                 return checked
@@ -536,9 +539,10 @@ def _prompt_custom_field_value(
         label_map = dict(options)
         try:
             if multiple:
-                checked = inline_checkbox(label, options)
-                if not checked:
-                    return None
+                while True:
+                    checked = inline_checkbox(label, options)
+                    if checked:
+                        break
                 display = ", ".join(label_map[k] for k in checked)
                 print(messages.prompt_field_value.format(name=name, value=display))
                 return checked
@@ -557,9 +561,10 @@ def _prompt_custom_field_value(
         label_map = dict(options)
         try:
             if multiple:
-                checked = inline_checkbox(label, options)
-                if not checked:
-                    return None
+                while True:
+                    checked = inline_checkbox(label, options)
+                    if checked:
+                        break
                 display = ", ".join(label_map[k] for k in checked)
                 print(messages.prompt_field_value.format(name=name, value=display))
                 return checked
@@ -585,13 +590,14 @@ def _prompt_custom_field_value(
 
     # 長いテキスト
     if field_format == "text":
-        try:
-            value = open_editor()
-        except (KeyboardInterrupt, EOFError):
-            return None
-        if not value:
-            return None
-        return value
+        # 空のまま閉じられたらエディタを開き直す
+        while True:
+            try:
+                value = open_editor()
+            except (KeyboardInterrupt, EOFError):
+                return None
+            if value:
+                return value
 
     # 日付
     if field_format == "date":
@@ -658,9 +664,10 @@ def _prompt_custom_field_value(
         if options:
             try:
                 if multiple:
-                    checked = inline_checkbox(label, options)
-                    if not checked:
-                        return None
+                    while True:
+                        checked = inline_checkbox(label, options)
+                        if checked:
+                            break
                     print(
                         messages.prompt_field_value.format(
                             name=name, value=", ".join(checked)
@@ -680,10 +687,10 @@ def _prompt_custom_field_value(
 
     # 自由入力(string,link)
     try:
-        return (
-            prompt(messages.prompt_custom_field_label.format(name=label)).strip()
-            or None
-        )
+        return prompt(
+            messages.prompt_custom_field_label.format(name=label),
+            validator=RequiredValidator(),
+        ).strip()
     except (KeyboardInterrupt, EOFError):
         return None
 

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -14,7 +14,12 @@ from redi.cli._common import (
     open_editor,
     resolve_alias,
 )
-from redi.cli.prompt_util import DueDateValidator, FloatValidator, HourValidator
+from redi.cli.prompt_util import (
+    DueDateValidator,
+    FloatValidator,
+    HourValidator,
+    IntValidator,
+)
 from redi.config import default_project_id, redmine_url
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
@@ -572,6 +577,20 @@ def _prompt_custom_field_value(
             return None
         print(messages.prompt_field_value.format(name=name, value=bool_label_map[key]))
         return key
+
+    # 整数
+    if field_format == "int":
+        try:
+            value = prompt(
+                messages.prompt_custom_field_label.format(name=label),
+                validator=IntValidator(),
+            ).strip()
+        except (KeyboardInterrupt, EOFError):
+            return None
+        if not value:
+            return None
+        print(messages.prompt_field_value.format(name=name, value=value))
+        return value
 
     # 小数
     if field_format == "float":

--- a/src/redi/cli/prompt_util.py
+++ b/src/redi/cli/prompt_util.py
@@ -14,6 +14,14 @@ _FLOAT_PATTERN = re.compile(r"-?\d+(\.\d+)?")
 _INT_PATTERN = re.compile(r"-?\d+")
 
 
+class RequiredValidator(Validator):
+    """空文字（空白のみを含む）を拒否する Validator。"""
+
+    def validate(self, document: Document) -> None:
+        if not document.text.strip():
+            raise ValidationError(message=messages.error_input_required)
+
+
 class UrlValidator(Validator):
     """http:// または https:// で始まるURLを許容するValidator。
 

--- a/src/redi/cli/prompt_util.py
+++ b/src/redi/cli/prompt_util.py
@@ -10,6 +10,7 @@ from redi.i18n import messages
 
 _URL_PREFIXES = ("http://", "https://")
 _DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
+_FLOAT_PATTERN = re.compile(r"-?\d+(\.\d+)?")
 
 
 class UrlValidator(Validator):
@@ -36,6 +37,18 @@ class HourValidator(Validator):
     def validate(self, document: Document) -> None:
         text = document.text
         if not text.replace(".", "", 1).isdigit():
+            raise ValidationError(message=messages.error_numeric_required)
+
+
+class FloatValidator(Validator):
+    """カスタムフィールド float 形式用の Validator。
+
+    符号付き整数または小数（負の値も許容）を受け付ける。
+    """
+
+    def validate(self, document: Document) -> None:
+        text = document.text.strip()
+        if not _FLOAT_PATTERN.fullmatch(text):
             raise ValidationError(message=messages.error_numeric_required)
 
 

--- a/src/redi/cli/prompt_util.py
+++ b/src/redi/cli/prompt_util.py
@@ -11,6 +11,7 @@ from redi.i18n import messages
 _URL_PREFIXES = ("http://", "https://")
 _DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
 _FLOAT_PATTERN = re.compile(r"-?\d+(\.\d+)?")
+_INT_PATTERN = re.compile(r"-?\d+")
 
 
 class UrlValidator(Validator):
@@ -49,6 +50,18 @@ class FloatValidator(Validator):
     def validate(self, document: Document) -> None:
         text = document.text.strip()
         if not _FLOAT_PATTERN.fullmatch(text):
+            raise ValidationError(message=messages.error_numeric_required)
+
+
+class IntValidator(Validator):
+    """カスタムフィールド int 形式用の Validator。
+
+    符号付き整数（負の値も許容）を受け付ける。
+    """
+
+    def validate(self, document: Document) -> None:
+        text = document.text.strip()
+        if not _INT_PATTERN.fullmatch(text):
             raise ValidationError(message=messages.error_numeric_required)
 
 

--- a/src/redi/cli/prompt_util.py
+++ b/src/redi/cli/prompt_util.py
@@ -65,6 +65,21 @@ class IntValidator(Validator):
             raise ValidationError(message=messages.error_numeric_required)
 
 
+class DateValidator(Validator):
+    """YYYY-MM-DD 形式の日付のみを許容する Validator。"""
+
+    def validate(self, document: Document) -> None:
+        text = document.text.strip()
+        if text == "":
+            raise ValidationError(message=messages.error_input_required)
+        if not _DATE_PATTERN.fullmatch(text):
+            raise ValidationError(message=messages.error_date_format)
+        try:
+            date.fromisoformat(text)
+        except ValueError:
+            raise ValidationError(message=messages.error_date_format)
+
+
 class DueDateValidator(Validator):
     """期日入力用の Validator。空文字または開始日以降の YYYY-MM-DD のみ許容する。"""
 

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -368,6 +368,8 @@ class MessagesProto(Protocol):
     """prompt_what_next の選択肢: そのまま送信"""
     action_continue_in_browser: str
     """prompt_what_next の選択肢: ブラウザで続きを編集"""
+    attachment_field_unsupported_notice: str
+    """{name}: 必須カスタムフィールドに添付ファイル型がある場合の未対応通知。ブラウザでの編集が必要"""
 
     # ---- prompt validators ----
     error_input_required: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -358,6 +358,10 @@ class MessagesProto(Protocol):
     """{name}, {value}"""
     prompt_custom_field_label: str
     """{name}"""
+    label_bool_true: str
+    """カスタムフィールド bool 形式の真の表示ラベル"""
+    label_bool_false: str
+    """カスタムフィールド bool 形式の偽の表示ラベル"""
     prompt_what_next: str
     """イシュー作成時に次のアクションを選ばせるメニューのタイトル"""
     action_submit: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -255,6 +255,9 @@ class En(MessagesProto):
     prompt_what_next = "What's next?"
     action_submit = "Submit"
     action_continue_in_browser = "Continue in browser"
+    attachment_field_unsupported_notice = (
+        "{name}: attachment-type fields are not supported; please edit in browser"
+    )
 
     # ---- prompt validators ----
     error_input_required = "Required"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -250,6 +250,8 @@ class En(MessagesProto):
     prompt_required_field = "{name} (required)"
     prompt_field_value = "{name}: {value}"
     prompt_custom_field_label = "{name}: "
+    label_bool_true = "Yes"
+    label_bool_false = "No"
     prompt_what_next = "What's next?"
     action_submit = "Submit"
     action_continue_in_browser = "Continue in browser"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -262,7 +262,7 @@ class En(MessagesProto):
     # ---- prompt validators ----
     error_input_required = "Required"
     error_url_format = "Enter a URL starting with http:// or https://"
-    error_date_format = "Use YYYY-MM-DD (empty to clear)"
+    error_date_format = "Use YYYY-MM-DD"
     error_date_after_start = "Enter a date on or after start date {date}"
     error_numeric_required = "Enter a number"
     error_page_title_required = "Enter a page title"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -254,6 +254,8 @@ class Ja(MessagesProto):
     prompt_required_field = "{name}（必須）"
     prompt_field_value = "{name}: {value}"
     prompt_custom_field_label = "{name}: "
+    label_bool_true = "はい"
+    label_bool_false = "いいえ"
     prompt_what_next = "次のアクションを選択してください"
     action_submit = "送信する"
     action_continue_in_browser = "ブラウザで編集する"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -259,6 +259,9 @@ class Ja(MessagesProto):
     prompt_what_next = "次のアクションを選択してください"
     action_submit = "送信する"
     action_continue_in_browser = "ブラウザで編集する"
+    attachment_field_unsupported_notice = (
+        "{name}: 添付ファイル型はサポート対象外のためブラウザでの編集が必要です"
+    )
 
     # ---- prompt validators ----
     error_input_required = "入力してください"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -266,7 +266,7 @@ class Ja(MessagesProto):
     # ---- prompt validators ----
     error_input_required = "入力してください"
     error_url_format = "http:// または https:// で始まるURLを入力してください"
-    error_date_format = "YYYY-MM-DD で入力してください（空文字でクリア）"
+    error_date_format = "YYYY-MM-DD で入力してください"
     error_date_after_start = "開始日 {date} 以降の日付を入力してください"
     error_numeric_required = "数値を入力してください"
     error_page_title_required = "ページタイトルを入力してください"

--- a/tests/unit/test_prompt_util.py
+++ b/tests/unit/test_prompt_util.py
@@ -9,6 +9,7 @@ from prompt_toolkit.validation import ValidationError
 import re
 
 from redi.cli.prompt_util import (
+    DateValidator,
     DueDateValidator,
     FloatValidator,
     HourValidator,
@@ -212,6 +213,42 @@ class TestFloatValidator:
             ValidationError, match=re.escape(messages.error_numeric_required)
         ):
             FloatValidator().validate(Document(text=text))
+
+
+class TestDateValidator:
+    """DateValidator()は YYYY-MM-DD 形式の日付を許容する"""
+
+    def test_empty_string_raises(self):
+        """空文字は入力必須エラーになる"""
+        with pytest.raises(ValidationError):
+            DateValidator().validate(Document(text=""))
+
+    def test_surrounding_whitespace_is_stripped(self):
+        """前後の空白は無視して評価される"""
+        DateValidator().validate(Document(text="  2026-04-26  "))
+
+    @pytest.mark.parametrize("text", ["2026-04-26", "2026-12-31", "1999-01-01"])
+    def test_valid_date_passes(self, text: str):
+        """任意の YYYY-MM-DD は通る"""
+        DateValidator().validate(Document(text=text))
+
+    @pytest.mark.parametrize(
+        "text",
+        ["2026/04/26", "26-04-26", "2026-4-26", "abc", "2026-04"],
+    )
+    def test_invalid_format_raises(self, text: str):
+        """YYYY-MM-DD 形式に合わない入力は形式エラーになる"""
+        with pytest.raises(ValidationError, match="YYYY-MM-DD"):
+            DateValidator().validate(Document(text=text))
+
+    @pytest.mark.parametrize(
+        "text",
+        ["2026-13-01", "2026-02-30", "2026-00-10"],
+    )
+    def test_calendar_invalid_date_raises(self, text: str):
+        """形式は合っていてもカレンダー上不正な日付は形式エラーになる"""
+        with pytest.raises(ValidationError, match="YYYY-MM-DD"):
+            DateValidator().validate(Document(text=text))
 
 
 class TestDueDateValidator:

--- a/tests/unit/test_prompt_util.py
+++ b/tests/unit/test_prompt_util.py
@@ -14,6 +14,7 @@ from redi.cli.prompt_util import (
     FloatValidator,
     HourValidator,
     IntValidator,
+    RequiredValidator,
     UrlValidator,
     digit_and_period_key_bindings,
     digit_only_key_bindings,
@@ -87,6 +88,23 @@ class TestDigitOnlyKeyBindings:
     def test_rejected_input_preserves_existing_text(self):
         """拒否された入力は既存バッファを変更しない"""
         assert _invoke(digit_only_key_bindings(), ".", initial="12") == "12"
+
+
+class TestRequiredValidator:
+    """RequiredValidator()は空文字（空白のみ）を拒否する"""
+
+    @pytest.mark.parametrize("text", ["a", "  hello  ", "0", "あ"])
+    def test_non_empty_passes(self, text: str):
+        """非空白文字を含む入力は通る"""
+        RequiredValidator().validate(Document(text=text))
+
+    @pytest.mark.parametrize("text", ["", " ", "   ", "\t"])
+    def test_empty_or_whitespace_raises_required(self, text: str):
+        """空文字や空白のみは『入力してください』でエラーになる"""
+        with pytest.raises(
+            ValidationError, match=re.escape(messages.error_input_required)
+        ):
+            RequiredValidator().validate(Document(text=text))
 
 
 class TestUrlValidator:

--- a/tests/unit/test_prompt_util.py
+++ b/tests/unit/test_prompt_util.py
@@ -12,6 +12,7 @@ from redi.cli.prompt_util import (
     DueDateValidator,
     FloatValidator,
     HourValidator,
+    IntValidator,
     UrlValidator,
     digit_and_period_key_bindings,
     digit_only_key_bindings,
@@ -161,6 +162,30 @@ class TestHourValidator:
             ValidationError, match=re.escape(messages.error_numeric_required)
         ):
             HourValidator().validate(Document(text=text))
+
+
+class TestIntValidator:
+    """IntValidator()は符号付き整数を許容する"""
+
+    @pytest.mark.parametrize("text", ["0", "1", "100", "-1", "-100"])
+    def test_valid_numbers_pass(self, text: str):
+        """正負の整数は通る"""
+        IntValidator().validate(Document(text=text))
+
+    def test_surrounding_whitespace_is_stripped(self):
+        """前後の空白は無視して評価される"""
+        IntValidator().validate(Document(text="  -1  "))
+
+    @pytest.mark.parametrize(
+        "text",
+        ["", " ", "abc", "1.5", "1,5", "+1", "--1", "1-"],
+    )
+    def test_invalid_inputs_raise(self, text: str):
+        """空文字や数値以外、小数や不正な符号位置はエラーになる"""
+        with pytest.raises(
+            ValidationError, match=re.escape(messages.error_numeric_required)
+        ):
+            IntValidator().validate(Document(text=text))
 
 
 class TestFloatValidator:

--- a/tests/unit/test_prompt_util.py
+++ b/tests/unit/test_prompt_util.py
@@ -10,6 +10,7 @@ import re
 
 from redi.cli.prompt_util import (
     DueDateValidator,
+    FloatValidator,
     HourValidator,
     UrlValidator,
     digit_and_period_key_bindings,
@@ -160,6 +161,32 @@ class TestHourValidator:
             ValidationError, match=re.escape(messages.error_numeric_required)
         ):
             HourValidator().validate(Document(text=text))
+
+
+class TestFloatValidator:
+    """FloatValidator()は符号付き整数・小数を許容する"""
+
+    @pytest.mark.parametrize(
+        "text", ["0", "1", "1.5", "12.34", "100", "0.5", "-1", "-1.5", "-0.5"]
+    )
+    def test_valid_numbers_pass(self, text: str):
+        """正負の整数・小数は通る"""
+        FloatValidator().validate(Document(text=text))
+
+    def test_surrounding_whitespace_is_stripped(self):
+        """前後の空白は無視して評価される"""
+        FloatValidator().validate(Document(text="  -1.5  "))
+
+    @pytest.mark.parametrize(
+        "text",
+        ["", " ", "abc", "1.5h", "1,5", "1..5", "1.2.3", "+1", ".5", "1.", "--1"],
+    )
+    def test_invalid_inputs_raise(self, text: str):
+        """空文字や数値以外、不完全な数値表記はエラーになる"""
+        with pytest.raises(
+            ValidationError, match=re.escape(messages.error_numeric_required)
+        ):
+            FloatValidator().validate(Document(text=text))
 
 
 class TestDueDateValidator:


### PR DESCRIPTION
resolve #153 

- **feat(issue create): support custom_field bool**
- **feat(issue create): support custom_field float**
- **feat(issue create): support custom_field int**
- **feat(issue create): support custom_field progressbar**
- **feat(issue create): support custom_field date**
- **feat(issue create): support custom_field text**
- **update: attachment(ファイル)はサポート出来ていないコメントを追加; string,linkに対応するコメントを追加**
- **feat(issue create): attachment のような扱えない必須カスタムフィールドが設定されている場合にスキップする(ブラウザでの継続だけ出来るようにする)**
- **feat(issue create): 必須カスタムフィールドで空入力をキャンセル扱いせず再入力させる**
- **feat(issue create): text/description の入力後に 1 行省略表示する。prompt() 系の重複表示を解消**
- **docs: コメントを修正**
- **refactor: try-catchしてNoneを返している箇所はそのようにせず伝搬させる**
- **feat(issue create): カスタムフィールドの初期値が設定されていればそれを使用する**
