### PR TITLE
feat(tui): フィルタモーダルで自分と実ユーザーの重複表示を解消

### DIFF
--- a/src/redi/api/me.py
+++ b/src/redi/api/me.py
@@ -6,6 +6,16 @@ from redi.client import client
 from redi.i18n import messages
 
 
+def fetch_my_user_id() -> str | None:
+    """`/my/account.json` から自分のユーザー id を取得する。失敗時は None。"""
+    try:
+        response = client.get("/my/account.json")
+        response.raise_for_status()
+        return str(response.json()["user"]["id"])
+    except requests.RequestException:
+        return None
+
+
 def read_my_account(full: bool = False) -> None:
     response = client.get("/my/account.json")
     response.raise_for_status()

--- a/src/redi/api/membership.py
+++ b/src/redi/api/membership.py
@@ -1,9 +1,44 @@
 import json
+from typing import NotRequired, TypedDict, cast
 
 import requests
 
 from redi.client import client
 from redi.i18n import messages
+
+
+class ProjectUser(TypedDict):
+    """`memberships[].user` の要素。"""
+
+    id: int
+    name: str
+
+
+class Role(TypedDict):
+    """`memberships[].roles` の要素。"""
+
+    id: int
+    name: str
+
+
+class Membership(TypedDict):
+    """`memberships[]` の要素。
+
+    `user` と `roles` は本ライブラリで扱うユーザーメンバーシップでは常に存在する前提。
+    """
+
+    id: int
+    user: ProjectUser
+    roles: list[Role]
+
+
+class MembershipsResponse(TypedDict):
+    """GET /projects/{id}/memberships.json のレスポンス。"""
+
+    memberships: list[Membership]
+    total_count: NotRequired[int]
+    offset: NotRequired[int]
+    limit: NotRequired[int]
 
 
 def list_memberships(project_id: str, full: bool = False) -> None:
@@ -17,12 +52,12 @@ def list_memberships(project_id: str, full: bool = False) -> None:
         print(_format_membership_line(m))
 
 
-def fetch_project_users(project_id: str) -> list[dict]:
+def fetch_project_users(project_id: str) -> list[ProjectUser]:
     """プロジェクトのメンバー（user）を返す。"""
     response = client.get(f"/projects/{project_id}/memberships.json")
     response.raise_for_status()
-    memberships = response.json()["memberships"]
-    return [m["user"] for m in memberships if m.get("user")]
+    data = cast(MembershipsResponse, response.json())
+    return [m["user"] for m in data["memberships"] if "user" in m]
 
 
 def fetch_membership(membership_id: str) -> dict:

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -19,6 +19,7 @@ from prompt_toolkit.layout.controls import FormattedTextControl
 from prompt_toolkit.widgets import Frame
 
 from redi.api.issue_status import fetch_issue_statuses
+from redi.api.me import fetch_my_user_id
 from redi.api.membership import fetch_project_users
 from redi.config import default_project_id
 from redi.i18n import messages
@@ -173,15 +174,24 @@ def _build_assignee_choices(project_id: str | None) -> list[tuple[str | None, st
     return choices
 
 
-def _build_user_choices(project_id: str | None) -> list[tuple[str | None, str]]:
-    """time_entry フィルタモーダルのユーザー選択肢。先頭は特殊指定 (未設定/自分)。"""
+def _build_user_choices(
+    project_id: str | None, me_id: str | None = None
+) -> list[tuple[str | None, str]]:
+    """time_entry フィルタモーダルのユーザー選択肢。先頭は特殊指定 (未設定/自分)。
+
+    `me_id` が指定されていれば、`fetch_project_users` の結果から自身を除外して
+    「自分」項目との重複表示を避ける。
+    """
     choices: list[tuple[str | None, str]] = [
         (None, messages.tui_filter_assignee_none),
         ("me", messages.tui_filter_assignee_me),
     ]
     if project_id:
         for u in fetch_project_users(project_id):
-            choices.append((str(u["id"]), u.get("name", "")))
+            uid = str(u["id"])
+            if me_id is not None and uid == me_id:
+                continue
+            choices.append((uid, u.get("name", "")))
     return choices
 
 
@@ -291,6 +301,8 @@ def run_issue_tui(
 ) -> TuiResult | None:
     if state is None:
         state = TuiState()
+    if state.me_id is None:
+        state.me_id = fetch_my_user_id()
     last = state.last_result
     if last:
         state.tab = last.tab
@@ -576,7 +588,7 @@ def run_issue_tui(
 
     def _open_time_entry_filter_modal() -> None:
         modal = state.time_entry_tab.filter_modal
-        modal.user_choices = _build_user_choices(default_project_id)
+        modal.user_choices = _build_user_choices(default_project_id, state.me_id)
         modal.user_cursor = 0
         for idx, (api_val, _label) in enumerate(modal.user_choices):
             if api_val == state.time_entry_tab.filter.user_id:

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -161,8 +161,14 @@ def _build_status_choices() -> list[tuple[str | None, str]]:
     return choices
 
 
-def _build_assignee_choices(project_id: str | None) -> list[tuple[str | None, str]]:
-    """フィルタモーダルの担当者選択肢。先頭は特殊指定 (未設定/me/未割当)。"""
+def _build_assignee_choices(
+    project_id: str | None, me_id: str | None = None
+) -> list[tuple[str | None, str]]:
+    """フィルタモーダルの担当者選択肢。先頭は特殊指定 (未設定/me/未割当)。
+
+    `me_id` が指定されていれば、`fetch_project_users` の結果から自身を除外して
+    「自分」項目との重複表示を避ける。
+    """
     choices: list[tuple[str | None, str]] = [
         (None, messages.tui_filter_assignee_none),
         ("me", messages.tui_filter_assignee_me),
@@ -170,7 +176,10 @@ def _build_assignee_choices(project_id: str | None) -> list[tuple[str | None, st
     ]
     if project_id:
         for u in fetch_project_users(project_id):
-            choices.append((str(u["id"]), u.get("name", "")))
+            uid = str(u["id"])
+            if me_id is not None and uid == me_id:
+                continue
+            choices.append((uid, u.get("name", "")))
     return choices
 
 
@@ -572,7 +581,9 @@ def run_issue_tui(
     def _open_filter_modal() -> None:
         modal = state.issue_tab.filter_modal
         modal.status_choices = _build_status_choices()
-        modal.assignee_choices = _build_assignee_choices(default_project_id)
+        modal.assignee_choices = _build_assignee_choices(
+            default_project_id, state.me_id
+        )
         modal.status_cursor = 0
         for idx, (api_val, _label) in enumerate(modal.status_choices):
             if api_val == state.issue_tab.filter.status_id:

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -164,3 +164,6 @@ class TuiState:
     preview_scroll: int = 0
     # API エラー等を Float で出すための本文
     error_modal: str | None = None
+    # 起動時に `/my/account.json` から取得した自分のユーザー id。
+    # フィルタモーダルの選択肢で「自分」と実ユーザーの重複表示を避けるために使う。
+    me_id: str | None = None

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -1,0 +1,46 @@
+from redi.tui import app
+
+
+class TestBuildUserChoices:
+    """_build_user_choices() は time_entry フィルタモーダルのユーザー選択肢を組み立てる"""
+
+    def test_returns_specials_only_when_project_id_is_none(self):
+        """project_id が None のとき (指定なし) + (自分) のみ返す"""
+        choices = app._build_user_choices(None)
+        assert [v for v, _ in choices] == [None, "me"]
+
+    def test_includes_project_users_when_me_id_is_none(self, monkeypatch):
+        """me_id 未指定なら project users はそのまま全件並ぶ"""
+        monkeypatch.setattr(
+            app,
+            "fetch_project_users",
+            lambda _project_id: [
+                {"id": 5, "name": "Sandbox Developer"},
+                {"id": 9, "name": "Other"},
+            ],
+        )
+        choices = app._build_user_choices("1")
+        assert [v for v, _ in choices] == [None, "me", "5", "9"]
+
+    def test_excludes_self_when_me_id_matches_project_user(self, monkeypatch):
+        """me_id と一致する project user は除外して『自分』との重複を防ぐ"""
+        monkeypatch.setattr(
+            app,
+            "fetch_project_users",
+            lambda _project_id: [
+                {"id": 5, "name": "Sandbox Developer"},
+                {"id": 9, "name": "Other"},
+            ],
+        )
+        choices = app._build_user_choices("1", me_id="5")
+        assert [v for v, _ in choices] == [None, "me", "9"]
+
+    def test_keeps_all_users_when_me_id_not_in_project_users(self, monkeypatch):
+        """me_id が project users に居なければ何も除外しない"""
+        monkeypatch.setattr(
+            app,
+            "fetch_project_users",
+            lambda _project_id: [{"id": 5, "name": "Sandbox Developer"}],
+        )
+        choices = app._build_user_choices("1", me_id="999")
+        assert [v for v, _ in choices] == [None, "me", "5"]

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -44,3 +44,48 @@ class TestBuildUserChoices:
         )
         choices = app._build_user_choices("1", me_id="999")
         assert [v for v, _ in choices] == [None, "me", "5"]
+
+
+class TestBuildAssigneeChoices:
+    """_build_assignee_choices() は issue フィルタモーダルの担当者選択肢を組み立てる"""
+
+    def test_returns_specials_only_when_project_id_is_none(self):
+        """project_id が None のとき (指定なし) + (自分) + (未割当) のみ返す"""
+        choices = app._build_assignee_choices(None)
+        assert [v for v, _ in choices] == [None, "me", "!*"]
+
+    def test_includes_project_users_when_me_id_is_none(self, monkeypatch):
+        """me_id 未指定なら project users はそのまま全件並ぶ"""
+        monkeypatch.setattr(
+            app,
+            "fetch_project_users",
+            lambda _project_id: [
+                {"id": 5, "name": "Sandbox Developer"},
+                {"id": 9, "name": "Other"},
+            ],
+        )
+        choices = app._build_assignee_choices("1")
+        assert [v for v, _ in choices] == [None, "me", "!*", "5", "9"]
+
+    def test_excludes_self_when_me_id_matches_project_user(self, monkeypatch):
+        """me_id と一致する project user は除外して『自分』との重複を防ぐ"""
+        monkeypatch.setattr(
+            app,
+            "fetch_project_users",
+            lambda _project_id: [
+                {"id": 5, "name": "Sandbox Developer"},
+                {"id": 9, "name": "Other"},
+            ],
+        )
+        choices = app._build_assignee_choices("1", me_id="5")
+        assert [v for v, _ in choices] == [None, "me", "!*", "9"]
+
+    def test_keeps_all_users_when_me_id_not_in_project_users(self, monkeypatch):
+        """me_id が project users に居なければ何も除外しない"""
+        monkeypatch.setattr(
+            app,
+            "fetch_project_users",
+            lambda _project_id: [{"id": 5, "name": "Sandbox Developer"}],
+        )
+        choices = app._build_assignee_choices("1", me_id="999")
+        assert [v for v, _ in choices] == [None, "me", "!*", "5"]


### PR DESCRIPTION
resolve #192 

## Summary
- 起動時に `/my/account.json` から自分のユーザー id を取得して `TuiState.me_id` に保持
- `_build_user_choices` (time_entry) / `_build_assignee_choices` (issue) で `fetch_project_users` の結果から自身を除外し、「自分」項目との重複表示を防ぐ
- `_build_user_choices` / `_build_assignee_choices` の単体テストを追加

## Test plan
- [x] `task check` がパスすること
- [x] TUI 起動後、time_entry タブで `f` を押してフィルタモーダルを開いたとき、project users 一覧に自分が含まれず「自分」の 1 つだけになっていること
- [x] issue タブで `f` を押してフィルタモーダルを開き、担当者セクションで project users 一覧に自分が含まれず「自分」の 1 つだけになっていること