### PR TITLE
test(i18n): MessagesProto の未使用 key と実装漏れを検査

### DIFF
--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -439,8 +439,6 @@ class MessagesProto(Protocol):
     """{id}, {name}"""
     delete_target_time_entry: str
     """{id}, {hours}, {activity}, {spent_on}"""
-    delete_confirm_tui: str
-    """{summary}"""
 
     # ---- detail/output labels ----
     label_assignable: str
@@ -490,7 +488,6 @@ class MessagesProto(Protocol):
     label_allowed_statuses_header: str
     label_revisions_header: str
     label_journals_header: str
-    label_comments_header: str
     label_due_date_field: str
     """{value}"""
     label_sharing_field: str
@@ -500,8 +497,6 @@ class MessagesProto(Protocol):
     label_trackers_header: str
     label_issue_categories_header: str
     label_enabled_modules_header: str
-    label_user_field: str
-    """{name}, {id}"""
     label_issue_field: str
     """{id}"""
     label_comments_field: str
@@ -594,14 +589,7 @@ class MessagesProto(Protocol):
     arg_help_skip_confirm: str
     arg_help_open_web: str
     arg_help_project_id: str
-    arg_help_project_id_filter: str
-    arg_help_user_id: str
     arg_help_full_profiles: str
-
-    # ---- argparse helps (subcommand summary) ----
-    arg_help_crud_subcommands: str
-    arg_help_role_subcommands: str
-    arg_help_file_subcommands: str
 
     # ---- argparse helps (project) ----
     arg_help_project_command: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -5,7 +5,9 @@ class MessagesProto(Protocol):
     """全言語が満たすべきメッセージ集合の輪郭。
 
     新しいメッセージを追加するときはまずここに key を宣言し、
-    ja.py / en.py に実装を追加する。実装側に欠けがあれば ty が検出する。
+    ja.py / en.py に実装を追加する。実装側に欠けがあれば
+    tests/unit/i18n/test_i18n.py の TestProtocolImplemented が検出する
+    (Protocol の annotation-only メンバは ty では強制されないため)。
     """
 
     # ---- profile / config ----

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -324,7 +324,6 @@ class En(MessagesProto):
     delete_target_time_entry = (
         "Time entry to delete: {id} {hours}h {activity} ({spent_on})"
     )
-    delete_confirm_tui = "Delete? {summary} [y/N]"
 
     # ---- detail labels ----
     label_assignable = "Assignable: {value}"
@@ -358,14 +357,12 @@ class En(MessagesProto):
     label_allowed_statuses_header = "Allowed statuses:"
     label_revisions_header = "Revisions:"
     label_journals_header = "Journals/changes:"
-    label_comments_header = "Comments:"
     label_due_date_field = "Due date: {value}"
     label_sharing_field = "Sharing: {value}"
     label_parent_project = "Parent project: {id} {name}"
     label_trackers_header = "Trackers:"
     label_issue_categories_header = "Issue categories:"
     label_enabled_modules_header = "Enabled modules:"
-    label_user_field = "  User: {name} (id={id})"
     label_issue_field = "  Issue: #{id}"
     label_comments_field = "  Comments: {value}"
     label_user_in_te = "  User: {name} (id={id})"
@@ -451,8 +448,6 @@ class En(MessagesProto):
     arg_help_skip_confirm = "Skip confirmation prompt"
     arg_help_open_web = "Open the Redmine page in a browser"
     arg_help_project_id = "Project ID"
-    arg_help_project_id_filter = "Filter by project ID"
-    arg_help_user_id = "Filter by user ID ('me' allowed)"
     arg_help_full_profiles = "Show all profiles"
 
     # ---- argparse helps (subcommand summary) ----

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -323,7 +323,6 @@ class Ja(MessagesProto):
     delete_target_category = "削除するイシューカテゴリ: {id} {name}"
     delete_target_group = "削除するグループ: {id} {name}"
     delete_target_time_entry = "削除する作業時間: {id} {hours}h {activity} ({spent_on})"
-    delete_confirm_tui = "削除しますか? {summary} [y/N]"
 
     # ---- detail labels ----
     label_assignable = "割り当て可能: {value}"
@@ -357,14 +356,12 @@ class Ja(MessagesProto):
     label_allowed_statuses_header = "遷移可能なステータス:"
     label_revisions_header = "リビジョン:"
     label_journals_header = "コメント/変更履歴:"
-    label_comments_header = "コメント:"
     label_due_date_field = "期日: {value}"
     label_sharing_field = "共有: {value}"
     label_parent_project = "親プロジェクト: {id} {name}"
     label_trackers_header = "トラッカー:"
     label_issue_categories_header = "イシューカテゴリ:"
     label_enabled_modules_header = "有効モジュール:"
-    label_user_field = "  ユーザー: {name} (id={id})"
     label_issue_field = "  イシュー: #{id}"
     label_comments_field = "  コメント: {value}"
     label_user_in_te = "  ユーザー: {name} (id={id})"
@@ -454,8 +451,6 @@ class Ja(MessagesProto):
     arg_help_skip_confirm = "確認プロンプトをスキップ"
     arg_help_open_web = "ブラウザでRedmineのページを開く"
     arg_help_project_id = "プロジェクトID"
-    arg_help_project_id_filter = "プロジェクトIDでフィルタリング"
-    arg_help_user_id = "ユーザーIDでフィルタリング（'me'も可）"
     arg_help_full_profiles = "全プロファイルを表示"
 
     # ---- argparse helps (subcommand summary) ----

--- a/tests/unit/i18n/test_i18n.py
+++ b/tests/unit/i18n/test_i18n.py
@@ -8,12 +8,11 @@ from redi.i18n.ja import Ja
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
-SCAN_DIRS = (REPO_ROOT / "src", REPO_ROOT / "tests")
 
 
 def _scan_sources() -> str:
     parts: list[str] = []
-    for base in SCAN_DIRS:
+    for base in (REPO_ROOT / "src", REPO_ROOT / "tests"):
         for p in base.rglob("*.py"):
             parts.append(p.read_text())
     return "\n".join(parts)
@@ -75,7 +74,11 @@ class TestFormat:
 
 
 class TestNoUnusedKeys:
-    """_protocol.py に宣言した全 key が src/ または tests/ から参照されている"""
+    """_protocol.py に宣言した全 key が src/ または tests/ から参照されている
+
+    なお逆向き(`messages.<key>` の <key> が未定義) は ty が
+    unresolved-attribute として検出するためテストでは扱わない。
+    """
 
     def test_all_keys_referenced(self):
         """MessagesProto の公開 key が `messages.<key>` として参照されている"""
@@ -86,20 +89,3 @@ class TestNoUnusedKeys:
             if not k.startswith("_") and f"messages.{k}" not in searched
         ]
         assert not unused, unused
-
-
-class TestNoUndefinedKeys:
-    """src/ または tests/ で参照される `messages.<key>` は _protocol.py で定義されている"""
-
-    def test_no_undefined_references(self):
-        """`messages.<key>` の <key> が MessagesProto に存在する"""
-        defined = set(MessagesProto.__annotations__)
-        pat = re.compile(r"\bmessages\.([A-Za-z_][A-Za-z0-9_]*)")
-        undefined: set[str] = set()
-        for base in SCAN_DIRS:
-            for p in base.rglob("*.py"):
-                for m in pat.finditer(p.read_text()):
-                    key = m.group(1)
-                    if key not in defined:
-                        undefined.add(key)
-        assert not undefined, undefined

--- a/tests/unit/i18n/test_i18n.py
+++ b/tests/unit/i18n/test_i18n.py
@@ -73,6 +73,24 @@ class TestFormat:
         assert En.profile_created.format(name="dev") == "Created profile 'dev'"
 
 
+class TestProtocolImplemented:
+    """MessagesProto で宣言した key を Ja / En 双方が実装している
+
+    Protocol の annotation-only メンバは ty では実装漏れを検出できないため
+    このテストで補完する。
+    """
+
+    def test_ja_implements_all(self):
+        """Ja は MessagesProto の全 key を実装している"""
+        missing = [k for k in MessagesProto.__annotations__ if not hasattr(Ja, k)]
+        assert not missing, missing
+
+    def test_en_implements_all(self):
+        """En は MessagesProto の全 key を実装している"""
+        missing = [k for k in MessagesProto.__annotations__ if not hasattr(En, k)]
+        assert not missing, missing
+
+
 class TestNoUnusedKeys:
     """_protocol.py に宣言した全 key が src/ または tests/ から参照されている
 

--- a/tests/unit/i18n/test_i18n.py
+++ b/tests/unit/i18n/test_i18n.py
@@ -1,8 +1,22 @@
 import re
+from pathlib import Path
 
 from redi import i18n
+from redi.i18n._protocol import MessagesProto
 from redi.i18n.en import En
 from redi.i18n.ja import Ja
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCAN_DIRS = (REPO_ROOT / "src", REPO_ROOT / "tests")
+
+
+def _scan_sources() -> str:
+    parts: list[str] = []
+    for base in SCAN_DIRS:
+        for p in base.rglob("*.py"):
+            parts.append(p.read_text())
+    return "\n".join(parts)
 
 
 class TestKeysParity:
@@ -58,3 +72,34 @@ class TestFormat:
     def test_profile_created_en(self):
         """en: name を埋め込んだ英語メッセージになる"""
         assert En.profile_created.format(name="dev") == "Created profile 'dev'"
+
+
+class TestNoUnusedKeys:
+    """_protocol.py に宣言した全 key が src/ または tests/ から参照されている"""
+
+    def test_all_keys_referenced(self):
+        """MessagesProto の公開 key が `messages.<key>` として参照されている"""
+        searched = _scan_sources()
+        unused = [
+            k
+            for k in MessagesProto.__annotations__
+            if not k.startswith("_") and f"messages.{k}" not in searched
+        ]
+        assert not unused, unused
+
+
+class TestNoUndefinedKeys:
+    """src/ または tests/ で参照される `messages.<key>` は _protocol.py で定義されている"""
+
+    def test_no_undefined_references(self):
+        """`messages.<key>` の <key> が MessagesProto に存在する"""
+        defined = set(MessagesProto.__annotations__)
+        pat = re.compile(r"\bmessages\.([A-Za-z_][A-Za-z0-9_]*)")
+        undefined: set[str] = set()
+        for base in SCAN_DIRS:
+            for p in base.rglob("*.py"):
+                for m in pat.finditer(p.read_text()):
+                    key = m.group(1)
+                    if key not in defined:
+                        undefined.add(key)
+        assert not undefined, undefined


### PR DESCRIPTION
resolve #170 

## Summary
- `tests/unit/i18n/test_i18n.py` に `MessagesProto` の key 整合性検査を 2 件追加
  - `TestNoUnusedKeys`: `_protocol.py` で宣言された全 key が `messages.<key>` の形で `src/` または `tests/` から参照されていることを確認
  - `TestProtocolImplemented`: `MessagesProto` で宣言した key を `Ja` / `En` 双方が実装していることを確認 (annotation-only な Protocol メンバを subclass で実装しているか、ty では現状検出できないためテストで補完)
- 検査により検出された未使用 key を削除
  - `delete_confirm_tui`, `label_comments_header`, `label_user_field`, `arg_help_project_id_filter`, `arg_help_user_id`
- `_protocol.py` の docstring を実情に合わせて更新

## 補足
- 逆向き(`messages.<key>` の `<key>` が `MessagesProto` で未定義) の検査は当初追加したが、`messages: MessagesProto` と型付けされているため ty が `unresolved-attribute` として検出可能なので削除した
- ja/en 内部のヘルパ alias (`arg_help_crud_subcommands` 等) は他 key の値設定で参照されているため、`_protocol.py` の宣言からのみ外して ja/en の class 属性として残した

## Test plan
- [x] `task check` (format / lint / typecheck / test) が通る
- [x] 故意に `_protocol.py` で未使用 key を追加すると `TestNoUnusedKeys` が失敗することを目視確認
- [x] 故意に `MessagesProto` にだけ key を追加して ja/en に実装しないと `TestProtocolImplemented` が失敗することを目視確認
- [x] 故意に `messages.no_such_key` を src 配下に追加すると `ty check` が失敗することを目視確認