### PR TITLE
feat(time_entry): list に --from/--to と --limit/--offset を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ redi issue_journal delete <journal_id> # confirm before delete (-y to skip)
 
 # time_entry (alias: te)
 redi time_entry -p <project_id> -u me
+redi time_entry --from 2026-01-01 --to 2026-01-31 # filter by date range
+redi time_entry --limit 50 --offset 100 # pagination
 redi time_entry create 1.5 -i <issue_id> -a <activity_id> -c "comment"
 redi time_entry update <time_entry_id> --hours 2.0
 redi time_entry delete <time_entry_id> # confirm before delete (-y to skip)

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -106,15 +106,27 @@ def fetch_issue_subjects(issue_ids: list[int]) -> dict[int, str]:
 def list_time_entries(
     project_id: str | None = None,
     user_id: str | None = None,
+    from_date: str | None = None,
+    to_date: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
     full: bool = False,
 ) -> None:
     if project_id:
         path = f"/projects/{project_id}/time_entries.json"
     else:
         path = "/time_entries.json"
-    params = {}
+    params: dict = {}
     if user_id:
         params["user_id"] = user_id
+    if from_date:
+        params["from"] = from_date
+    if to_date:
+        params["to"] = to_date
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
     response = client.get(path, params=params)
     response.raise_for_status()
     time_entries = response.json()["time_entries"]

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -44,6 +44,22 @@ def add_time_entry_parser(
         "--user_id", "-u", help=messages.arg_help_time_entry_user_id
     )
     time_entry_parser.add_argument(
+        "--from",
+        dest="from_date",
+        help=messages.arg_help_time_entry_from,
+    )
+    time_entry_parser.add_argument(
+        "--to",
+        dest="to_date",
+        help=messages.arg_help_time_entry_to,
+    )
+    time_entry_parser.add_argument(
+        "--limit", "-l", type=int, help=messages.arg_help_limit
+    )
+    time_entry_parser.add_argument(
+        "--offset", "-o", type=int, help=messages.arg_help_offset
+    )
+    time_entry_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
     te_subparsers = time_entry_parser.add_subparsers(dest="time_entry_command")
@@ -325,4 +341,12 @@ def handle_time_entry(args: argparse.Namespace) -> None:
         delete_time_entry(args.time_entry_id)
     elif cmd == "list" or cmd is None:
         project_id = args.project_id or default_project_id
-        list_time_entries(project_id=project_id, user_id=args.user_id, full=args.full)
+        list_time_entries(
+            project_id=project_id,
+            user_id=args.user_id,
+            from_date=args.from_date,
+            to_date=args.to_date,
+            limit=args.limit,
+            offset=args.offset,
+            full=args.full,
+        )

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -828,6 +828,8 @@ class MessagesProto(Protocol):
     # ---- argparse helps (time entry) ----
     arg_help_time_entry_command: str
     arg_help_time_entry_user_id: str
+    arg_help_time_entry_from: str
+    arg_help_time_entry_to: str
     arg_help_time_entry_list: str
     arg_help_time_entry_create: str
     arg_help_time_entry_hours: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -700,6 +700,8 @@ class En(MessagesProto):
         "list(l), view(v), create(c) (log), update(u), delete(d)"
     )
     arg_help_time_entry_user_id = "Filter by user ID ('me' allowed)"
+    arg_help_time_entry_from = "Filter by start date (YYYY-MM-DD, inclusive)"
+    arg_help_time_entry_to = "Filter by end date (YYYY-MM-DD, inclusive)"
     arg_help_time_entry_list = "List time entries"
     arg_help_time_entry_create = "Log time entry"
     arg_help_time_entry_hours = "Hours (e.g. 1.5; omit to enter interactively)"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -707,6 +707,8 @@ class Ja(MessagesProto):
     # ---- argparse helps (time entry) ----
     arg_help_time_entry_command = "list(l): 一覧, view(v): 詳細, create(c): 登録, update(u): 更新, delete(d): 削除"
     arg_help_time_entry_user_id = "ユーザーIDでフィルタリング（'me'も可）"
+    arg_help_time_entry_from = "開始日でフィルタリング（YYYY-MM-DD、以降）"
+    arg_help_time_entry_to = "終了日でフィルタリング（YYYY-MM-DD、以前）"
     arg_help_time_entry_list = "作業時間一覧"
     arg_help_time_entry_create = "作業時間登録"
     arg_help_time_entry_hours = "時間（例: 1.5、省略で対話的に入力）"


### PR DESCRIPTION
resolve #183 

## Summary
- `redi time_entry` (list) に `--from` / `--to` を追加し、`GET /time_entries.json` の `from` / `to` パラメータで日付範囲フィルタリングできるようにした
- `--limit` / `--offset` を追加し、CLI から取得件数とオフセットを指定可能にした
- README / i18n (ja/en) / Protocol を更新

## Test plan
- [x] `task check` (format/lint/typecheck/test) が通ること
- [x] `redi time_entry --from 2026-01-01 --to 2026-01-31` で期間内のエントリのみ表示されること
- [x] `redi time_entry --limit 5 --offset 0` でページングが効くこと
- [x] `-p <project_id>` 併用時 (`/projects/<id>/time_entries.json`) でも各オプションが機能すること