### PR TITLE
feat: CLIでの項目選択/チェック時に gg/G で先頭・末尾へ移動できるようにする

### DIFF
--- a/src/redi/cli/picker.py
+++ b/src/redi/cli/picker.py
@@ -42,6 +42,16 @@ def inline_checkbox(
         nonlocal cursor
         cursor = min(len(values) - 1, cursor + 1)
 
+    @kb.add("g", "g")
+    def _top(event):
+        nonlocal cursor
+        cursor = 0
+
+    @kb.add("G")
+    def _bottom(event):
+        nonlocal cursor
+        cursor = len(values) - 1
+
     @kb.add(" ")
     def _toggle(event):
         value = values[cursor][0]
@@ -112,6 +122,16 @@ def inline_choice(
     def _down(event):
         nonlocal cursor
         cursor = min(len(options) - 1, cursor + 1)
+
+    @kb.add("g", "g")
+    def _top(event):
+        nonlocal cursor
+        cursor = 0
+
+    @kb.add("G")
+    def _bottom(event):
+        nonlocal cursor
+        cursor = len(options) - 1
 
     @kb.add("enter")
     def _accept(event):


### PR DESCRIPTION
## 概要

closes #239

issue update / wiki update などの選択 UI で、項目が多い時に1つずつしか移動できず大変だったため、vim 風の `gg`/`G` で先頭・末尾へジャンプできるようにしました。

## 変更内容

共通の選択 UI である `src/redi/cli/picker.py` の `inline_choice` / `inline_checkbox` の両関数にキーバインドを追加しました。これらは issue update・wiki update を含むすべての選択 UI で利用されています。

- `gg` → 先頭へ移動
- `G` → 末尾へ移動

既存の `j`/`k`・矢印キーと同じスタイルで実装しています。

## Test plan

- [x] `task check` (format / lint / typecheck / test) が通ること
- [x] issue update の選択画面で `gg` で先頭、`G` で末尾に移動できること
- [x] wiki update の選択画面で `gg` で先頭、`G` で末尾に移動できること
- [x] チェックボックス選択（更新項目選択）でも `gg`/`G` が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)