### PR TITLE
fix(api): プロジェクト一覧を全ページ取得する

### DIFF
--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -12,6 +12,9 @@ from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
 
+# Redmine の一覧 API が 1 リクエストで返せる上限
+PROJECTS_PAGE_LIMIT = 100
+
 
 class Project(TypedDict):
     """redmine Project
@@ -50,10 +53,25 @@ def list_projects(full: bool = False) -> None:
 
 
 def fetch_projects() -> list[Project]:
-    response = client.get("/projects.json")
-    response.raise_for_status()
-    data = response.json()
-    return cast("list[Project]", data.get("projects", []))
+    """アクセスできるプロジェクトを全件返す。
+
+    Redmine の一覧 API は limit 未指定だと既定件数しか返さないため、
+    `total_count` を見て全件揃うまで offset を進める。
+    """
+    projects: list[Project] = []
+    offset = 0
+    while True:
+        response = client.get(
+            "/projects.json", params={"limit": PROJECTS_PAGE_LIMIT, "offset": offset}
+        )
+        response.raise_for_status()
+        data = response.json()
+        page = cast("list[Project]", data.get("projects", []))
+        projects.extend(page)
+        total_count = data.get("total_count")
+        if not page or total_count is None or len(projects) >= total_count:
+            return projects
+        offset += len(page)
 
 
 def resolve_project_id(value: str) -> str:


### PR DESCRIPTION
## 概要

Closes #283

プロジェクト切替モーダルに一部のプロジェクトしか表示されず、それ以外のプロジェクトへ TUI 上で切り替えられなかった問題を修正する。

## 原因

`fetch_projects()` が `GET /projects.json` を limit 未指定で呼んでいた。Redmine の一覧 API は limit 未指定だと既定件数(25件)しか返さないため、それ以降のプロジェクトが取得できていなかった。

## 変更内容

`fetch_projects()` で `total_count` を見ながら全件揃うまで offset を進めるようにした。1 リクエストあたりは Redmine の上限である 100 件。

この関数は TUI のプロジェクト切替モーダル(`open_project_modal` / `_build_project_choices`)のほか、`redi project list`、`resolve_project_id`、`redi time_entry` のプロジェクト選択からも使われるため、それらも全件を扱えるようになる。

## 動作確認

ローカル Redmine にダミープロジェクトを追加して33件の状態にし、比較した。

| | `redi project list` | TUI プロジェクト切替モーダル |
| --- | --- | --- |
| 修正前 | 25件 | 25件 |
| 修正後 | 33件 | 33件 |

`task check` (format / lint / typecheck / test) が通ることを確認済み。