### PR TITLE
feat(time_entry): spent_on にバリデーション追加 (#181 )

### DIFF
--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -512,7 +512,14 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
             print(
                 messages.activity_label.format(value=activity_labels[args.activity_id])
             )
-            args.spent_on = prompt(messages.prompt_spent_on).strip() or None
+            args.spent_on = (
+                prompt(
+                    messages.prompt_spent_on,
+                    validator=DateValidator(allow_empty=True),
+                    key_bindings=date_key_bindings(),
+                ).strip()
+                or None
+            )
             args.time_comments = prompt(messages.prompt_time_comments).strip() or None
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -5,10 +5,14 @@ from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.validation import Validator
 
 from redi.cli.alias import resolve_alias
-from redi.cli.keybinding import digit_and_period_key_bindings, digit_only_key_bindings
+from redi.cli.keybinding import (
+    date_key_bindings,
+    digit_and_period_key_bindings,
+    digit_only_key_bindings,
+)
 from redi.cli.picker import inline_checkbox, inline_choice
 from redi.cli.confirm import confirm_delete
-from redi.cli.validator import HourValidator
+from redi.cli.validator import DateValidator, HourValidator
 from redi.config import default_project_id
 from redi.i18n import messages
 from redi.api.enumeration import fetch_time_entry_activities
@@ -179,7 +183,14 @@ def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
                 messages.activity_label.format(value=activity_labels[args.activity_id])
             )
         if not args.spent_on:
-            args.spent_on = prompt(messages.prompt_spent_on).strip() or None
+            args.spent_on = (
+                prompt(
+                    messages.prompt_spent_on,
+                    validator=DateValidator(allow_empty=True),
+                    key_bindings=date_key_bindings(),
+                ).strip()
+                or None
+            )
         if not args.comments:
             args.comments = prompt(messages.prompt_comment).strip() or None
     except (KeyboardInterrupt, EOFError):
@@ -235,6 +246,8 @@ def _interactive_fill_time_entry_update_args(args: argparse.Namespace) -> None:
                 prompt(
                     messages.prompt_update_spent_on,
                     default=current.get("spent_on", "") or "",
+                    validator=DateValidator(allow_empty=True),
+                    key_bindings=date_key_bindings(),
                 ).strip()
                 or None
             )


### PR DESCRIPTION
## Summary
- TUI 経由の作業時間登録（create/update）における `spent_on` 対話入力に `DateValidator(allow_empty=True)` と `date_key_bindings()` を適用
- issue update から派生する time entry 追加フローの `spent_on` にも同様に適用（同じ穴のため一括対応）

Closes #181

## Test plan
- [x] `redi te c` を実行し、`spent_on` プロンプトで数字・`-` 以外がブロックされる
- [x] `redi te c` で `2024-13-40` のような不正日付を入れたとき送信できずエラー表示される
- [x] `redi te c` で空文字 Enter なら今日として登録される
- [x] `redi te u <id>` で `spent_on` 更新を選んだ際にも同じバリデーションがきく
- [x] TUI の time_entries タブで `c` / `u` 経由で同様に検証
- [x] TUI の issues タブから issue update → time entry 追加で `spent_on` プロンプトを通したとき検証