### PR TITLE
feat(tui): time_entry タブにページング機能を追加

### DIFF
--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -92,6 +92,25 @@ def format_time_entry_line(
     return "  ".join(parts)
 
 
+def fetch_time_entries_page(
+    project_id: str | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+) -> dict:
+    if project_id:
+        path = f"/projects/{project_id}/time_entries.json"
+    else:
+        path = "/time_entries.json"
+    params: dict = {}
+    if limit is not None:
+        params["limit"] = limit
+    if offset is not None:
+        params["offset"] = offset
+    response = client.get(path, params=params)
+    response.raise_for_status()
+    return response.json()
+
+
 def fetch_issue_subjects(issue_ids: list[int]) -> dict[int, str]:
     if not issue_ids:
         return {}

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -545,6 +545,7 @@ class MessagesProto(Protocol):
     """{page_label}"""
     tui_status_hint_wiki: str
     tui_status_hint_time_entries: str
+    """{page_label}"""
     tui_flash_reloaded: str
     tui_filter_status_open_default: str
     tui_filter_status_all: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -399,7 +399,7 @@ class En(MessagesProto):
     tui_status_hint_issues = " {page_label}  jk:move /:search f:filter c:create u:update v:web ?:help q:quit "
     tui_status_hint_wiki = " jk:move /:search c:create u:update v:web ?:help q:quit "
     tui_status_hint_time_entries = (
-        " jk:move /:search c:create u:update v:web ?:help q:quit "
+        " {page_label}  jk:move /:search c:create u:update v:web ?:help q:quit "
     )
     tui_flash_reloaded = "Reloaded"
     tui_filter_status_open_default = "open (default)"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -400,7 +400,7 @@ class Ja(MessagesProto):
     )
     tui_status_hint_wiki = " jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
     tui_status_hint_time_entries = (
-        " jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
+        " {page_label}  jk:移動 /:検索 c:作成 u:更新 v:web ?:ヘルプ q:終了 "
     )
     tui_flash_reloaded = "再読込しました"
     tui_filter_status_open_default = "open (デフォルト)"

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -292,6 +292,8 @@ def run_issue_tui(
             if last.wiki_title in titles:
                 state.wiki_tab.cursor = titles.index(last.wiki_title)
     if state.tab == "time_entries":
+        if last and last.tab == "time_entries":
+            state.time_entry_tab.offset = last.position.offset
         TABS["time_entries"].on_activate(state)
         if last and last.tab == "time_entries":
             max_cursor = max(0, len(state.time_entry_tab.entries) - 1)

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -99,7 +99,9 @@ class WikiTabState:
 @dataclass
 class TimeEntryTabState:
     loaded: bool = False
+    offset: int = 0
     entries: list[dict] = field(default_factory=list)
+    total_count: int = 0
     issue_subjects: dict[int, str] = field(default_factory=dict)
     cursor: int = 0
     error: str | None = None

--- a/src/redi/tui/time_entry_tab.py
+++ b/src/redi/tui/time_entry_tab.py
@@ -2,7 +2,11 @@ import webbrowser
 
 import requests
 
-from redi.api.time_entry import fetch_issue_subjects, format_time_entry_line
+from redi.api.time_entry import (
+    fetch_issue_subjects,
+    fetch_time_entries_page,
+    format_time_entry_line,
+)
 from redi.client import client
 from redi.config import default_project_id, redmine_url
 from redi.i18n import messages
@@ -11,25 +15,14 @@ from redi.tui.state import Renderable, TuiPosition, TuiResult, TuiState
 from redi.tui.tab import TabView, noop, noop_jump
 
 
-def _fetch_time_entries(project_id: str | None) -> list[dict]:
-    if project_id:
-        path = f"/projects/{project_id}/time_entries.json"
-    else:
-        path = "/time_entries.json"
-    response = client.get(path)
-    response.raise_for_status()
-    return response.json()["time_entries"]
-
-
-def _load_time_entries(state: TuiState) -> None:
-    if state.time_entry_tab.loaded:
-        return
-    state.time_entry_tab.loaded = True
-    try:
-        entries = _fetch_time_entries(default_project_id)
-    except requests.exceptions.RequestException as e:
-        state.time_entry_tab.error = messages.tui_time_entry_load_failed.format(error=e)
-        return
+def _fetch_page_with_subjects(state: TuiState, offset: int) -> dict:
+    """`offset` から始まる 1 ページ分の time_entries と issue subjects をまとめて返す。"""
+    page = fetch_time_entries_page(
+        project_id=default_project_id,
+        limit=state.page_size,
+        offset=offset,
+    )
+    entries = page["time_entries"]
     issue_ids = sorted(
         {
             te["issue"]["id"]
@@ -41,9 +34,31 @@ def _load_time_entries(state: TuiState) -> None:
         subjects = fetch_issue_subjects(issue_ids)
     except requests.exceptions.RequestException:
         subjects = {}
-    state.time_entry_tab.entries = entries
-    state.time_entry_tab.issue_subjects = subjects
+    return {
+        "time_entries": entries,
+        "total_count": page.get("total_count", len(entries)),
+        "issue_subjects": subjects,
+    }
+
+
+def _apply_page(state: TuiState, page: dict, offset: int) -> None:
+    state.time_entry_tab.offset = offset
+    state.time_entry_tab.entries = page["time_entries"]
+    state.time_entry_tab.total_count = page["total_count"]
+    state.time_entry_tab.issue_subjects = page["issue_subjects"]
     state.time_entry_tab.cursor = 0
+
+
+def _load_time_entries(state: TuiState) -> None:
+    if state.time_entry_tab.loaded:
+        return
+    state.time_entry_tab.loaded = True
+    try:
+        page = _fetch_page_with_subjects(state, state.time_entry_tab.offset)
+    except requests.exceptions.RequestException as e:
+        state.time_entry_tab.error = messages.tui_time_entry_load_failed.format(error=e)
+        return
+    _apply_page(state, page, state.time_entry_tab.offset)
 
 
 def _render_list(state: TuiState) -> Renderable:
@@ -106,8 +121,21 @@ def _render_preview(state: TuiState) -> Renderable:
     return [("", "\n".join(lines))]
 
 
+def _page_label(state: TuiState) -> str:
+    total = state.time_entry_tab.total_count
+    page_size = state.page_size or 1
+    current = state.time_entry_tab.offset // page_size + 1
+    total_pages = max(1, (total + page_size - 1) // page_size)
+    count = len(state.time_entry_tab.entries)
+    if count == 0:
+        return f"Page {current}/{total_pages} (0 / {total})"
+    start = state.time_entry_tab.offset + 1
+    end = state.time_entry_tab.offset + count
+    return f"Page {current}/{total_pages} ({start}-{end} / {total})"
+
+
 def _status_hint(state: TuiState) -> str:
-    return messages.tui_status_hint_time_entries
+    return messages.tui_status_hint_time_entries.format(page_label=_page_label(state))
 
 
 def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
@@ -123,7 +151,10 @@ def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
             action="create",
             tab="time_entries",
             issue_id=issue_id,
-            position=TuiPosition(cursor=state.time_entry_tab.cursor),
+            position=TuiPosition(
+                offset=state.time_entry_tab.offset,
+                cursor=state.time_entry_tab.cursor,
+            ),
         )
     if key == "u":
         entries = state.time_entry_tab.entries
@@ -134,7 +165,10 @@ def _on_action_key(state: TuiState, key: str) -> TuiResult | None:
             action="update",
             tab="time_entries",
             time_entry_id=str(te["id"]),
-            position=TuiPosition(cursor=state.time_entry_tab.cursor),
+            position=TuiPosition(
+                offset=state.time_entry_tab.offset,
+                cursor=state.time_entry_tab.cursor,
+            ),
         )
     return None
 
@@ -208,30 +242,64 @@ def confirm_delete(state: TuiState) -> None:
         state.flash_message = messages.tui_time_entry_delete_failed.format(error=e)
         return
     entries.pop(cursor)
+    state.time_entry_tab.total_count = max(0, state.time_entry_tab.total_count - 1)
     if cursor >= len(entries):
         state.time_entry_tab.cursor = max(0, len(entries) - 1)
 
 
 def _on_reload(state: TuiState) -> None:
-    """time_entry 一覧を取り直す。
+    """現在のページのまま time_entry 一覧を取り直す。
 
-    `loaded` を立てたままだと `_load_time_entries` が早期 return するので
-    一度倒す。既存のカーソル位置は entry id 一致で復元を試み、無ければ先頭に戻る。
+    同じ id の entry が残っていればその位置に cursor を復元し、無ければ
+    元の cursor 位置を新一覧の範囲内にクランプする。
     """
     prev_id: int | None = None
     if state.time_entry_tab.entries:
         prev_id = state.time_entry_tab.entries[state.time_entry_tab.cursor].get("id")
-    state.time_entry_tab.loaded = False
+    prev_cursor = state.time_entry_tab.cursor
     state.time_entry_tab.error = None
-    state.time_entry_tab.entries = []
-    state.time_entry_tab.issue_subjects = {}
-    state.time_entry_tab.cursor = 0
-    _load_time_entries(state)
+    try:
+        page = _fetch_page_with_subjects(state, state.time_entry_tab.offset)
+    except requests.exceptions.RequestException as e:
+        state.time_entry_tab.error = messages.tui_time_entry_load_failed.format(error=e)
+        return
+    state.time_entry_tab.entries = page["time_entries"]
+    state.time_entry_tab.total_count = page["total_count"]
+    state.time_entry_tab.issue_subjects = page["issue_subjects"]
+    if not state.time_entry_tab.entries:
+        state.time_entry_tab.cursor = 0
+        return
     if prev_id is not None:
         for i, te in enumerate(state.time_entry_tab.entries):
             if te.get("id") == prev_id:
                 state.time_entry_tab.cursor = i
                 return
+    state.time_entry_tab.cursor = max(
+        0, min(prev_cursor, len(state.time_entry_tab.entries) - 1)
+    )
+
+
+def _on_page_forward(state: TuiState) -> None:
+    next_offset = state.time_entry_tab.offset + state.page_size
+    try:
+        page = _fetch_page_with_subjects(state, next_offset)
+    except requests.exceptions.RequestException as e:
+        state.time_entry_tab.error = messages.tui_time_entry_load_failed.format(error=e)
+        return
+    if page["time_entries"]:
+        _apply_page(state, page, next_offset)
+
+
+def _on_page_backward(state: TuiState) -> None:
+    if state.time_entry_tab.offset <= 0:
+        return
+    prev_offset = max(0, state.time_entry_tab.offset - state.page_size)
+    try:
+        page = _fetch_page_with_subjects(state, prev_offset)
+    except requests.exceptions.RequestException as e:
+        state.time_entry_tab.error = messages.tui_time_entry_load_failed.format(error=e)
+        return
+    _apply_page(state, page, prev_offset)
 
 
 def _on_open_web(state: TuiState) -> None:
@@ -251,6 +319,7 @@ _HELP_LINES: list[tuple[str, str]] = [
     ("  ↑/k/Ctrl+P", messages.tui_help_move_up),
     ("  ↓/j/Ctrl+N", messages.tui_help_move_down),
     ("  gg / G", messages.tui_help_goto_top_bottom),
+    ("  ←/h / →/l", messages.tui_help_prev_next_page),
     ("  Tab / Shift+Tab", messages.tui_help_switch_tab),
     ("  Ctrl+E / Ctrl+Y", messages.tui_help_preview_scroll_line),
     ("  Ctrl+D / Ctrl+U", messages.tui_help_preview_scroll_half_page),
@@ -280,8 +349,8 @@ TIME_ENTRY_TAB = TabView(
     on_goto_bottom=_on_goto_bottom,
     on_jump_to_id=noop_jump,
     on_enter=noop,
-    on_page_forward=noop,
-    on_page_backward=noop,
+    on_page_forward=_on_page_forward,
+    on_page_backward=_on_page_backward,
     on_open_web=_on_open_web,
     on_open_web_by_id=noop_jump,
     on_activate=_load_time_entries,

--- a/tests/unit/tui/test_tab_reload.py
+++ b/tests/unit/tui/test_tab_reload.py
@@ -129,49 +129,81 @@ class TestWikiReload:
 
 
 class TestTimeEntryReload:
-    """time_entry タブの _on_reload() は loaded を倒して取り直す"""
+    """time_entry タブの _on_reload() は現在のページを再取得する"""
 
-    def test_restores_cursor_by_id(self, monkeypatch):
-        """同じ id の entry が残っていれば cursor をその位置に復元する"""
+    def test_preserves_offset_and_restores_cursor_by_id(self, monkeypatch):
+        """offset を保ったまま再取得し、同じ id が残っていれば cursor をその位置に復元する"""
         state = TuiState()
+        state.page_size = 5
         state.time_entry_tab.loaded = True
+        state.time_entry_tab.offset = 10
         state.time_entry_tab.entries = [
             {"id": 100},
             {"id": 200},
             {"id": 300},
         ]
+        state.time_entry_tab.total_count = 30
         state.time_entry_tab.cursor = 1  # id=200 にいる
 
-        def fake_load(state):
-            assert state.time_entry_tab.loaded is False
-            state.time_entry_tab.loaded = True
+        def fake_fetch(state, offset):
+            assert offset == 10
             # 200 は残っているが順序が変わる
-            state.time_entry_tab.entries = [
-                {"id": 400},
-                {"id": 200},
-            ]
-            state.time_entry_tab.cursor = 0
+            return {
+                "time_entries": [{"id": 400}, {"id": 200}],
+                "total_count": 30,
+                "issue_subjects": {},
+            }
 
-        monkeypatch.setattr(time_entry_tab, "_load_time_entries", fake_load)
+        monkeypatch.setattr(time_entry_tab, "_fetch_page_with_subjects", fake_fetch)
 
         time_entry_tab._on_reload(state)
 
+        assert state.time_entry_tab.offset == 10
         assert state.time_entry_tab.cursor == 1
+        assert state.time_entry_tab.total_count == 30
 
-    def test_falls_back_to_top_when_id_missing(self, monkeypatch):
-        """前回の id が新一覧に無ければ cursor=0 のまま"""
+    def test_clamps_cursor_when_new_page_is_shorter(self, monkeypatch):
+        """id 一致が無く件数が減ったら cursor は末尾にクランプされる"""
         state = TuiState()
-        state.time_entry_tab.loaded = True
-        state.time_entry_tab.entries = [{"id": 999}]
-        state.time_entry_tab.cursor = 0
+        state.page_size = 5
+        state.time_entry_tab.offset = 0
+        state.time_entry_tab.entries = [{"id": i} for i in range(1, 6)]
+        state.time_entry_tab.total_count = 5
+        state.time_entry_tab.cursor = 4
 
-        def fake_load(state):
-            state.time_entry_tab.loaded = True
-            state.time_entry_tab.entries = [{"id": 111}, {"id": 222}]
-            state.time_entry_tab.cursor = 0
-
-        monkeypatch.setattr(time_entry_tab, "_load_time_entries", fake_load)
+        monkeypatch.setattr(
+            time_entry_tab,
+            "_fetch_page_with_subjects",
+            lambda state, offset: {
+                "time_entries": [{"id": 999}],
+                "total_count": 1,
+                "issue_subjects": {},
+            },
+        )
 
         time_entry_tab._on_reload(state)
 
         assert state.time_entry_tab.cursor == 0
+        assert state.time_entry_tab.total_count == 1
+
+    def test_empty_result_resets_cursor(self, monkeypatch):
+        """再取得結果が空でも例外を投げず cursor=0 になる"""
+        state = TuiState()
+        state.page_size = 5
+        state.time_entry_tab.entries = [{"id": 999}]
+        state.time_entry_tab.cursor = 0
+        monkeypatch.setattr(
+            time_entry_tab,
+            "_fetch_page_with_subjects",
+            lambda state, offset: {
+                "time_entries": [],
+                "total_count": 0,
+                "issue_subjects": {},
+            },
+        )
+
+        time_entry_tab._on_reload(state)
+
+        assert state.time_entry_tab.cursor == 0
+        assert state.time_entry_tab.entries == []
+        assert state.time_entry_tab.total_count == 0

--- a/tests/unit/tui/test_time_entry_tab.py
+++ b/tests/unit/tui/test_time_entry_tab.py
@@ -1,0 +1,167 @@
+from redi.tui import time_entry_tab
+from redi.tui.state import TuiState
+
+
+def _make_state(
+    *, offset: int, page_size: int, total_count: int, entries_on_page: int
+) -> TuiState:
+    state = TuiState()
+    state.page_size = page_size
+    state.time_entry_tab.offset = offset
+    state.time_entry_tab.total_count = total_count
+    state.time_entry_tab.entries = [{"id": i} for i in range(entries_on_page)]
+    return state
+
+
+class TestPageLabel:
+    """_page_label() はステータスラインに出すページ表示文字列を返す"""
+
+    def test_first_page_full(self):
+        """page_size 25, total 87 で先頭ページなら 1/4 (1-25 / 87)"""
+        state = _make_state(offset=0, page_size=25, total_count=87, entries_on_page=25)
+        assert time_entry_tab._page_label(state) == "Page 1/4 (1-25 / 87)"
+
+    def test_middle_page(self):
+        """offset=25 (2ページ目) なら 2/4 (26-50 / 87)"""
+        state = _make_state(offset=25, page_size=25, total_count=87, entries_on_page=25)
+        assert time_entry_tab._page_label(state) == "Page 2/4 (26-50 / 87)"
+
+    def test_last_partial_page(self):
+        """最終ページが部分埋まり (12件) なら end は total に揃う"""
+        state = _make_state(offset=75, page_size=25, total_count=87, entries_on_page=12)
+        assert time_entry_tab._page_label(state) == "Page 4/4 (76-87 / 87)"
+
+    def test_single_page_when_total_fits(self):
+        """total <= page_size なら 1/1"""
+        state = _make_state(offset=0, page_size=25, total_count=10, entries_on_page=10)
+        assert time_entry_tab._page_label(state) == "Page 1/1 (1-10 / 10)"
+
+    def test_empty_state_does_not_crash(self):
+        """entries が空でも例外を投げない"""
+        state = _make_state(offset=0, page_size=25, total_count=0, entries_on_page=0)
+        assert time_entry_tab._page_label(state) == "Page 1/1 (0 / 0)"
+
+
+class TestPageForward:
+    """_on_page_forward() は次ページを取得して offset/cursor をリセットする"""
+
+    def test_advances_offset_when_next_page_has_entries(self, monkeypatch):
+        state = TuiState()
+        state.page_size = 5
+        state.time_entry_tab.offset = 0
+        state.time_entry_tab.entries = [{"id": i} for i in range(1, 6)]
+        state.time_entry_tab.total_count = 12
+        state.time_entry_tab.cursor = 3
+
+        def fake_fetch(state, offset):
+            assert offset == 5
+            return {
+                "time_entries": [{"id": i} for i in range(6, 11)],
+                "total_count": 12,
+                "issue_subjects": {},
+            }
+
+        monkeypatch.setattr(time_entry_tab, "_fetch_page_with_subjects", fake_fetch)
+
+        time_entry_tab._on_page_forward(state)
+
+        assert state.time_entry_tab.offset == 5
+        assert state.time_entry_tab.cursor == 0
+        assert len(state.time_entry_tab.entries) == 5
+
+    def test_does_not_advance_when_next_page_is_empty(self, monkeypatch):
+        """次ページが空ならカーソル/オフセットを動かさない (現ページ維持)"""
+        state = TuiState()
+        state.page_size = 5
+        state.time_entry_tab.offset = 5
+        state.time_entry_tab.entries = [{"id": i} for i in range(6, 11)]
+        state.time_entry_tab.total_count = 10
+        state.time_entry_tab.cursor = 2
+
+        monkeypatch.setattr(
+            time_entry_tab,
+            "_fetch_page_with_subjects",
+            lambda state, offset: {
+                "time_entries": [],
+                "total_count": 10,
+                "issue_subjects": {},
+            },
+        )
+
+        time_entry_tab._on_page_forward(state)
+
+        assert state.time_entry_tab.offset == 5
+        assert state.time_entry_tab.cursor == 2
+        assert len(state.time_entry_tab.entries) == 5
+
+
+class TestPageBackward:
+    """_on_page_backward() は前ページを取得する。先頭ページなら何もしない"""
+
+    def test_moves_back_one_page(self, monkeypatch):
+        state = TuiState()
+        state.page_size = 5
+        state.time_entry_tab.offset = 10
+        state.time_entry_tab.entries = [{"id": i} for i in range(11, 16)]
+        state.time_entry_tab.total_count = 20
+        state.time_entry_tab.cursor = 4
+
+        def fake_fetch(state, offset):
+            assert offset == 5
+            return {
+                "time_entries": [{"id": i} for i in range(6, 11)],
+                "total_count": 20,
+                "issue_subjects": {},
+            }
+
+        monkeypatch.setattr(time_entry_tab, "_fetch_page_with_subjects", fake_fetch)
+
+        time_entry_tab._on_page_backward(state)
+
+        assert state.time_entry_tab.offset == 5
+        assert state.time_entry_tab.cursor == 0
+
+    def test_does_nothing_on_first_page(self, monkeypatch):
+        """offset=0 のときは fetch すら呼ばない"""
+        state = TuiState()
+        state.page_size = 5
+        state.time_entry_tab.offset = 0
+        state.time_entry_tab.entries = [{"id": 1}]
+        state.time_entry_tab.cursor = 0
+
+        called = False
+
+        def fake_fetch(state, offset):
+            nonlocal called
+            called = True
+            return {"time_entries": [], "total_count": 0, "issue_subjects": {}}
+
+        monkeypatch.setattr(time_entry_tab, "_fetch_page_with_subjects", fake_fetch)
+
+        time_entry_tab._on_page_backward(state)
+
+        assert not called
+        assert state.time_entry_tab.offset == 0
+
+
+class TestConfirmDeleteUpdatesTotal:
+    """削除時は total_count を 1 減らしてページ表示の整合性を保つ"""
+
+    def test_decrements_total_count(self, monkeypatch):
+        state = TuiState()
+        state.time_entry_tab.entries = [{"id": 1}, {"id": 2}]
+        state.time_entry_tab.total_count = 5
+        state.time_entry_tab.cursor = 0
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+        monkeypatch.setattr(
+            time_entry_tab.client, "delete", lambda path: FakeResponse()
+        )
+
+        time_entry_tab.confirm_delete(state)
+
+        assert state.time_entry_tab.total_count == 4
+        assert len(state.time_entry_tab.entries) == 1


### PR DESCRIPTION
resolve #185 

## Summary
- time_entry タブで `h`/`l` (`←`/`→`) による前後ページ移動を追加 (issue タブと同様)
- ステータスバーに `Page N/M (start-end / total)` を表示
- リロード (`R`) は現在のページを維持して再取得し、可能なら同じ id にカーソルを復元
- 削除時に `total_count` を 1 減らしてページ表示の整合性を保つ
- TuiResult.position に offset を含めるようにし、再入場時にもページ位置を保つ

## Test plan
- [x] `task check` がパスする
- [x] time_entry タブで `l`/`→` を押すと次ページに進む
- [x] time_entry タブで `h`/`←` を押すと前ページに戻り、先頭ページでは何も起きない
- [x] ステータスバーに `Page N/M ...` が表示される
- [x] `R` でリロードしてもカーソル位置が維持される
- [x] エントリ削除後にページ表示の total が減る