### PR TITLE
feat(tui): フィルタモーダルに ctrl+n / ctrl+p を追加

### DIFF
--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -604,6 +604,7 @@ def run_issue_tui(
 
     @kb.add("j", filter=show_filter_modal)
     @kb.add("down", filter=show_filter_modal)
+    @kb.add("c-n", filter=show_filter_modal)
     def _(event):
         modal = state.issue_tab.filter_modal
         if modal.focus == "status":
@@ -617,6 +618,7 @@ def run_issue_tui(
 
     @kb.add("k", filter=show_filter_modal)
     @kb.add("up", filter=show_filter_modal)
+    @kb.add("c-p", filter=show_filter_modal)
     def _(event):
         modal = state.issue_tab.filter_modal
         if modal.focus == "status":
@@ -659,12 +661,14 @@ def run_issue_tui(
 
     @kb.add("j", filter=show_time_entry_filter_modal)
     @kb.add("down", filter=show_time_entry_filter_modal)
+    @kb.add("c-n", filter=show_time_entry_filter_modal)
     def _(event):
         modal = state.time_entry_tab.filter_modal
         modal.user_cursor = min(len(modal.user_choices) - 1, modal.user_cursor + 1)
 
     @kb.add("k", filter=show_time_entry_filter_modal)
     @kb.add("up", filter=show_time_entry_filter_modal)
+    @kb.add("c-p", filter=show_time_entry_filter_modal)
     def _(event):
         modal = state.time_entry_tab.filter_modal
         modal.user_cursor = max(0, modal.user_cursor - 1)

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -605,7 +605,7 @@ def run_issue_tui(
     @kb.add("j", filter=show_filter_modal)
     @kb.add("down", filter=show_filter_modal)
     @kb.add("c-n", filter=show_filter_modal)
-    def _(event):
+    def _issue_filter_modal_cursor_down(event):
         modal = state.issue_tab.filter_modal
         if modal.focus == "status":
             modal.status_cursor = min(
@@ -619,7 +619,7 @@ def run_issue_tui(
     @kb.add("k", filter=show_filter_modal)
     @kb.add("up", filter=show_filter_modal)
     @kb.add("c-p", filter=show_filter_modal)
-    def _(event):
+    def _issue_filter_modal_cursor_up(event):
         modal = state.issue_tab.filter_modal
         if modal.focus == "status":
             modal.status_cursor = max(0, modal.status_cursor - 1)
@@ -662,14 +662,14 @@ def run_issue_tui(
     @kb.add("j", filter=show_time_entry_filter_modal)
     @kb.add("down", filter=show_time_entry_filter_modal)
     @kb.add("c-n", filter=show_time_entry_filter_modal)
-    def _(event):
+    def _time_entry_filter_modal_cursor_down(event):
         modal = state.time_entry_tab.filter_modal
         modal.user_cursor = min(len(modal.user_choices) - 1, modal.user_cursor + 1)
 
     @kb.add("k", filter=show_time_entry_filter_modal)
     @kb.add("up", filter=show_time_entry_filter_modal)
     @kb.add("c-p", filter=show_time_entry_filter_modal)
-    def _(event):
+    def _time_entry_filter_modal_cursor_up(event):
         modal = state.time_entry_tab.filter_modal
         modal.user_cursor = max(0, modal.user_cursor - 1)
 


### PR DESCRIPTION
resolve #190 

## Summary
- issue タブと time_entry タブのフィルタモーダルで j/k・矢印キーに加えて ctrl+n / ctrl+p でもカーソル移動できるようにした
- normal_mode や `cli/picker.py` 等の他の上下移動箇所は既に 3 種類すべて揃っており、フィルタモーダルのみ揃っていなかったため整合させた

## Test plan
- [ ] `task check` がパスすること
- [ ] TUI 起動後、issue タブで `f` を押してフィルタモーダルを開き、ctrl+n / ctrl+p で status / assignee の選択肢を上下移動できること
- [ ] time_entry タブで `f` を押してフィルタモーダルを開き、ctrl+n / ctrl+p でユーザー選択肢を上下移動できること