### PR TITLE
feat(tui): フィルタの絞り込み条件をTUIループ間で引き継ぐ

### DIFF
--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -183,7 +183,7 @@ def main() -> None:
             tui_result = run_issue_tui(state=tui_state, debug_log_path=debug_log_path)
             if tui_result is None:
                 return
-            tui_state = TuiState(last_result=tui_result)
+            tui_state = tui_state.carry_over(tui_result)
             try:
                 if tui_result.action == "update" and tui_result.tab == "issues":
                     handle_issue_update(

--- a/src/redi/tui/state.py
+++ b/src/redi/tui/state.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Literal
 
@@ -184,3 +186,11 @@ class TuiState:
     # 起動時に `/my/account.json` から取得した自分のユーザー id。
     # フィルタモーダルの選択肢で「自分」と実ユーザーの重複表示を避けるために使う。
     me_id: str | None = None
+
+    def carry_over(self, result: TuiResult) -> TuiState:
+        """action 実行後の次のTUIループに 絞り込み条件を引き継ぐ"""
+
+        next_state = TuiState(last_result=result)
+        next_state.issue_tab.filter = self.issue_tab.filter
+        next_state.time_entry_tab.filter = self.time_entry_tab.filter
+        return next_state

--- a/tests/unit/tui/test_state.py
+++ b/tests/unit/tui/test_state.py
@@ -1,5 +1,5 @@
 from redi.i18n import messages
-from redi.tui.state import IssueFilter, TimeEntryFilter
+from redi.tui.state import IssueFilter, TimeEntryFilter, TuiResult, TuiState
 
 
 class TestIssueFilter:
@@ -73,3 +73,31 @@ class TestTimeEntryFilter:
         f = TimeEntryFilter(user_id="42", user_label="Alice")
         assert f.is_active() is True
         assert f.short_label() == "user=Alice"
+
+
+class TestCarryOver:
+    """carry_over() は action 実行後の次ループ用に TuiState を作り直す"""
+
+    def test_issue_filter_is_preserved(self):
+        """issue タブの絞り込み条件は次ループの TuiState に引き継がれる"""
+        prev = TuiState()
+        prev.issue_tab.filter = IssueFilter(
+            status_id="closed", status_label="closed のみ"
+        )
+        result = TuiResult(action="comment", tab="issues", issue_id="1")
+
+        next_state = prev.carry_over(result)
+
+        assert next_state.issue_tab.filter == prev.issue_tab.filter
+        assert next_state.issue_tab.filter.status_id == "closed"
+
+    def test_time_entry_filter_is_preserved(self):
+        """time_entry タブの絞り込み条件も引き継がれる"""
+        prev = TuiState()
+        prev.time_entry_tab.filter = TimeEntryFilter(user_id="42", user_label="Alice")
+        result = TuiResult(action="update", tab="time_entries", time_entry_id="9")
+
+        next_state = prev.carry_over(result)
+
+        assert next_state.time_entry_tab.filter == prev.time_entry_tab.filter
+        assert next_state.time_entry_tab.filter.user_id == "42"


### PR DESCRIPTION
resolve #226

- issue/time_entry のフィルタをTUIでコメント投稿など実行した際に引き継がれるようにした
