### PR TITLE
[cli] --profile で補完候補をきくようにした

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 Repository = "https://github.com/kawagh/redi"
 
 [project.scripts]
-redi = "redi.cli:main"
+redi = "redi.cli.main:main"
 
 [build-system]
 requires = ["uv_build>=0.9.2,<0.12.0"]

--- a/src/redi/cli/__init__.py
+++ b/src/redi/cli/__init__.py
@@ -1,3 +1,0 @@
-from redi.cli.main import main
-
-__all__ = ["main"]

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -46,7 +46,7 @@ from redi.cli.time_entry_command import add_time_entry_parser, handle_time_entry
 from redi.cli.user_command import add_user_parser, handle_user
 from redi.cli.version_command import add_version_parser, handle_version
 from redi.cli.wiki_command import add_wiki_parser, handle_wiki
-from redi.config import CONFIG_PATH, check_config
+from redi.config import CONFIG_PATH, check_config, list_profile_names
 from redi.api.custom_field import list_custom_fields
 from redi.api.enumeration import (
     list_document_categories,
@@ -76,7 +76,7 @@ def _format_validation_error(e: RedmineValidationException) -> str:
     )
 
 
-def _profile_parser() -> argparse.ArgumentParser:
+def _profile_parser(profile_names: list[str]) -> argparse.ArgumentParser:
     """--profile を後置するためのパーサ"""
     parser = argparse.ArgumentParser(
         # 親子でヘルプを衝突させない
@@ -86,6 +86,8 @@ def _profile_parser() -> argparse.ArgumentParser:
         "--profile",
         # 下流のパーサでprofileが未指定の場合に上流パーサの値を上書きするのを防ぐ
         default=argparse.SUPPRESS,
+        choices=profile_names or None,
+        metavar="PROFILE",
         help=messages.arg_help_profile,
     )
     return parser
@@ -103,11 +105,14 @@ def build_redi_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=messages.arg_help_debug_tui,
     )
+    profile_names = list_profile_names()
     parser.add_argument(
         "--profile",
+        choices=profile_names or None,
+        metavar="PROFILE",
         help=messages.arg_help_profile,
     )
-    parents = [_profile_parser()]
+    parents = [_profile_parser(profile_names)]
     subparsers = parser.add_subparsers(dest="command")
     add_project_parser(subparsers, parents)
     add_issue_parser(subparsers, parents)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -2,6 +2,7 @@ import argparse
 
 import pytest
 
+from redi.cli import main as main_module
 from redi.cli.main import build_redi_parser
 
 
@@ -9,7 +10,8 @@ class TestProfileFlagPlacement:
     """--profile はサブコマンドの前後どちらに置いても受け付けられる"""
 
     @pytest.fixture
-    def parser(self) -> argparse.ArgumentParser:
+    def parser(self, monkeypatch) -> argparse.ArgumentParser:
+        monkeypatch.setattr(main_module, "list_profile_names", lambda: [])
         return build_redi_parser()
 
     def test_before_subcommand(self, parser):


### PR DESCRIPTION
- **feat(cli): --profile の補完候補に config.toml のプロファイル名を使う**
- **refactor(cli): エントリポイントを redi.cli.main:main に変更**
    - テストでモジュールインポートがしづらかった
