### PR TITLE
update(types): time_entry リソースを型つけ

### DIFF
--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -25,8 +25,8 @@ class TimeEntry(TypedDict):
     user: IdName
     activity: IdName
     hours: float
-    comments: str
-    spent_on: str
+    comments: str | None
+    spent_on: str  # YYYY-MM-DD
     created_on: str
     updated_on: str
     # チケットに紐づく作業時間の場合のみ存在

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -1,11 +1,51 @@
+from __future__ import annotations
+
 import json
+from typing import NotRequired, TypedDict, cast
 
 import requests
 
 from redi.api.exceptions import RedmineValidationException, print_http_error_body
 from redi.api.project import resolve_project_id
+from redi.api.types import IdName
 from redi.client import client
 from redi.i18n import messages
+
+
+class TimeEntry(TypedDict):
+    """redmine TimeEntry
+
+    GET /time_entries.json / GET /time_entries/{id}.json を実行して確認できた
+    フィールドを記載。`issue` はチケットに紐づく作業時間の場合のみ存在し、
+    `id` のみを持つ（件名は含まれないため別途 fetch_issue_subjects で取得する）。
+    """
+
+    id: int
+    project: IdName
+    user: IdName
+    activity: IdName
+    hours: float
+    comments: str
+    spent_on: str
+    created_on: str
+    updated_on: str
+    # チケットに紐づく作業時間の場合のみ存在
+    issue: NotRequired[TimeEntryIssueRef]
+
+
+class TimeEntryIssueRef(TypedDict):
+    """作業時間が参照するチケット。`id` のみを持つ。"""
+
+    id: int
+
+
+class TimeEntriesPageResponse(TypedDict):
+    """GET /time_entries.json のレスポンス"""
+
+    time_entries: list[TimeEntry]
+    total_count: int
+    offset: int
+    limit: int
 
 
 def create_time_entry(
@@ -49,7 +89,7 @@ def create_time_entry(
         print_http_error_body(e)
         print(messages.time_entry_create_failed)
         exit(1)
-    created = response.json()["time_entry"]
+    created = cast("TimeEntry", response.json()["time_entry"])
     print(
         messages.time_entry_created.format(
             id=created["id"], hours=created["hours"], spent_on=created["spent_on"]
@@ -61,7 +101,7 @@ COMMENT_PREVIEW_MAX_LEN = 30
 
 
 def format_time_entry_line(
-    te: dict,
+    te: TimeEntry,
     include_user: bool = True,
     issue_subjects: dict[int, str] | None = None,
 ) -> str:
@@ -97,7 +137,7 @@ def fetch_time_entries_page(
     user_id: str | None = None,
     limit: int | None = None,
     offset: int | None = None,
-) -> dict:
+) -> TimeEntriesPageResponse:
     if project_id:
         path = f"/projects/{project_id}/time_entries.json"
     else:
@@ -111,7 +151,7 @@ def fetch_time_entries_page(
         params["offset"] = offset
     response = client.get(path, params=params)
     response.raise_for_status()
-    return response.json()
+    return cast("TimeEntriesPageResponse", response.json())
 
 
 def fetch_issue_subjects(issue_ids: list[int]) -> dict[int, str]:
@@ -151,7 +191,7 @@ def list_time_entries(
         params["offset"] = offset
     response = client.get(path, params=params)
     response.raise_for_status()
-    time_entries = response.json()["time_entries"]
+    time_entries = cast("list[TimeEntry]", response.json()["time_entries"])
     if full:
         print(json.dumps(time_entries, ensure_ascii=False))
         return
@@ -174,13 +214,13 @@ def list_time_entries(
         )
 
 
-def fetch_time_entry(time_entry_id: str) -> dict:
+def fetch_time_entry(time_entry_id: str) -> TimeEntry:
     response = client.get(f"/time_entries/{time_entry_id}.json")
     if response.status_code == 404:
         print(messages.time_entry_not_found.format(id=time_entry_id))
         exit(1)
     response.raise_for_status()
-    return response.json()["time_entry"]
+    return cast("TimeEntry", response.json()["time_entry"])
 
 
 def read_time_entry(time_entry_id: str, full: bool = False) -> None:

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from redi.api.issue import Issue
+from redi.api.time_entry import TimeEntry
 from redi.api.wiki import WikiPage
 from redi.i18n import messages
 
@@ -145,7 +146,7 @@ class TimeEntryFilterModalState:
 class TimeEntryTabState:
     loaded: bool = False
     offset: int = 0
-    entries: list[dict] = field(default_factory=list)
+    entries: list[TimeEntry] = field(default_factory=list)
     total_count: int = 0
     issue_subjects: dict[int, str] = field(default_factory=dict)
     cursor: int = 0

--- a/tests/unit/tui/test_tab_reload.py
+++ b/tests/unit/tui/test_tab_reload.py
@@ -3,6 +3,7 @@
 from typing import cast
 
 from redi.api.issue import Issue
+from redi.api.time_entry import TimeEntry
 from redi.api.wiki import WikiPage
 from redi.tui import issue_tab, time_entry_tab, wiki_tab
 from redi.tui.state import TuiState
@@ -146,11 +147,14 @@ class TestTimeEntryReload:
         state.page_size = 5
         state.time_entry_tab.loaded = True
         state.time_entry_tab.offset = 10
-        state.time_entry_tab.entries = [
-            {"id": 100},
-            {"id": 200},
-            {"id": 300},
-        ]
+        state.time_entry_tab.entries = cast(
+            list[TimeEntry],
+            [
+                {"id": 100},
+                {"id": 200},
+                {"id": 300},
+            ],
+        )
         state.time_entry_tab.total_count = 30
         state.time_entry_tab.cursor = 1  # id=200 にいる
 
@@ -176,7 +180,9 @@ class TestTimeEntryReload:
         state = TuiState()
         state.page_size = 5
         state.time_entry_tab.offset = 0
-        state.time_entry_tab.entries = [{"id": i} for i in range(1, 6)]
+        state.time_entry_tab.entries = cast(
+            list[TimeEntry], [{"id": i} for i in range(1, 6)]
+        )
         state.time_entry_tab.total_count = 5
         state.time_entry_tab.cursor = 4
 
@@ -199,7 +205,7 @@ class TestTimeEntryReload:
         """再取得結果が空でも例外を投げず cursor=0 になる"""
         state = TuiState()
         state.page_size = 5
-        state.time_entry_tab.entries = [{"id": 999}]
+        state.time_entry_tab.entries = cast(list[TimeEntry], [{"id": 999}])
         state.time_entry_tab.cursor = 0
         monkeypatch.setattr(
             time_entry_tab,

--- a/tests/unit/tui/test_time_entry_tab.py
+++ b/tests/unit/tui/test_time_entry_tab.py
@@ -1,3 +1,6 @@
+from typing import cast
+
+from redi.api.time_entry import TimeEntry
 from redi.tui import time_entry_tab
 from redi.tui.state import TuiState
 
@@ -9,7 +12,9 @@ def _make_state(
     state.page_size = page_size
     state.time_entry_tab.offset = offset
     state.time_entry_tab.total_count = total_count
-    state.time_entry_tab.entries = [{"id": i} for i in range(entries_on_page)]
+    state.time_entry_tab.entries = cast(
+        list[TimeEntry], [{"id": i} for i in range(entries_on_page)]
+    )
     return state
 
 
@@ -49,7 +54,9 @@ class TestPageForward:
         state = TuiState()
         state.page_size = 5
         state.time_entry_tab.offset = 0
-        state.time_entry_tab.entries = [{"id": i} for i in range(1, 6)]
+        state.time_entry_tab.entries = cast(
+            list[TimeEntry], [{"id": i} for i in range(1, 6)]
+        )
         state.time_entry_tab.total_count = 12
         state.time_entry_tab.cursor = 3
 
@@ -74,7 +81,9 @@ class TestPageForward:
         state = TuiState()
         state.page_size = 5
         state.time_entry_tab.offset = 5
-        state.time_entry_tab.entries = [{"id": i} for i in range(6, 11)]
+        state.time_entry_tab.entries = cast(
+            list[TimeEntry], [{"id": i} for i in range(6, 11)]
+        )
         state.time_entry_tab.total_count = 10
         state.time_entry_tab.cursor = 2
 
@@ -102,7 +111,9 @@ class TestPageBackward:
         state = TuiState()
         state.page_size = 5
         state.time_entry_tab.offset = 10
-        state.time_entry_tab.entries = [{"id": i} for i in range(11, 16)]
+        state.time_entry_tab.entries = cast(
+            list[TimeEntry], [{"id": i} for i in range(11, 16)]
+        )
         state.time_entry_tab.total_count = 20
         state.time_entry_tab.cursor = 4
 
@@ -126,7 +137,7 @@ class TestPageBackward:
         state = TuiState()
         state.page_size = 5
         state.time_entry_tab.offset = 0
-        state.time_entry_tab.entries = [{"id": 1}]
+        state.time_entry_tab.entries = cast(list[TimeEntry], [{"id": 1}])
         state.time_entry_tab.cursor = 0
 
         called = False
@@ -191,7 +202,7 @@ class TestConfirmDeleteUpdatesTotal:
 
     def test_decrements_total_count(self, monkeypatch):
         state = TuiState()
-        state.time_entry_tab.entries = [{"id": 1}, {"id": 2}]
+        state.time_entry_tab.entries = cast(list[TimeEntry], [{"id": 1}, {"id": 2}])
         state.time_entry_tab.total_count = 5
         state.time_entry_tab.cursor = 0
 


### PR DESCRIPTION
## 概要

closes #223

time_entry リソースに型を付けた。wiki / project リソースの型付け (#222 / #219) と同じ方針で、実 API のレスポンスを確認しながら `TypedDict` を定義した。

## 変更内容

- `src/redi/api/time_entry.py`
    - `GET /time_entries.json` / `GET /time_entries/{id}.json` を実行して確認できたフィールドをもとに以下の `TypedDict` を定義
        - `TimeEntry` … `id` / `project` / `user` / `activity`（共通の `IdName`）/ `hours` / `comments` / `spent_on` / `created_on` / `updated_on`。`comments` は null になりうるため `str | None`、`issue` はチケットに紐づく場合のみ存在するため `NotRequired`
        - `TimeEntryIssueRef` … `issue` 参照は `id` のみを持つ（件名を含まないので `IdName` とは別型）
        - `TimeEntriesPageResponse` … 一覧レスポンス
    - `create_time_entry` / `format_time_entry_line` / `fetch_time_entries_page` / `list_time_entries` / `fetch_time_entry` の戻り値・引数を型付け
- `src/redi/tui/state.py`
    - `TimeEntryTabState.entries` を `list[dict]` → `list[TimeEntry]`
- テスト (`test_time_entry_tab.py` / `test_tab_reload.py`)
    - 最小フィクスチャを wiki の前例どおり `cast(list[TimeEntry], ...)` で包んで型チェックを通した

## Test plan

- [x] `task format` / `task lint` / `task typecheck` がパスする
- [x] `task test` がパスする（296 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)