### PR TITLE
feat: issue create/update 失敗時に本文を一時ファイルへ退避する #246

### DIFF
--- a/src/redi/cli/editor.py
+++ b/src/redi/cli/editor.py
@@ -22,3 +22,16 @@ def open_editor(initial_text: str = "") -> str:
             return f.read().strip()
     finally:
         os.unlink(tmp_path)
+
+
+def save_text_to_tempfile(text: str) -> str:
+    """text を一時ファイルに保存してそのパスを返す(呼び出し側で削除しない)。
+
+    issue create/update などが失敗したときに、エディタで記載した本文が
+    失われないよう退避させる用途で使う。
+    """
+    with tempfile.NamedTemporaryFile(
+        prefix="redi-", suffix=".md", mode="w", delete=False
+    ) as f:
+        f.write(text)
+        return f.name

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -6,7 +6,7 @@ from datetime import date
 from prompt_toolkit import prompt
 
 from redi.cli.alias import resolve_alias
-from redi.cli.editor import open_editor
+from redi.cli.editor import open_editor, save_text_to_tempfile
 from redi.cli.keybinding import (
     date_key_bindings,
     digit_and_period_key_bindings,
@@ -891,6 +891,14 @@ def _interactive_select_issue_template(
     return template
 
 
+def _save_body_on_failure(text: str) -> None:
+    """送信失敗時に、エディタで記載した本文を一時ファイルへ退避する。"""
+    if not text:
+        return
+    path = save_text_to_tempfile(text)
+    print(messages.body_saved_to_tempfile.format(path=path))
+
+
 def handle_issue_create(args: argparse.Namespace) -> None:
     project_id = args.project_id or default_project_id
     if not project_id:
@@ -938,6 +946,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             tracker_id=tracker_id,
             existing=args.custom_fields,
         )
+    description_from_editor = args.description is None
     if args.description is None:
         description = open_editor(initial_text=template_description)
         if description:
@@ -992,20 +1001,25 @@ def handle_issue_create(args: argparse.Namespace) -> None:
                 webbrowser.open(url)
                 return
             break
-    create_issue(
-        project_id=project_id,
-        subject=subject,
-        description=description,
-        tracker_id=tracker_id,
-        priority_id=args.priority_id,
-        assigned_to_id=args.assigned_to_id,
-        fixed_version_id=args.fixed_version_id,
-        parent_issue_id=args.parent_issue_id,
-        start_date=args.start_date,
-        due_date=args.due_date,
-        estimated_hours=args.estimated_hours,
-        custom_fields=custom_fields,
-    )
+    try:
+        create_issue(
+            project_id=project_id,
+            subject=subject,
+            description=description,
+            tracker_id=tracker_id,
+            priority_id=args.priority_id,
+            assigned_to_id=args.assigned_to_id,
+            fixed_version_id=args.fixed_version_id,
+            parent_issue_id=args.parent_issue_id,
+            start_date=args.start_date,
+            due_date=args.due_date,
+            estimated_hours=args.estimated_hours,
+            custom_fields=custom_fields,
+        )
+    except Exception:
+        if description_from_editor:
+            _save_body_on_failure(description)
+        raise
 
 
 def handle_issue_update(args: argparse.Namespace) -> None:
@@ -1037,9 +1051,11 @@ def handle_issue_update(args: argparse.Namespace) -> None:
     if no_args_provided:
         _interactive_fill_issue_update_args(args)
     description = args.description
+    description_from_editor = False
     if description is not None and description == "":
         current = fetch_issue(args.issue_id)
         description = open_editor(current.get("description") or "")
+        description_from_editor = True
     should_update_issue = (
         args.subject
         or description is not None
@@ -1062,24 +1078,29 @@ def handle_issue_update(args: argparse.Namespace) -> None:
     )
     should_create_time_entry = args.hours is not None
     if should_update_issue:
-        update_issue(
-            issue_id=args.issue_id,
-            subject=args.subject,
-            description=description if description else None,
-            tracker_id=args.tracker_id,
-            status_id=args.status_id,
-            priority_id=args.priority_id,
-            assigned_to_id=args.assigned_to_id,
-            fixed_version_id=args.fixed_version_id,
-            parent_issue_id=args.parent_issue_id,
-            start_date=args.start_date,
-            due_date=args.due_date,
-            done_ratio=args.done_ratio,
-            estimated_hours=args.estimated_hours,
-            notes=args.notes or "",
-            custom_fields=args.custom_fields,
-            attachments=args.attach,
-        )
+        try:
+            update_issue(
+                issue_id=args.issue_id,
+                subject=args.subject,
+                description=description if description else None,
+                tracker_id=args.tracker_id,
+                status_id=args.status_id,
+                priority_id=args.priority_id,
+                assigned_to_id=args.assigned_to_id,
+                fixed_version_id=args.fixed_version_id,
+                parent_issue_id=args.parent_issue_id,
+                start_date=args.start_date,
+                due_date=args.due_date,
+                done_ratio=args.done_ratio,
+                estimated_hours=args.estimated_hours,
+                notes=args.notes or "",
+                custom_fields=args.custom_fields,
+                attachments=args.attach,
+            )
+        except Exception:
+            if description_from_editor and description:
+                _save_body_on_failure(description)
+            raise
     if args.delete_relation:
         if not args.relate_to:
             print(messages.delete_relation_requires_to)

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -946,7 +946,6 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             tracker_id=tracker_id,
             existing=args.custom_fields,
         )
-    description_from_editor = args.description is None
     if args.description is None:
         description = open_editor(initial_text=template_description)
         if description:
@@ -1017,8 +1016,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             custom_fields=custom_fields,
         )
     except Exception:
-        if description_from_editor:
-            _save_body_on_failure(description)
+        _save_body_on_failure(description)
         raise
 
 
@@ -1051,11 +1049,9 @@ def handle_issue_update(args: argparse.Namespace) -> None:
     if no_args_provided:
         _interactive_fill_issue_update_args(args)
     description = args.description
-    description_from_editor = False
     if description is not None and description == "":
         current = fetch_issue(args.issue_id)
         description = open_editor(current.get("description") or "")
-        description_from_editor = True
     should_update_issue = (
         args.subject
         or description is not None
@@ -1098,8 +1094,7 @@ def handle_issue_update(args: argparse.Namespace) -> None:
                 attachments=args.attach,
             )
         except Exception:
-            if description_from_editor and description:
-                _save_body_on_failure(description)
+            _save_body_on_failure(description)
             raise
     if args.delete_relation:
         if not args.relate_to:

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -67,6 +67,8 @@ class MessagesProto(Protocol):
     """--delete-relation には --to が必要"""
     relate_and_to_required: str
     """--relate と --to は両方指定する"""
+    body_saved_to_tempfile: str
+    """送信に失敗したため本文を一時ファイルに保存。{path}"""
 
     # ---- not found ----
     role_not_found: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -35,6 +35,9 @@ class En(MessagesProto):
     issue_or_project_id_required = "Specify issue_id or project_id"
     delete_relation_requires_to = "--delete-relation requires --to"
     relate_and_to_required = "Specify both --relate and --to"
+    body_saved_to_tempfile = (
+        "Submission failed; saved the body to a temporary file: {path}"
+    )
 
     # ---- not found ----
     role_not_found = "Role not found: #{id}"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -35,6 +35,9 @@ class Ja(MessagesProto):
     issue_or_project_id_required = "issue_idまたはproject_idを指定してください"
     delete_relation_requires_to = "--delete-relation には --to が必要です"
     relate_and_to_required = "--relate と --to は両方指定してください"
+    body_saved_to_tempfile = (
+        "送信に失敗したため、本文を一時ファイルに保存しました: {path}"
+    )
 
     # ---- not found ----
     role_not_found = "ロールが見つかりません: #{id}"

--- a/tests/unit/cli/test_editor.py
+++ b/tests/unit/cli/test_editor.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+from redi.cli.editor import save_text_to_tempfile
+
+
+class TestSaveTextToTempfile:
+    """save_text_to_tempfile はテキストを削除されない一時ファイルへ保存する"""
+
+    def test_writes_text_and_returns_path(self):
+        """書き込んだ内容が保存され、パスが返る"""
+        text = "保存したい本文\n複数行"
+        path = save_text_to_tempfile(text)
+        try:
+            assert Path(path).read_text() == text
+            assert path.endswith(".md")
+        finally:
+            os.unlink(path)
+
+    def test_file_is_not_deleted(self):
+        """呼び出し後もファイルが残っている(open_editor と異なり削除しない)"""
+        path = save_text_to_tempfile("残るべき内容")
+        try:
+            assert Path(path).exists()
+        finally:
+            os.unlink(path)

--- a/tests/unit/cli/test_issue_command.py
+++ b/tests/unit/cli/test_issue_command.py
@@ -1,0 +1,45 @@
+import os
+from pathlib import Path
+
+from redi.cli import issue_command
+
+
+class TestSaveBodyOnFailure:
+    """_save_body_on_failure は本文を退避し、保存先を通知する"""
+
+    def test_saves_non_empty_body(self, monkeypatch, capsys):
+        """本文があれば一時ファイルへ保存し、パスを出力する"""
+        saved: list[str] = []
+
+        def fake_save(text: str) -> str:
+            saved.append(text)
+            return "/tmp/redi-test.md"
+
+        monkeypatch.setattr(issue_command, "save_text_to_tempfile", fake_save)
+        issue_command._save_body_on_failure("失われたくない本文")
+
+        assert saved == ["失われたくない本文"]
+        assert "/tmp/redi-test.md" in capsys.readouterr().out
+
+    def test_skips_empty_body(self, monkeypatch, capsys):
+        """本文が空なら保存もせず、何も出力しない"""
+        called = False
+
+        def fake_save(text: str) -> str:
+            nonlocal called
+            called = True
+            return "x"
+
+        monkeypatch.setattr(issue_command, "save_text_to_tempfile", fake_save)
+        issue_command._save_body_on_failure("")
+
+        assert called is False
+        assert capsys.readouterr().out == ""
+
+    def test_round_trip_with_real_helper(self):
+        """実際の save_text_to_tempfile 経由で本文がファイルに残る"""
+        path = issue_command.save_text_to_tempfile("round trip")
+        try:
+            assert Path(path).read_text() == "round trip"
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
resolve #246

## なぜ

issue の create/update では `--description` を省略するとエディタが開いて本文を編集できるが、エディタを閉じた後に送信が失敗すると、入力した本文が失われてしまう。エディタ用の一時ファイルは閉じた時点で削除されるため、内容を復元する手段がない。

## 変更内容

- `redi.cli.editor.save_text_to_tempfile(text)` を追加。テキストを削除しない一時ファイル(`redi-*.md`)へ保存しパスを返す。
- issue create / update で送信(`create_issue` / `update_issue`)が失敗した場合に、本文を一時ファイルへ退避し保存先を表示するようにした。
    - エディタ経由で入力した本文だけでなく、`--description` で渡した本文も退避する。
- i18n キー `body_saved_to_tempfile` を追加(ja/en)。

## Test plan

- [x] エディタで本文を入力し、バリデーションエラー等で create/update が失敗したときに本文が一時ファイルへ保存され、保存先が表示される
- [x] `--description` で本文を渡した場合も、失敗時に退避される
- [x] 送信が成功した場合は一時ファイルを作らない
- [x] `task check` が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

制約付きのカスタムフィールドに違反することで動作を確認した

```
$ redi i c
トラッカー: バグ
題名: a
3文字以内（必須）: aaaa
説明 (description): NG
送信に失敗したため、本文を一時ファイルに保存しました: /tmp/redi-_pg5oxrh.md
issueの作成に失敗しました(入力エラー):
- 3文字以内 is too long (maximum is 3 characters)
```

```
$ redi i c title --description asdfasdfa
送信に失敗したため、本文を一時ファイルに保存しました: /tmp/redi-e1khm055.md
issueの作成に失敗しました(入力エラー):
- 3文字以内 cannot be blank
```
