### PR TITLE
feat: issue create 時にテンプレートを選択して使えるようにする

### DIFF
--- a/src/redi/api/issue_template.py
+++ b/src/redi/api/issue_template.py
@@ -39,6 +39,33 @@ def fetch_issue_templates(project_id: str) -> dict[str, list[IssueTemplate]]:
     return response.json()
 
 
+def fetch_enabled_issue_templates(
+    project_id: str, tracker_id: str | None = None
+) -> list[IssueTemplate]:
+    """issue create フローで選択肢として並べる有効なテンプレートを取得する。
+
+    プラグイン未インストール時は exit せず空リストを返す。
+    tracker_id を指定すると、その tracker に紐づくテンプレートのみに絞り込む。
+    """
+    response = client.get(f"/projects/{project_id}/issue_templates.json")
+    # プラグイン非インストール時は create を中断せずテンプレートなしとして扱う
+    if response.status_code == 404:
+        return []
+    response.raise_for_status()
+    data = response.json()
+    templates: list[IssueTemplate] = []
+    for key in _KEYS:
+        for template in data.get(key) or []:
+            if not template.get("enabled", True):
+                continue
+            if tracker_id is not None and str(template.get("tracker_id")) != str(
+                tracker_id
+            ):
+                continue
+            templates.append(template)
+    return templates
+
+
 def list_issue_templates(project_id: str, full: bool = False) -> None:
     templates = fetch_issue_templates(project_id)
     if full:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -39,6 +39,7 @@ from redi.api.issue import (
 )
 from redi.api.issue_relation import create_relation, delete_relation
 from redi.api.issue_status import fetch_issue_statuses
+from redi.api.issue_template import IssueTemplate, fetch_enabled_issue_templates
 from redi.api.membership import fetch_project_users
 from redi.api.project import fetch_project
 from redi.api.time_entry import create_time_entry
@@ -863,6 +864,33 @@ def _interactive_fill_optional_create_fields(
     return ",".join(added_cfs)
 
 
+def _interactive_select_issue_template(
+    project_id: str, tracker_id: str | None
+) -> IssueTemplate | None:
+    """create フローでテンプレートを選択させる。
+
+    redmine_issue_templates プラグインが無い、または有効なテンプレートが
+    無い場合は None を返し、選択ステップ自体をスキップする。
+    """
+    templates = fetch_enabled_issue_templates(project_id, tracker_id)
+    if not templates:
+        return None
+    options: list[tuple[str, str]] = [("", messages.prompt_select_template_none)] + [
+        (str(t["id"]), t["title"]) for t in templates
+    ]
+    template_map = {str(t["id"]): t for t in templates}
+    try:
+        selected = inline_choice(messages.prompt_select_template, options)
+    except KeyboardInterrupt:
+        print(messages.canceled)
+        exit(1)
+    if not selected:
+        return None
+    template = template_map[selected]
+    print(messages.template_label.format(value=template["title"]))
+    return template
+
+
 def handle_issue_create(args: argparse.Namespace) -> None:
     project_id = args.project_id or default_project_id
     if not project_id:
@@ -873,6 +901,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
     custom_fields = args.custom_fields
     interactive = subject is None or args.description is None
     browser_only = False
+    template_description = ""
     if subject is None:
         if tracker_id is None:
             project = fetch_project(project_id, include="trackers")
@@ -889,8 +918,14 @@ def handle_issue_create(args: argparse.Namespace) -> None:
                 print(messages.canceled)
                 exit(1)
             print(messages.tracker_label.format(value=labels[tracker_id]))
+        # テンプレートを選択し、題名・説明の初期値として反映させる
+        template = _interactive_select_issue_template(project_id, tracker_id)
+        subject_default = ""
+        if template is not None:
+            subject_default = template["issue_title"]
+            template_description = template["description"]
         try:
-            subject = prompt(messages.prompt_subject).strip()
+            subject = prompt(messages.prompt_subject, default=subject_default).strip()
         except (KeyboardInterrupt, EOFError):
             print(messages.canceled)
             exit(1)
@@ -904,7 +939,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             existing=args.custom_fields,
         )
     if args.description is None:
-        description = open_editor()
+        description = open_editor(initial_text=template_description)
         if description:
             print(
                 messages.prompt_field_value.format(

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -305,6 +305,8 @@ class MessagesProto(Protocol):
     """{value}"""
     estimated_hours_label: str
     """{value}"""
+    template_label: str
+    """{value}"""
 
     # ---- init flow ----
     api_key_url_hint: str
@@ -331,6 +333,8 @@ class MessagesProto(Protocol):
     prompt_parent_page: str
     prompt_edit_page: str
     prompt_select_tracker: str
+    prompt_select_template: str
+    prompt_select_template_none: str
     prompt_select_status: str
     prompt_select_priority: str
     prompt_select_assignee: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -196,6 +196,7 @@ class En(MessagesProto):
     fixed_version_label = "Fixed version: {value}"
     done_ratio_label = "Done ratio: {value}%"
     estimated_hours_label = "Estimated hours: {value} h"
+    template_label = "Template: {value}"
 
     # ---- init flow ----
     api_key_url_hint = "API key can be found at {url}/my/account"
@@ -220,6 +221,8 @@ class En(MessagesProto):
     prompt_parent_page = "Parent page"
     prompt_edit_page = "Page to edit"
     prompt_select_tracker = "Select tracker"
+    prompt_select_template = "Select template"
+    prompt_select_template_none = "(Do not use a template)"
     prompt_select_status = "Status"
     prompt_select_priority = "Priority"
     prompt_select_assignee = "Assignee"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -198,6 +198,7 @@ class Ja(MessagesProto):
     fixed_version_label = "対象バージョン: {value}"
     done_ratio_label = "進捗率: {value}%"
     estimated_hours_label = "予定工数: {value} h"
+    template_label = "テンプレート: {value}"
 
     # ---- init flow ----
     api_key_url_hint = "APIキーは {url}/my/account で確認できます"
@@ -222,6 +223,8 @@ class Ja(MessagesProto):
     prompt_parent_page = "親ページ"
     prompt_edit_page = "編集するページ"
     prompt_select_tracker = "トラッカーを選択"
+    prompt_select_template = "テンプレートを選択"
+    prompt_select_template_none = "（テンプレートを使用しない）"
     prompt_select_status = "ステータス"
     prompt_select_priority = "優先度"
     prompt_select_assignee = "担当者"


### PR DESCRIPTION
resolve #237

## 概要
#232 で追加した `issue_template` で取得できるテンプレートを、`issue create` の対話フローで選択して使えるようにしました。

- 選択したテンプレートの `issue_title` を題名の初期値として反映
- `description` をエディタを開いた際の初期値として反映

## 変更内容
- `fetch_enabled_issue_templates()` を追加
  - create フロー用にプロジェクトの有効なテンプレートを取得する
  - redmine_issue_templates プラグイン未インストール時 (404) は `exit` せず空リストを返し、create を中断しない
  - 選択中のトラッカーに紐づくテンプレートのみに絞り込む
- 対話的な `issue create` でトラッカー選択後にテンプレート選択ステップを追加
  - テンプレートが無い場合は選択ステップ自体をスキップ
  - 「（テンプレートを使用しない）」も選択可能
- i18n に `prompt_select_template` / `prompt_select_template_none` / `template_label` を追加 (en/ja)

## Test plan
- [x] テンプレートを選択し、題名・説明の初期値に反映されることを確認
- [x] 「テンプレートを使用しない」を選択した場合、従来どおり空の初期値になることを確認
- [x] プラグイン未インストールのプロジェクトでも `issue create` が中断されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)