### PR TITLE
fix(cli): picker の cursor 初期化に is not None を明示する

### DIFF
--- a/src/redi/cli/picker.py
+++ b/src/redi/cli/picker.py
@@ -11,7 +11,11 @@ def inline_checkbox(
     initial_checked: list[str] | None = None,
 ) -> list[str]:
     keys = [v for v, _ in values]
-    cursor = keys.index(initial_value) if initial_value in keys else 0
+    cursor = (
+        keys.index(initial_value)
+        if initial_value is not None and initial_value in keys
+        else 0
+    )
     checked: set[str] = {v for v in (initial_checked or []) if v in keys}
 
     def render():
@@ -98,7 +102,7 @@ def inline_choice(
     default: str | None = None,
 ) -> str:
     keys = [v for v, _ in options]
-    cursor = keys.index(default) if default in keys else 0
+    cursor = keys.index(default) if default is not None and default in keys else 0
 
     def render():
         fragments: list[tuple[str, str]] = []


### PR DESCRIPTION
## 概要

PR #267 (ty 0.0.59 → 0.0.62) の typecheck が失敗する原因の修正です。

ty 0.0.62 では `in` メンバーシップテストによる narrowing の挙動が変更され ([Make membership and equality narrowing consistent (astral-sh/ruff#26982)](https://github.com/astral-sh/ruff/pull/26982))、`x in list[str]` の真の分岐でも `str | None` から `None` が除去されなくなりました。その結果 `src/redi/cli/picker.py` の 2 箇所 (`inline_checkbox` / `inline_choice` の cursor 初期化) が `list.index(str)` への `invalid-argument-type` と判定されます。

`is not None` を明示して narrowing が確実に効くようにします。実行時の挙動は変わりません (`None in list[str]` は常に False のため)。

## 確認

- `uvx ty@0.0.62 check` → All checks passed! (修正前は 2 diagnostics)
- `task check` (ty 0.0.59 + テスト 303 passed) 通過

マージ後、#267 に `@dependabot rebase` をコメントすれば typecheck が通る想定です。