### PR TITLE
feat: redmine_issue_templateプラグインによって提供されるテンプレートを取得するissue_templateコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ redi news -p <project_id>
 redi issue_category -p <project_id>
 redi issue_category create "category" -p <project_id>
 
+# issue_template (alias: it)
+# This command requires redmine_issue_templates plugin ( https://www.redmine.org/plugins/redmine_issue_templates )
+redi issue_template # list issue_templates
+
 # others
 redi user # list users (alias: u)
 redi tracker # list trackers (alias: t)

--- a/src/redi/api/issue_template.py
+++ b/src/redi/api/issue_template.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from typing import TypedDict
+
+from redi.client import client
+from redi.i18n import messages
+
+
+class IssueTemplate(TypedDict):
+    """redmine_issue_templates プラグインで提供されるIssueTemplate
+    GET /projects/{project_id}/issue_templates.json のレスポンスに含まれる
+
+    https://www.redmine.org/plugins/redmine_issue_templates
+    """
+
+    id: int
+    tracker_id: int
+    tracker_name: str
+    title: str
+    issue_title: str
+    description: str
+    note: str
+    enabled: bool
+    created_on: str
+    updated_on: str
+
+
+_KEYS = ("issue_templates", "inherit_templates", "global_issue_templates")
+
+
+def fetch_issue_templates(project_id: str) -> dict[str, list[IssueTemplate]]:
+    response = client.get(f"/projects/{project_id}/issue_templates.json")
+    # プラグイン非インストール時
+    if response.status_code == 404:
+        print(messages.issue_template_not_available)
+        exit(1)
+    response.raise_for_status()
+    return response.json()
+
+
+def list_issue_templates(project_id: str, full: bool = False) -> None:
+    templates = fetch_issue_templates(project_id)
+    if full:
+        print(json.dumps(templates, ensure_ascii=False))
+        return
+    for key in _KEYS:
+        section = templates.get(key) or []
+        if not section:
+            continue
+        print(f"# {key}")
+        for template in section:
+            print(f"{template['id']} {template['title']}")

--- a/src/redi/cli/issue_template_command.py
+++ b/src/redi/cli/issue_template_command.py
@@ -1,0 +1,28 @@
+import argparse
+
+from redi.api.issue_template import list_issue_templates
+from redi.config import default_project_id
+from redi.i18n import messages
+
+
+def add_issue_template_parser(
+    subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
+) -> None:
+    it_parser = subparsers.add_parser(
+        "issue_template",
+        aliases=["it"],
+        help=messages.arg_help_issue_template_command,
+        parents=parents,
+    )
+    it_parser.add_argument("--project_id", "-p", help=messages.arg_help_project_id)
+    it_parser.add_argument(
+        "--full", action="store_true", help=messages.arg_help_full_json
+    )
+
+
+def handle_issue_template(args: argparse.Namespace) -> None:
+    project_id = args.project_id or default_project_id
+    if not project_id:
+        print(messages.project_id_required)
+        exit(1)
+    list_issue_templates(project_id, full=args.full)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -35,6 +35,10 @@ from redi.cli.issue_journal_command import (
     add_issue_journal_parser,
     handle_issue_journal,
 )
+from redi.cli.issue_template_command import (
+    add_issue_template_parser,
+    handle_issue_template,
+)
 from redi.cli.me_command import add_me_parser, handle_me
 from redi.cli.membership_command import add_membership_parser, handle_membership
 from redi.cli.news_command import add_news_parser, handle_news
@@ -140,6 +144,7 @@ def build_redi_parser() -> argparse.ArgumentParser:
     add_time_entry_parser(subparsers, parents)
     add_file_parser(subparsers, parents)
     add_issue_journal_parser(subparsers, parents)
+    add_issue_template_parser(subparsers, parents)
     return parser
 
 
@@ -391,5 +396,7 @@ def main() -> None:
         handle_file(args)
     elif args.command in ("issue_journal", "ij"):
         handle_issue_journal(args)
+    elif args.command in ("issue_template", "it"):
+        handle_issue_template(args)
     else:
         parser.print_help()

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -884,6 +884,10 @@ class MessagesProto(Protocol):
     arg_help_query_command: str
     arg_help_custom_field_command: str
 
+    # ---- argparse helps (issue_template) ----
+    arg_help_issue_template_command: str
+    issue_template_not_available: str
+
     # ---- config_command suffix ----
     config_profile_suffix: str
     """{name}"""

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -754,6 +754,14 @@ class En(MessagesProto):
     arg_help_query_command = "List custom queries"
     arg_help_custom_field_command = "List custom fields"
 
+    # ---- argparse helps (issue_template) ----
+    arg_help_issue_template_command = (
+        "List issue templates (requires redmine_issue_templates plugin)"
+    )
+    issue_template_not_available = (
+        "issue_templates endpoint not found (requires redmine_issue_templates plugin)"
+    )
+
     # ---- config_command suffix ----
     config_profile_suffix = " (profile: {name})"
 

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -763,6 +763,15 @@ class Ja(MessagesProto):
     arg_help_query_command = "カスタムクエリ一覧"
     arg_help_custom_field_command = "カスタムフィールド一覧"
 
+    # ---- argparse helps (issue_template) ----
+    arg_help_issue_template_command = (
+        "チケットテンプレート一覧 (redmine_issue_templates プラグインが必要です)"
+    )
+    issue_template_not_available = (
+        "issue_templates エンドポイントが見つかりません "
+        "(redmine_issue_templates プラグインが必要です)"
+    )
+
     # ---- config_command suffix ----
     config_profile_suffix = "（profile: {name}）"
 


### PR DESCRIPTION
## 対応内容

redmine_issue_templates プラグイン ( https://www.redmine.org/plugins/redmine_issue_templates )
で提供されるイシューテンプレートを取得する issue_template コマンドを追加した
