### PR TITLE
issue create/update (interactive) で project に紐づく tracker のみを候補にする

### DIFF
--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -42,7 +42,6 @@ from redi.api.issue_status import fetch_issue_statuses
 from redi.api.membership import fetch_project_users
 from redi.api.project import fetch_project
 from redi.api.time_entry import create_time_entry
-from redi.api.tracker import fetch_trackers
 from redi.api.version import fetch_versions
 from redi.i18n import messages
 
@@ -362,7 +361,12 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
     print(messages.update_items.format(items=", ".join(labels[v] for v in selected)))
     try:
         if "tracker" in selected:
-            trackers = fetch_trackers()
+            project_id = (current.get("project") or {}).get("id")
+            if not project_id:
+                print(messages.canceled_no_project)
+                exit(1)
+            project = fetch_project(str(project_id), include="trackers")
+            trackers = project.get("trackers") or []
             tracker_options: list[tuple[str, str]] = [
                 (str(t["id"]), t["name"]) for t in trackers
             ]

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -40,6 +40,7 @@ from redi.api.issue import (
 from redi.api.issue_relation import create_relation, delete_relation
 from redi.api.issue_status import fetch_issue_statuses
 from redi.api.membership import fetch_project_users
+from redi.api.project import fetch_project
 from redi.api.time_entry import create_time_entry
 from redi.api.tracker import fetch_trackers
 from redi.api.version import fetch_versions
@@ -863,7 +864,8 @@ def handle_issue_create(args: argparse.Namespace) -> None:
     browser_only = False
     if subject is None:
         if tracker_id is None:
-            trackers = fetch_trackers()
+            project = fetch_project(project_id, include="trackers")
+            trackers = project.get("trackers") or []
             tracker_options: list[tuple[str, str]] = [
                 (str(t["id"]), t["name"]) for t in trackers
             ]


### PR DESCRIPTION
resolve #105 

## Summary
- `issue create`(`issue update`) の対話フローで使うトラッカー候補を `GET /trackers.json` ではなく `GET /projects/[id].json?include=trackers` から取得するよう変更
- これによりプロジェクトに関係のないトラッカーが候補に出てこなくなり、トラッカー数が多い環境でも選びやすくなる

## Test plan
- [x] 複数トラッカーを持つプロジェクトで `redi issue create` を実行し、当該プロジェクトに紐づくトラッカーのみが候補に出ることを確認
- [ ] `redi issue create -t <tracker_id>` のように `--tracker_id` を明示した場合は従来通り候補選択がスキップされることを確認