### PR TITLE
feat(issue_journal): update/delete コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ redi relation view <relation_id>
 
 # issue_journal (alias: ij, requires Redmine 5.0+)
 redi issue_journal update <journal_id> "updated note"
+redi issue_journal update <journal_id> "" # updating with an empty note is equivalent to delete
 redi issue_journal delete <journal_id> # confirm before delete (-y to skip)
 
 # time_entry (alias: te)

--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ redi attachment delete <attachment_id> # confirm before delete (-y to skip)
 # relation (issue relation details)
 redi relation view <relation_id>
 
+# issue_journal (alias: ij, requires Redmine 5.0+)
+redi issue_journal update <journal_id> "updated note"
+redi issue_journal delete <journal_id> # confirm before delete (-y to skip)
+
 # time_entry (alias: te)
 redi time_entry -p <project_id> -u me
 redi time_entry create 1.5 -i <issue_id> -a <activity_id> -c "comment"

--- a/src/redi/api/issue_journal.py
+++ b/src/redi/api/issue_journal.py
@@ -1,0 +1,37 @@
+import requests
+
+from redi.client import client
+from redi.i18n import messages
+
+
+def update_issue_journal(journal_id: str, notes: str) -> None:
+    response = client.put(
+        f"/journals/{journal_id}.json",
+        json={"journal": {"notes": notes}},
+    )
+    if response.status_code == 404:
+        print(messages.issue_journal_not_found.format(id=journal_id))
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print(messages.issue_journal_update_failed)
+        exit(1)
+    print(messages.issue_journal_updated.format(id=journal_id))
+
+
+def delete_issue_journal(journal_id: str) -> None:
+    response = client.delete(f"/journals/{journal_id}.json")
+    if response.status_code == 404:
+        print(messages.issue_journal_not_found.format(id=journal_id))
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print(e.response.text)
+        print(messages.issue_journal_delete_failed)
+        exit(1)
+    print(messages.issue_journal_deleted.format(id=journal_id))

--- a/src/redi/cli/issue_journal_command.py
+++ b/src/redi/cli/issue_journal_command.py
@@ -1,0 +1,62 @@
+import argparse
+
+from redi.api.issue_journal import delete_issue_journal, update_issue_journal
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.i18n import messages
+
+
+def add_issue_journal_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
+    ij_parser = subparsers.add_parser(
+        "issue_journal",
+        aliases=["ij"],
+        help=messages.arg_help_issue_journal_command,
+        parents=parents,
+    )
+    ij_subparsers = ij_parser.add_subparsers(dest="issue_journal_command")
+    ij_parser.set_defaults(_print_help=ij_parser.print_help)
+
+    ij_update_parser = ij_subparsers.add_parser(
+        "update",
+        aliases=["u"],
+        help=messages.arg_help_issue_journal_update,
+        parents=parents,
+    )
+    ij_update_parser.add_argument(
+        "journal_id", help=messages.arg_help_issue_journal_update_id
+    )
+    ij_update_parser.add_argument(
+        "notes", help=messages.arg_help_issue_journal_update_notes
+    )
+
+    ij_delete_parser = ij_subparsers.add_parser(
+        "delete",
+        aliases=["d"],
+        help=messages.arg_help_issue_journal_delete,
+        parents=parents,
+    )
+    ij_delete_parser.add_argument(
+        "journal_id", help=messages.arg_help_issue_journal_delete_id
+    )
+    ij_delete_parser.add_argument(
+        "-y", "--yes", action="store_true", help=messages.arg_help_skip_confirm
+    )
+
+
+def handle_issue_journal(args: argparse.Namespace) -> None:
+    cmd = resolve_alias(args.issue_journal_command)
+    if cmd == "update":
+        update_issue_journal(args.journal_id, args.notes)
+        return
+    if cmd == "delete":
+        if not args.yes:
+            confirm_delete(
+                messages.delete_target_issue_journal.format(
+                    id=args.journal_id, notes=""
+                )
+            )
+        delete_issue_journal(args.journal_id)
+        return
+    args._print_help()

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -31,6 +31,10 @@ from redi.cli.issue_command import (
     handle_issue_create,
     handle_issue_update,
 )
+from redi.cli.issue_journal_command import (
+    add_issue_journal_parser,
+    handle_issue_journal,
+)
 from redi.cli.me_command import add_me_parser, handle_me
 from redi.cli.membership_command import add_membership_parser, handle_membership
 from redi.cli.news_command import add_news_parser, handle_news
@@ -129,6 +133,7 @@ def build_redi_parser() -> argparse.ArgumentParser:
     add_relation_parser(subparsers, parents)
     add_time_entry_parser(subparsers, parents)
     add_file_parser(subparsers, parents)
+    add_issue_journal_parser(subparsers, parents)
     return parser
 
 
@@ -361,5 +366,7 @@ def main() -> None:
             exit(1)
     elif args.command in ("file", "f"):
         handle_file(args)
+    elif args.command in ("issue_journal", "ij"):
+        handle_issue_journal(args)
     else:
         parser.print_help()

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -97,6 +97,8 @@ class MessagesProto(Protocol):
     """ファイルが見つからない。{path}"""
     attachment_not_found: str
     """添付ファイルが見つからない。{id}"""
+    issue_journal_not_found: str
+    """イシューのジャーナルが見つからない。{id}"""
     time_entry_not_found: str
     """作業時間が見つからない。{id}"""
     version_not_found: str
@@ -192,6 +194,10 @@ class MessagesProto(Protocol):
     """{id}"""
     attachment_updated: str
     """{url}"""
+    issue_journal_updated: str
+    """{id}"""
+    issue_journal_deleted: str
+    """{id}"""
     group_updated: str
     """{id}"""
     group_deleted: str
@@ -251,6 +257,8 @@ class MessagesProto(Protocol):
     time_entry_delete_failed: str
     attachment_delete_failed: str
     attachment_update_failed: str
+    issue_journal_update_failed: str
+    issue_journal_delete_failed: str
     group_create_failed: str
     group_update_failed: str
     group_delete_failed: str
@@ -435,6 +443,8 @@ class MessagesProto(Protocol):
     """{id}, {kind}, {principal_id}, {principal_name}, {roles}"""
     delete_target_attachment: str
     """{id}, {filename}"""
+    delete_target_issue_journal: str
+    """{id}, {notes}"""
     delete_target_category: str
     """{id}, {name}"""
     delete_target_group: str
@@ -795,6 +805,14 @@ class MessagesProto(Protocol):
     arg_help_relation_command: str
     arg_help_relation_view: str
     arg_help_relation_view_id: str
+
+    # ---- argparse helps (issue journal) ----
+    arg_help_issue_journal_command: str
+    arg_help_issue_journal_update: str
+    arg_help_issue_journal_update_id: str
+    arg_help_issue_journal_update_notes: str
+    arg_help_issue_journal_delete: str
+    arg_help_issue_journal_delete_id: str
 
     # ---- argparse helps (attachment) ----
     arg_help_attachment_command: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -53,6 +53,7 @@ class En(MessagesProto):
     parent_page_not_found = "Parent page not found: {title}"
     file_not_found = "File not found: {path}"
     attachment_not_found = "Attachment not found: #{id}"
+    issue_journal_not_found = "Issue journal not found: #{id}"
     time_entry_not_found = "Time entry not found: {id}"
     version_not_found = "Version not found: {id}"
     group_not_found = "Group not found: #{id}"
@@ -117,6 +118,8 @@ class En(MessagesProto):
     time_entry_deleted = "Deleted time entry: {id}"
     attachment_deleted = "Deleted attachment: #{id}"
     attachment_updated = "Updated attachment: {url}"
+    issue_journal_updated = "Updated issue journal: #{id}"
+    issue_journal_deleted = "Deleted issue journal: #{id}"
     group_updated = "Updated group: {id}"
     group_deleted = "Deleted group: {id}"
     group_user_added = "Added user {user_id} to group {group_id}"
@@ -163,6 +166,8 @@ class En(MessagesProto):
     time_entry_delete_failed = "Failed to delete time entry"
     attachment_delete_failed = "Failed to delete attachment"
     attachment_update_failed = "Failed to update attachment"
+    issue_journal_update_failed = "Failed to update issue journal"
+    issue_journal_delete_failed = "Failed to delete issue journal"
     group_create_failed = "Failed to create group"
     group_update_failed = "Failed to update group"
     group_delete_failed = "Failed to delete group"
@@ -319,6 +324,7 @@ class En(MessagesProto):
         "Membership to delete: {id} [{kind}] {principal_id} {principal_name} - {roles}"
     )
     delete_target_attachment = "Attachment to delete: {id} {filename}"
+    delete_target_issue_journal = "Issue journal to delete: #{id} {notes}"
     delete_target_category = "Issue category to delete: {id} {name}"
     delete_target_group = "Group to delete: {id} {name}"
     delete_target_time_entry = (
@@ -669,6 +675,14 @@ class En(MessagesProto):
     arg_help_relation_command = "Issue relation details"
     arg_help_relation_view = "Relation details"
     arg_help_relation_view_id = "Relation ID"
+
+    # ---- argparse helps (issue journal) ----
+    arg_help_issue_journal_command = "update(u), delete(d)"
+    arg_help_issue_journal_update = "Update issue journal note"
+    arg_help_issue_journal_update_id = "Journal ID"
+    arg_help_issue_journal_update_notes = "Note text"
+    arg_help_issue_journal_delete = "Delete issue journal"
+    arg_help_issue_journal_delete_id = "Journal ID"
 
     # ---- argparse helps (attachment) ----
     arg_help_attachment_command = "Attachment details/update/delete"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -55,6 +55,7 @@ class Ja(MessagesProto):
     parent_page_not_found = "親ページが見つかりません: {title}"
     file_not_found = "ファイルが見つかりません: {path}"
     attachment_not_found = "添付ファイルが見つかりません: #{id}"
+    issue_journal_not_found = "イシューのジャーナルが見つかりません: #{id}"
     time_entry_not_found = "作業時間が見つかりません: {id}"
     version_not_found = "バージョンが見つかりません: {id}"
     group_not_found = "グループが見つかりません: #{id}"
@@ -121,6 +122,8 @@ class Ja(MessagesProto):
     time_entry_deleted = "作業時間を削除しました: {id}"
     attachment_deleted = "添付ファイルを削除しました: #{id}"
     attachment_updated = "添付ファイルを更新しました: {url}"
+    issue_journal_updated = "イシューのジャーナルを更新しました: #{id}"
+    issue_journal_deleted = "イシューのジャーナルを削除しました: #{id}"
     group_updated = "グループを更新しました: {id}"
     group_deleted = "グループを削除しました: {id}"
     group_user_added = "グループ {group_id} にユーザー {user_id} を追加しました"
@@ -165,6 +168,8 @@ class Ja(MessagesProto):
     time_entry_delete_failed = "作業時間の削除に失敗しました"
     attachment_delete_failed = "添付ファイルの削除に失敗しました"
     attachment_update_failed = "添付ファイルの更新に失敗しました"
+    issue_journal_update_failed = "イシューのジャーナルの更新に失敗しました"
+    issue_journal_delete_failed = "イシューのジャーナルの削除に失敗しました"
     group_create_failed = "グループの作成に失敗しました"
     group_update_failed = "グループの更新に失敗しました"
     group_delete_failed = "グループの削除に失敗しました"
@@ -320,6 +325,7 @@ class Ja(MessagesProto):
     delete_target_wiki_page = "削除するWikiページ: {title}"
     delete_target_membership = "削除するメンバーシップ: {id} [{kind}] {principal_id} {principal_name} - {roles}"
     delete_target_attachment = "削除する添付ファイル: {id} {filename}"
+    delete_target_issue_journal = "削除するイシューのジャーナル: #{id} {notes}"
     delete_target_category = "削除するイシューカテゴリ: {id} {name}"
     delete_target_group = "削除するグループ: {id} {name}"
     delete_target_time_entry = "削除する作業時間: {id} {hours}h {activity} ({spent_on})"
@@ -678,6 +684,14 @@ class Ja(MessagesProto):
     arg_help_relation_command = "イシュー関係性 詳細"
     arg_help_relation_view = "関係性詳細"
     arg_help_relation_view_id = "関係性ID"
+
+    # ---- argparse helps (issue journal) ----
+    arg_help_issue_journal_command = "update(u): 更新, delete(d): 削除"
+    arg_help_issue_journal_update = "イシューのジャーナル(コメント)を更新"
+    arg_help_issue_journal_update_id = "ジャーナルID"
+    arg_help_issue_journal_update_notes = "コメント本文"
+    arg_help_issue_journal_delete = "イシューのジャーナルを削除"
+    arg_help_issue_journal_delete_id = "ジャーナルID"
 
     # ---- argparse helps (attachment) ----
     arg_help_attachment_command = "添付ファイル詳細/更新/削除"

--- a/tests/unit/cli/test_issue_journal_command.py
+++ b/tests/unit/cli/test_issue_journal_command.py
@@ -1,0 +1,54 @@
+import argparse
+
+import pytest
+
+from redi.cli.main import build_redi_parser
+
+
+class TestIssueJournalParser:
+    """issue_journal サブコマンドが parser に登録されている"""
+
+    @pytest.fixture
+    def parser(self) -> argparse.ArgumentParser:
+        return build_redi_parser()
+
+    def test_update_subcommand(self, parser):
+        """`issue_journal update <id> <notes>` を受け付ける"""
+        args = parser.parse_args(["issue_journal", "update", "42", "updated note"])
+
+        assert args.command == "issue_journal"
+        assert args.issue_journal_command == "update"
+        assert args.journal_id == "42"
+        assert args.notes == "updated note"
+
+    def test_update_alias(self, parser):
+        """`ij u` でも update を受け付ける"""
+        args = parser.parse_args(["ij", "u", "42", "note"])
+
+        assert args.command == "ij"
+        assert args.issue_journal_command == "u"
+        assert args.journal_id == "42"
+        assert args.notes == "note"
+
+    def test_delete_subcommand(self, parser):
+        """`issue_journal delete <id>` を受け付ける"""
+        args = parser.parse_args(["issue_journal", "delete", "42"])
+
+        assert args.command == "issue_journal"
+        assert args.issue_journal_command == "delete"
+        assert args.journal_id == "42"
+        assert args.yes is False
+
+    def test_delete_with_yes_flag(self, parser):
+        """`issue_journal delete <id> -y` で確認スキップ"""
+        args = parser.parse_args(["issue_journal", "delete", "42", "-y"])
+
+        assert args.yes is True
+
+    def test_delete_alias(self, parser):
+        """`ij d` でも delete を受け付ける"""
+        args = parser.parse_args(["ij", "d", "42"])
+
+        assert args.command == "ij"
+        assert args.issue_journal_command == "d"
+        assert args.journal_id == "42"


### PR DESCRIPTION
resolve #177

## Summary
- Redmine 5.0 から実装された `PUT/DELETE /journals/{id}` API を利用し、イシューのジャーナル(コメント) を更新・削除する `issue_journal` サブコマンドを追加
- alias は `ij`
- `redi issue_journal update <journal_id> <note>` / `redi issue_journal delete <journal_id>` (`-y` で確認スキップ)
- README の usage にも追記

## Test plan
- [x] `redi issue_journal update <journal_id> "updated"` で対象 journal が更新される
- [x] `redi issue_journal delete <journal_id>` で確認後に削除される
- [x] `redi issue_journal delete <journal_id> -y` で確認なしに削除される
- [x] 存在しない journal_id を指定した場合に not found のメッセージが表示される
- [x] alias `ij u` / `ij d` でも同様に動作する