### PR TITLE
feat(tui): ヘルプダイアログの右下にバージョンを表示する

### DIFF
--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -383,7 +383,7 @@ def _render_help(state: TuiState) -> Renderable:
     label = _help_version_label()
     padding = max(0, body_width - get_cwidth(label))
     parts.append(("", "\n"))
-    parts.append(("fg:ansibrightblack", f"{' ' * padding}{label}"))
+    parts.append(("fg:ansiwhite", f"{' ' * padding}{label}"))
     return parts
 
 

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -1,5 +1,6 @@
 import shutil
 from datetime import datetime
+from importlib.metadata import version
 from pathlib import Path
 
 import requests
@@ -17,6 +18,7 @@ from prompt_toolkit.layout.containers import (
     Window,
 )
 from prompt_toolkit.layout.controls import FormattedTextControl
+from prompt_toolkit.utils import get_cwidth
 from prompt_toolkit.widgets import Frame
 
 from redi.api.issue_status import fetch_issue_statuses
@@ -356,20 +358,32 @@ def _render_time_entry_filter_modal(state: TuiState) -> Renderable:
     return parts
 
 
+def _help_version_label() -> str:
+    return f"redi v{version('redtile')}"
+
+
 def _render_help(state: TuiState) -> Renderable:
     lines = TABS[state.tab].help_lines
     width = max(len(key) for key, _ in lines) + 2
     parts: Renderable = []
     seen_section = False
+    # バージョン行を右下に寄せるため、本文の最大表示幅 (CJK は2セル) を測る
+    body_width = 0
     for key, desc in lines:
         if not desc:
             if seen_section:
                 parts.append(("", "\n"))
             parts.append(("bold", f"{key}\n"))
             seen_section = True
+            body_width = max(body_width, get_cwidth(key))
         else:
             parts.append(("bold fg:ansicyan", key.ljust(width)))
             parts.append(("", f"  {desc}\n"))
+            body_width = max(body_width, width + 2 + get_cwidth(desc))
+    label = _help_version_label()
+    padding = max(0, body_width - get_cwidth(label))
+    parts.append(("", "\n"))
+    parts.append(("fg:ansibrightblack", f"{' ' * padding}{label}"))
     return parts
 
 

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -1,4 +1,7 @@
+from prompt_toolkit.utils import get_cwidth
+
 from redi.tui import app
+from redi.tui.state import TuiState
 
 
 class TestBuildUserChoices:
@@ -89,3 +92,31 @@ class TestBuildAssigneeChoices:
         )
         choices = app._build_assignee_choices("1", me_id="999")
         assert [v for v, _ in choices] == [None, "me", "!*", "5"]
+
+
+def _rendered_lines(parts) -> list[str]:
+    return "".join(text for _style, text in parts).split("\n")
+
+
+class TestRenderHelp:
+    """_render_help() は各タブのヘルプ本文と末尾のバージョンを組み立てる"""
+
+    def test_shows_version_at_last_line(self):
+        """最終行に redi のバージョンを表示する"""
+        lines = _rendered_lines(app._render_help(TuiState()))
+        assert lines[-1].strip() == app._help_version_label()
+
+    def test_version_line_is_right_aligned(self):
+        """バージョン行は本文の最大幅に右寄せする (右下に表示)"""
+        for tab in app.TABS:
+            state = TuiState()
+            state.tab = tab
+            lines = _rendered_lines(app._render_help(state))
+            body_width = max(get_cwidth(line) for line in lines[:-1])
+            assert get_cwidth(lines[-1]) == body_width
+            assert lines[-1].endswith(app._help_version_label())
+
+    def test_blank_line_before_version(self):
+        """バージョン行の直前は空行にして本文と分ける"""
+        lines = _rendered_lines(app._render_help(TuiState()))
+        assert lines[-2] == ""


### PR DESCRIPTION
## 概要

TUI の各タブのヘルプダイアログ (`?`) の右下に、利用中の redi のバージョンを表示するようにした。

Closes #271

## 変更内容

- `_render_help()` の末尾に空行 + 右寄せのバージョン行 (`redi vX.Y.Z`) を追加
  - バージョンは `importlib.metadata.version("redtile")` から取得 (CLI の `--version` と同じソース)
  - 右寄せ幅は本文の最大表示幅を `get_cwidth()` で計測して算出 (日本語の 2 セル幅に対応)
- `tests/unit/tui/test_app.py` に `_render_help()` のテストを追加 (最終行がバージョン / 全タブで右寄せ / 直前が空行)

## 表示例 (wiki タブ / 日本語)

```
その他
  ?                  このヘルプを表示 / 閉じる
  q / Ctrl+C         終了

                                                 redi v0.0.45
```

## 確認

- `task check` (format, lint, typecheck, test) がパス