### PR TITLE
[issue update(interactive)] カスタムフィールドに対応

### DIFF
--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -45,10 +45,18 @@ class Issue(TypedDict):
     total_estimated_hours: float | None
     spent_hours: float
     total_spent_hours: float
+    # GET /issues/{id}では含まれる
+    custom_fields: NotRequired[list[IssueCustomField]]
     created_on: str
     updated_on: str
     closed_on: str | None
     journals: NotRequired[list[Journal]]
+
+
+class IssueCustomField(TypedDict):
+    id: int
+    name: str
+    value: str
 
 
 class IssueStatus(TypedDict):

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -56,7 +56,9 @@ class Issue(TypedDict):
 class IssueCustomField(TypedDict):
     id: int
     name: str
-    value: str
+    # valueがlist[str] の時に True
+    multiple: NotRequired[bool]
+    value: str | list[str]
 
 
 class IssueStatus(TypedDict):

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -555,8 +555,8 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
                 continue
             custom_field_for_prompt = custom_field
             current_value = current_cf_values.get(custom_field["id"])
-            if isinstance(current_value, str) and current_value:
-                # 現在値を入力のデフォルトとして提示する
+            # 文字列・複数選択(リスト)いずれの現在値も入力のデフォルトとして提示する
+            if current_value:
                 custom_field_for_prompt = cast(
                     CustomField, {**custom_field, "default_value": current_value}
                 )
@@ -599,26 +599,32 @@ def _choose_from_options(
     label: str,
     options: list[tuple[str, str]],
     multiple: bool,
-    default_value: str,
+    default_value: str | list[str],
 ) -> str | list[str] | object:
     """選択肢からの入力を取得する共通処理。空オプションは _SKIP_UNSUPPORTED_FIELD を返す。"""
     if not options:
         return _SKIP_UNSUPPORTED_FIELD
     label_map = dict(options)
     if multiple:
+        # 複数選択の現在値(リスト)はそのまま、単一値は1要素のリストにして初期チェックする
+        if isinstance(default_value, list):
+            initial_checked = default_value
+        else:
+            initial_checked = [default_value] if default_value else None
         # 空選択は受け付けず、最低 1 つチェックされるまで再表示する
         while True:
             checked = inline_checkbox(
                 label,
                 options,
-                initial_checked=[default_value] if default_value else None,
+                initial_checked=initial_checked,
             )
             if checked:
                 break
         display = ", ".join(label_map[k] for k in checked)
         print(messages.prompt_field_value.format(name=name, value=display))
         return checked
-    key = inline_choice(label, options, default=default_value or None)
+    default_key = default_value[0] if isinstance(default_value, list) else default_value
+    key = inline_choice(label, options, default=default_key or None)
     print(messages.prompt_field_value.format(name=name, value=label_map[key]))
     return key
 

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -2,6 +2,7 @@ import argparse
 import urllib.parse
 import webbrowser
 from datetime import date
+from typing import cast
 
 from prompt_toolkit import prompt
 
@@ -346,6 +347,27 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         ("notes", messages.field_notes),
         ("time_entry", messages.field_time_entry),
     ]
+    # 対象イシューのプロジェクト/トラッカーに該当するカスタムフィールドを選択肢に並べる
+    issue_project_id = current.get("project").get("id")
+    issue_tracker_id = current.get("tracker").get("id")
+    applicable_custom_fields: list[CustomField] = []
+    all_custom_fields = fetch_custom_fields()
+    if all_custom_fields is not None:
+        project_custom_field_ids = fetch_project_issue_custom_field_ids(
+            str(issue_project_id)
+        )
+        tracker_id_str = str(issue_tracker_id)
+        applicable_custom_fields = filter_required_issue_custom_fields(
+            all_custom_fields,
+            project_custom_field_ids,
+            tracker_id_str,
+        ) + filter_optional_issue_custom_fields(
+            all_custom_fields,
+            project_custom_field_ids,
+            tracker_id_str,
+        )
+        for custom_field in applicable_custom_fields:
+            field_values.append((f"cf_{custom_field['id']}", custom_field["name"]))
     try:
         selected = inline_checkbox(
             messages.prompt_select_update_items,
@@ -522,6 +544,39 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
                 or None
             )
             args.time_comments = prompt(messages.prompt_time_comments).strip() or None
+        # 選択されたカスタムフィールドの値を入力する
+        current_cf_values = {
+            custome_field["id"]: custome_field.get("value")
+            for custome_field in (current.get("custom_fields") or [])
+        }
+        added_custom_fields: list[str] = []
+        for custom_field in applicable_custom_fields:
+            if f"cf_{custom_field['id']}" not in selected:
+                continue
+            custom_field_for_prompt = custom_field
+            current_value = current_cf_values.get(custom_field["id"])
+            if isinstance(current_value, str) and current_value:
+                # 現在値を入力のデフォルトとして提示する
+                custom_field_for_prompt = cast(
+                    CustomField, {**custom_field, "default_value": current_value}
+                )
+            custom_field_value = _prompt_custom_field_value(
+                custom_field_for_prompt, str(issue_project_id)
+            )
+            if custom_field_value is _SKIP_UNSUPPORTED_FIELD:
+                continue
+            if isinstance(custom_field_value, list):
+                for v in custom_field_value:
+                    added_custom_fields.append(f"{custom_field['id']}={v}")
+            else:
+                added_custom_fields.append(f"{custom_field['id']}={custom_field_value}")
+        if added_custom_fields:
+            if args.custom_fields:
+                args.custom_fields = (
+                    args.custom_fields + "," + ",".join(added_custom_fields)
+                )
+            else:
+                args.custom_fields = ",".join(added_custom_fields)
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
         exit(1)

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -711,7 +711,9 @@ def _prompt_custom_field_value(
             progress_options: list[tuple[str, str]] = [
                 (str(r), f"{r}%") for r in range(0, 101, 10)
             ]
-            value = inline_choice(label, progress_options)
+            value = inline_choice(
+                label, progress_options, default=default_value or None
+            )
             print(messages.prompt_field_value.format(name=name, value=f"{value}%"))
             return value
 

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -546,8 +546,8 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
             args.time_comments = prompt(messages.prompt_time_comments).strip() or None
         # 選択されたカスタムフィールドの値を入力する
         current_cf_values = {
-            custome_field["id"]: custome_field.get("value")
-            for custome_field in (current.get("custom_fields") or [])
+            custom_field["id"]: custom_field.get("value")
+            for custom_field in (current.get("custom_fields") or [])
         }
         added_custom_fields: list[str] = []
         for custom_field in applicable_custom_fields:


### PR DESCRIPTION
## 対応内容

- GET /issues.json で含まれるカスタムフィールドの型を記載
- issue updateコマンドでカスタムフィールドを更新出来るようにした

## 動作確認

- [x] 以下の形式のカスタムフィールドを更新出来ることを確認した
    - テキスト
    - バージョン
    - リスト
    - リンク
    - 小数
    - 整数
    - 日付
    - 真偽値
    - 進捗バー

- [x] 以下の形式のカスタムフィールドを更新する際に過去の入力値が引き継がれていることを確認した
    - テキスト
    - バージョン
    - リスト
    - リンク
    - 小数
    - 整数
    - 日付
    - 真偽値
    - 進捗バー
