### PR TITLE
fix: requests 2.34 への bump で発生した型エラーを解消

### DIFF
--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -4,6 +4,7 @@ import os
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -25,7 +26,7 @@ def upload_file(file_path: str) -> dict:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.file_upload_failed_with_path.format(path=file_path))
         exit(1)
     token = response.json()["upload"]["token"]
@@ -78,7 +79,7 @@ def delete_attachment(attachment_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.attachment_delete_failed)
         exit(1)
     print(messages.attachment_deleted.format(id=attachment_id))
@@ -107,7 +108,7 @@ def update_attachment(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.attachment_update_failed)
         exit(1)
     print(

--- a/src/redi/api/exceptions.py
+++ b/src/redi/api/exceptions.py
@@ -5,6 +5,17 @@ import requests
 ValidationAction = Literal["create", "update"]
 
 
+def print_http_error_body(e: requests.exceptions.HTTPError) -> None:
+    """HTTPError のレスポンス本文を安全に出力する。
+
+    HTTPError.response は型上 Response | None だが、
+    raise_for_status() 経由で送出された場合は通常 None ではない。
+    None の場合は何も出力しない。
+    """
+    if e.response is not None:
+        print(e.response.text)
+
+
 class RedmineValidationException(Exception):
     """Redmine API がバリデーションエラー (HTTP 422) を返したときに送出する例外。
 

--- a/src/redi/api/exceptions.py
+++ b/src/redi/api/exceptions.py
@@ -6,12 +6,6 @@ ValidationAction = Literal["create", "update"]
 
 
 def print_http_error_body(e: requests.exceptions.HTTPError) -> None:
-    """HTTPError のレスポンス本文を安全に出力する。
-
-    HTTPError.response は型上 Response | None だが、
-    raise_for_status() 経由で送出された場合は通常 None ではない。
-    None の場合は何も出力しない。
-    """
     if e.response is not None:
         print(e.response.text)
 

--- a/src/redi/api/file.py
+++ b/src/redi/api/file.py
@@ -3,6 +3,7 @@ import json
 import requests
 
 from redi.api.attachment import upload_file
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
 
@@ -50,7 +51,7 @@ def create_file(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.file_upload_failed)
         exit(1)
     print(messages.file_uploaded.format(filename=upload["filename"]))

--- a/src/redi/api/group.py
+++ b/src/redi/api/group.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -83,7 +84,7 @@ def update_group(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.group_update_failed)
         exit(1)
     print(messages.group_updated.format(id=group_id))
@@ -104,7 +105,7 @@ def add_group_user(group_id: str, user_id: int) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.group_add_user_failed)
         exit(1)
     print(messages.group_user_added.format(group_id=group_id, user_id=user_id))
@@ -124,7 +125,7 @@ def remove_group_user(group_id: str, user_id: int) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.group_remove_user_failed)
         exit(1)
     print(messages.group_user_removed.format(group_id=group_id, user_id=user_id))
@@ -142,7 +143,7 @@ def delete_group(group_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.group_delete_failed)
         exit(1)
     print(messages.group_deleted.format(id=group_id))
@@ -160,7 +161,7 @@ def create_group(name: str, user_ids: list[int] | None = None) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.group_create_failed)
         exit(1)
     created = response.json()["group"]

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 import requests
 
 from redi.api.attachment import upload_file
-from redi.api.exceptions import RedmineValidationException
+from redi.api.exceptions import RedmineValidationException, print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -300,7 +300,7 @@ def create_issue(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.issue_create_failed)
         exit(1)
     created = response.json()["issue"]
@@ -372,7 +372,7 @@ def update_issue(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.issue_update_failed)
         exit(1)
     url = f"{redmine_url}/issues/{issue_id}"
@@ -391,7 +391,7 @@ def add_watcher(issue_id: str, user_id: int) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.watcher_add_failed)
         exit(1)
     print(messages.watcher_added.format(issue_id=issue_id, user_id=user_id))
@@ -408,7 +408,7 @@ def remove_watcher(issue_id: str, user_id: int) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.watcher_remove_failed)
         exit(1)
     print(messages.watcher_removed.format(issue_id=issue_id, user_id=user_id))
@@ -423,7 +423,7 @@ def delete_issue(issue_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.issue_delete_failed)
         exit(1)
     print(messages.issue_deleted.format(id=issue_id))

--- a/src/redi/api/issue_category.py
+++ b/src/redi/api/issue_category.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
 
@@ -75,7 +76,7 @@ def create_issue_category(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.category_create_failed)
         exit(1)
     created = response.json()["issue_category"]
@@ -106,7 +107,7 @@ def update_issue_category(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.category_update_failed)
         exit(1)
     print(messages.category_updated.format(id=category_id))
@@ -124,7 +125,7 @@ def delete_issue_category(category_id: str, reassign_to_id: int | None = None) -
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.category_delete_failed)
         exit(1)
     print(messages.category_deleted.format(id=category_id))

--- a/src/redi/api/issue_journal.py
+++ b/src/redi/api/issue_journal.py
@@ -1,5 +1,6 @@
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
 
@@ -16,7 +17,7 @@ def update_issue_journal(journal_id: str, notes: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.issue_journal_update_failed)
         exit(1)
     print(messages.issue_journal_updated.format(id=journal_id))
@@ -31,7 +32,7 @@ def delete_issue_journal(journal_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.issue_journal_delete_failed)
         exit(1)
     print(messages.issue_journal_deleted.format(id=journal_id))

--- a/src/redi/api/issue_relation.py
+++ b/src/redi/api/issue_relation.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -48,7 +49,7 @@ def create_relation(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.relation_create_failed)
         exit(1)
     print(
@@ -83,7 +84,7 @@ def delete_relation(issue_id: str, issue_to_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.relation_delete_failed)
         return
     print(

--- a/src/redi/api/me.py
+++ b/src/redi/api/me.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
 
@@ -64,7 +65,7 @@ def update_my_account(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.account_update_failed)
         exit(1)
     print(messages.account_updated)

--- a/src/redi/api/membership.py
+++ b/src/redi/api/membership.py
@@ -3,6 +3,7 @@ from typing import NotRequired, TypedDict, cast
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
 
@@ -112,7 +113,7 @@ def create_membership(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.membership_create_failed)
         exit(1)
     created = response.json()["membership"]
@@ -131,7 +132,7 @@ def update_membership(membership_id: str, role_ids: list[int]) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.membership_update_failed)
         exit(1)
     print(messages.membership_updated.format(id=membership_id))
@@ -146,7 +147,7 @@ def delete_membership(membership_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.membership_delete_failed)
         exit(1)
     print(messages.membership_deleted.format(id=membership_id))

--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -3,6 +3,7 @@ import webbrowser
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -74,7 +75,7 @@ def create_project(
         print(f"{project['id']} {project['name']} ({project['identifier']})")
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         exit(1)
 
 
@@ -105,7 +106,7 @@ def update_project(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.project_update_failed)
         exit(1)
     print(messages.project_updated.format(id=project_id))
@@ -120,7 +121,7 @@ def archive_project(project_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.project_archive_failed)
         exit(1)
     print(messages.project_archived.format(id=project_id))
@@ -135,7 +136,7 @@ def unarchive_project(project_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.project_unarchive_failed)
         exit(1)
     print(messages.project_unarchived.format(id=project_id))
@@ -150,7 +151,7 @@ def delete_project(project_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.project_delete_failed)
         exit(1)
     print(messages.project_deleted.format(id=project_id))

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from redi.api.exceptions import RedmineValidationException
+from redi.api.exceptions import RedmineValidationException, print_http_error_body
 from redi.api.project import resolve_project_id
 from redi.client import client
 from redi.i18n import messages
@@ -46,7 +46,7 @@ def create_time_entry(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.time_entry_create_failed)
         exit(1)
     created = response.json()["time_entry"]
@@ -247,7 +247,7 @@ def update_time_entry(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.time_entry_update_failed)
         exit(1)
     print(messages.time_entry_updated.format(id=time_entry_id))
@@ -259,7 +259,7 @@ def delete_time_entry(time_entry_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.time_entry_delete_failed)
         exit(1)
     print(messages.time_entry_deleted.format(id=time_entry_id))

--- a/src/redi/api/user.py
+++ b/src/redi/api/user.py
@@ -2,6 +2,7 @@ import json
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -45,7 +46,7 @@ def create_user(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.user_create_failed)
         exit(1)
     created = response.json()["user"]
@@ -175,7 +176,7 @@ def update_user(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.user_update_failed)
         exit(1)
     print(messages.user_updated.format(id=user_id))
@@ -193,7 +194,7 @@ def delete_user(user_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.user_delete_failed)
         exit(1)
     print(messages.user_deleted.format(id=user_id))

--- a/src/redi/api/version.py
+++ b/src/redi/api/version.py
@@ -3,6 +3,7 @@ import webbrowser
 
 import requests
 
+from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -32,7 +33,7 @@ def create_version(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.version_create_failed)
         exit(1)
     created = response.json()["version"]
@@ -74,7 +75,7 @@ def update_version(
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.version_update_failed)
         exit(1)
     print(
@@ -134,7 +135,7 @@ def delete_version(version_id: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.version_delete_failed)
         exit(1)
     print(messages.version_deleted.format(id=version_id))

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -5,7 +5,7 @@ from typing import NotRequired, TypedDict
 
 import requests
 
-from redi.api.exceptions import RedmineValidationException
+from redi.api.exceptions import RedmineValidationException, print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -173,7 +173,7 @@ def delete_wiki(project_id: str, page_title: str) -> None:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
-        print(e.response.text)
+        print_http_error_body(e)
         print(messages.wiki_page_delete_failed)
         exit(1)
     print(messages.wiki_page_deleted.format(title=page_title))

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -31,11 +31,14 @@ def _verify_connection(url: str, api_key: str) -> dict | None:
         response.raise_for_status()
         return response.json().get("user")
     except requests.exceptions.HTTPError as e:
-        print(
-            messages.connection_failed_http.format(
-                status=e.response.status_code, reason=e.response.reason
+        if e.response is not None:
+            print(
+                messages.connection_failed_http.format(
+                    status=e.response.status_code, reason=e.response.reason
+                )
             )
-        )
+        else:
+            print(messages.connection_failed_other.format(error=e))
     except requests.exceptions.RequestException as e:
         print(messages.connection_failed_other.format(error=e))
     return None

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,7 @@ dev = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -289,9 +289,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- closes #205 
- `requests` を 2.33.1 から 2.34.2 へ更新（PR #204 を取り込み）
- `requests` 2.34.0 で型がインライン化され `HTTPError.response` が `Response | None` に厳密化されたことで発生した `ty` の `unresolved-attribute` エラーを解消
- 共通ヘルパー `print_http_error_body` を `api/exceptions.py` に追加し、`api/*.py` の `print(e.response.text)` 40 箇所を置換
- `init_command.py` の `e.response.status_code` / `e.response.reason` 参照には `None` ガードを追加（None 時は `connection_failed_other` メッセージへフォールバック）

## Test plan
- [x] `task check`（format / lint / typecheck / test）がローカルで全件 pass することを確認
- [x] CI の Typecheck ジョブが緑になることを確認
- [x] 実 Redmine に対して `redi init` でエラー時のメッセージが従来通り出ることを手動確認