### PR TITLE
fix(tui): TUI からの issue create で AttributeError を解消

### DIFF
--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -218,6 +218,10 @@ def main() -> None:
                             priority_id=None,
                             assigned_to_id=None,
                             fixed_version_id=None,
+                            parent_issue_id=None,
+                            start_date=None,
+                            due_date=None,
+                            estimated_hours=None,
                             description=None,
                             custom_fields=None,
                         )

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -217,6 +217,7 @@ def main() -> None:
                             tracker_id=None,
                             priority_id=None,
                             assigned_to_id=None,
+                            fixed_version_id=None,
                             description=None,
                             custom_fields=None,
                         )


### PR DESCRIPTION
## Summary
- closes #201 
- TUI から issue create を実行した際、`handle_issue_create` に渡される `argparse.Namespace` に `fixed_version_id` などの属性が含まれておらず、`AttributeError` で issue 作成に失敗していたのを修正
- 欠落していた `fixed_version_id` / `parent_issue_id` / `start_date` / `due_date` / `estimated_hours` の 5 つを Namespace に追加 (CLI 経由の `redi issue create` では argparse が default=None で埋めていたが、TUI 経由ではこの経路を通らないため明示が必要)

## Test plan
- [x] `redi --tui` から issue 作成導線に入り、submit / browser / optional のいずれを選んでも AttributeError が出ないこと
- [x] optional から fixed_version, parent_issue, start_date, due_date, estimated_hours を選択して値が反映されること
- [x] CLI からの `redi issue create` が従来通り動くこと
- [x] `task check` がパスすること