### PR TITLE
キャッシュの保存先をredmineごとに分ける

### DIFF
--- a/src/redi/cache.py
+++ b/src/redi/cache.py
@@ -1,14 +1,31 @@
 import json
 import time
 from pathlib import Path
+from urllib.parse import urlsplit
 
 CACHE_DIR = Path.home() / ".cache" / "redi"
 # キャッシュの生存時間[s]
 DEFAULT_TTL = 100 * 12 * 30 * 24 * 60 * 60  # 100 years
 
 
+def _slugify_url(url: str) -> str:
+    """redmineのURL をディレクトリ名に変換する
+
+    https://redmine.example.com → redmine.example.com_8080_sub
+    http://localhost:3000 → localhost_3000
+    http://redmine.example.com:8080/sub → redmine.example.com_8080_sub
+    """
+    parsed = urlsplit(url)
+    host = parsed.hostname or ""
+    port = f"{parsed.port}" if parsed.port else ""
+    path = parsed.path.rstrip("/").lstrip("/").replace("/", "_")
+    return "_".join(filter(None, [host, port, path]))
+
+
 def _cache_path(key: str) -> Path:
-    return CACHE_DIR / f"{key}.json"
+    from redi import config
+
+    return CACHE_DIR / _slugify_url(config.redmine_url) / f"{key}.json"
 
 
 def load(key: str, ttl: int = DEFAULT_TTL) -> list[dict] | None:
@@ -25,6 +42,7 @@ def load(key: str, ttl: int = DEFAULT_TTL) -> list[dict] | None:
 
 
 def save(key: str, value: list[dict]) -> None:
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _cache_path(key)
+    path.parent.mkdir(parents=True, exist_ok=True)
     data = {"timestamp": time.time(), "value": value}
-    _cache_path(key).write_text(json.dumps(data, ensure_ascii=False))
+    path.write_text(json.dumps(data, ensure_ascii=False))

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,7 +1,7 @@
 import json
 import time
 
-from redi import cache
+from redi import cache, config
 
 
 class TestSave:
@@ -11,12 +11,14 @@ class TestSave:
         """存在しないディレクトリでも自動作成して保存できる"""
         cache_dir = tmp_path / "nested" / "cache"
         monkeypatch.setattr(cache, "CACHE_DIR", cache_dir)
+        monkeypatch.setattr(config, "redmine_url", "http://localhost:3000")
         cache.save("statuses", [{"id": 1}])
-        assert (cache_dir / "statuses.json").exists()
+        assert (cache_dir / "localhost_3000" / "statuses.json").exists()
 
     def test_overwrites_with_latest_data(self, tmp_path, monkeypatch):
         """同じキーで上書き保存すると最新のデータに更新される"""
         monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        monkeypatch.setattr(config, "redmine_url", "https://localhost:3000")
         cache.save("statuses", [{"id": 1, "name": "旧データ"}])
         cache.save("statuses", [{"id": 1, "name": "新データ"}])
         assert cache.load("statuses") == [{"id": 1, "name": "新データ"}]
@@ -28,6 +30,7 @@ class TestLoad:
     def test_returns_saved_data(self, tmp_path, monkeypatch):
         """保存したデータがそのまま返る"""
         monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        monkeypatch.setattr(config, "redmine_url", "http://localhost:3000")
         data = [{"id": 1, "name": "新規"}]
         cache.save("statuses", data)
 
@@ -36,12 +39,14 @@ class TestLoad:
     def test_returns_none_for_missing_key(self, tmp_path, monkeypatch):
         """存在しないキーを指定するとNoneが返る"""
         monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        monkeypatch.setattr(config, "redmine_url", "http://localhost:3000")
 
         assert cache.load("nonexistent") is None
 
     def test_returns_none_when_expired(self, tmp_path, monkeypatch):
         """保存時刻からTTLを過ぎるとNoneが返る"""
         monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        monkeypatch.setattr(config, "redmine_url", "http://localhost:3000")
         data = [{"id": 1, "name": "新規"}]
         monkeypatch.setattr(time, "time", lambda: 1000.0)
         cache.save("statuses", data)
@@ -52,6 +57,7 @@ class TestLoad:
     def test_returns_data_within_ttl(self, tmp_path, monkeypatch):
         """TTL以内であればデータが返る"""
         monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+        monkeypatch.setattr(config, "redmine_url", "http://localhost:3000")
         data = [{"id": 1, "name": "新規"}]
         monkeypatch.setattr(time, "time", lambda: 1000.0)
         cache.save("statuses", data)
@@ -61,13 +67,17 @@ class TestLoad:
     def test_returns_none_for_invalid_json(self, tmp_path, monkeypatch):
         """不正なJSONの場合Noneが返る"""
         monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
-        path = tmp_path / "statuses.json"
+        monkeypatch.setattr(config, "redmine_url", "http://localhost:3000")
+        path = tmp_path / "localhost_3000" / "statuses.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("invalid json")
         assert cache.load("statuses") is None
 
     def test_returns_none_for_missing_value_key(self, tmp_path, monkeypatch):
         """valueキーが欠落したJSONの場合Noneが返る"""
         monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
-        path = tmp_path / "statuses.json"
+        monkeypatch.setattr(config, "redmine_url", "http://localhost:3000")
+        path = tmp_path / "localhost_3000" / "statuses.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps({"timestamp": time.time()}))
         assert cache.load("statuses") is None

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -2,6 +2,7 @@ import json
 import time
 
 from redi import cache, config
+import pytest
 
 
 class TestSave:
@@ -81,3 +82,22 @@ class TestLoad:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps({"timestamp": time.time()}))
         assert cache.load("statuses") is None
+
+
+class TestSlugifyUrl:
+    """_slugify_url() は URL をディレクトリ名に変換する"""
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("http://redmine.example.com", "redmine.example.com"),
+            ("https://redmine.example.com", "redmine.example.com"),
+            ("https://redmine.example.com/", "redmine.example.com"),
+            ("https://redmine.example.com/main", "redmine.example.com_main"),
+            ("https://redmine.example.com/main/", "redmine.example.com_main"),
+            ("http://localhost:3000", "localhost_3000"),
+            ("http://localhost:3001", "localhost_3001"),
+        ],
+    )
+    def test_slugify(self, url, expected):
+        assert cache._slugify_url(url) == expected


### PR DESCRIPTION
resolve #207 

- **[update] キャッシュの保存先をredmineのインスタンスごとに分ける**
- **test(cache): 既存テストを redmine_url の monkeypatch に対応**
- **test: _slugify_url() のテストを追加**
