### PR TITLE
feat(cli): attachment download コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ redi file create ./foo.zip -p <project_id> -d "description"
 
 # attachment (alias: a)
 redi attachment view <attachment_id>
+redi attachment download <attachment_id> # alias: dl, save with the original filename
+redi attachment download <attachment_id> -o ./dir_or_path # confirm before overwrite (-y to skip)
 redi attachment update <attachment_id> -f new_name.png -d "desc"
 redi attachment delete <attachment_id> # confirm before delete (-y to skip)
 

--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -50,7 +50,7 @@ def fetch_attachment(attachment_id: str) -> dict:
 
 
 def resolve_download_path(attachment: dict, output: str | None) -> Path:
-    filename = os.path.basename(attachment["filename"]) or str(attachment["id"])
+    filename = Path(attachment["filename"]).name or str(attachment["id"])
     if output is None:
         return Path(filename)
     path = Path(output).expanduser()

--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -1,6 +1,7 @@
 import json
 import mimetypes
 import os
+from pathlib import Path
 
 import requests
 
@@ -8,6 +9,8 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 
 
 def upload_file(file_path: str) -> dict:
@@ -44,6 +47,48 @@ def fetch_attachment(attachment_id: str) -> dict:
         exit(1)
     response.raise_for_status()
     return response.json()["attachment"]
+
+
+def resolve_download_path(attachment: dict, output: str | None) -> Path:
+    filename = os.path.basename(attachment["filename"]) or str(attachment["id"])
+    if output is None:
+        return Path(filename)
+    path = Path(output).expanduser()
+    if path.is_dir():
+        return path / filename
+    return path
+
+
+def resolve_download_url_path(attachment: dict) -> str:
+    # API キーを他ホストへ送らないよう、redmine_url 配下でない content_url は使わない
+    content_url = attachment.get("content_url") or ""
+    if not redmine_url or not content_url.startswith(redmine_url):
+        print(messages.attachment_content_url_unexpected.format(url=content_url))
+        exit(1)
+    return content_url[len(redmine_url) :]
+
+
+def download_attachment(attachment: dict, path: Path) -> None:
+    response = client.get(resolve_download_url_path(attachment), stream=True)
+    if response.status_code == 404:
+        print(messages.attachment_not_found.format(id=attachment["id"]))
+        exit(1)
+    try:
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        print(e)
+        print_http_error_body(e)
+        print(messages.attachment_download_failed)
+        exit(1)
+    try:
+        with open(path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                f.write(chunk)
+    except OSError as e:
+        print(e)
+        print(messages.attachment_download_failed)
+        exit(1)
+    print(messages.attachment_downloaded.format(path=path))
 
 
 def read_attachment(attachment_id: str, full: bool = False) -> None:

--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import requests
 
 from redi.api.exceptions import print_http_error_body
+from redi.api.types import Attachment
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -40,7 +41,7 @@ def upload_file(file_path: str) -> dict:
     }
 
 
-def fetch_attachment(attachment_id: str) -> dict:
+def fetch_attachment(attachment_id: str) -> Attachment:
     response = client.get(f"/attachments/{attachment_id}.json")
     if response.status_code == 404:
         print(messages.attachment_not_found.format(id=attachment_id))
@@ -49,7 +50,7 @@ def fetch_attachment(attachment_id: str) -> dict:
     return response.json()["attachment"]
 
 
-def resolve_download_path(attachment: dict, output: str | None) -> Path:
+def resolve_download_path(attachment: Attachment, output: str | None) -> Path:
     filename = Path(attachment["filename"]).name or str(attachment["id"])
     if output is None:
         return Path(filename)
@@ -59,7 +60,7 @@ def resolve_download_path(attachment: dict, output: str | None) -> Path:
     return path
 
 
-def resolve_download_url_path(attachment: dict) -> str:
+def resolve_download_url_path(attachment: Attachment) -> str:
     # API キーを他ホストへ送らないよう、redmine_url 配下でない content_url は使わない
     content_url = attachment.get("content_url") or ""
     if not redmine_url or not content_url.startswith(redmine_url):
@@ -68,7 +69,7 @@ def resolve_download_url_path(attachment: dict) -> str:
     return content_url[len(redmine_url) :]
 
 
-def download_attachment(attachment: dict, path: Path) -> None:
+def download_attachment(attachment: Attachment, path: Path) -> None:
     response = client.get(resolve_download_url_path(attachment), stream=True)
     if response.status_code == 404:
         print(messages.attachment_not_found.format(id=attachment["id"]))

--- a/src/redi/api/types.py
+++ b/src/redi/api/types.py
@@ -9,3 +9,19 @@ class IdName(TypedDict):
 
     id: int
     name: str
+
+
+class Attachment(TypedDict):
+    """添付ファイル。
+
+    GET /attachments/{id}.json や include=attachments で返るフィールドを記載。
+    """
+
+    id: int
+    filename: str
+    filesize: int  # bytes
+    content_type: str  # ex. text/plain
+    description: str
+    content_url: str
+    author: IdName
+    created_on: str

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -8,7 +8,7 @@ from typing import NotRequired, TypedDict, cast
 import requests
 
 from redi.api.exceptions import RedmineValidationException, print_http_error_body
-from redi.api.types import IdName
+from redi.api.types import Attachment, IdName
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
@@ -34,26 +34,13 @@ class WikiPage(TypedDict):
     author: NotRequired[IdName]
     comments: NotRequired[str]
     # include=attachments 指定時のみ存在
-    attachments: NotRequired[list[WikiAttachment]]
+    attachments: NotRequired[list[Attachment]]
 
 
 class WikiPageParent(TypedDict):
     """Wiki ページの親ページ参照。`title` のみを持つ。"""
 
     title: str
-
-
-class WikiAttachment(TypedDict):
-    """Wiki ページの添付ファイル。include=attachments 指定時に含まれる。"""
-
-    id: int
-    filename: str
-    filesize: int  # bytes
-    content_type: str  # ex. text/plain
-    description: str
-    content_url: str
-    author: IdName
-    created_on: str
 
 
 class WikiPageUpdateBody(TypedDict):

--- a/src/redi/cli/alias.py
+++ b/src/redi/cli/alias.py
@@ -4,6 +4,7 @@ SUBCOMMAND_ALIASES: dict[str, str] = {
     "u": "update",
     "co": "comment",
     "d": "delete",
+    "dl": "download",
     "l": "list",
 }
 

--- a/src/redi/cli/attachment_command.py
+++ b/src/redi/cli/attachment_command.py
@@ -2,12 +2,14 @@ import argparse
 
 from redi.api.attachment import (
     delete_attachment,
+    download_attachment,
     fetch_attachment,
     read_attachment,
+    resolve_download_path,
     update_attachment,
 )
 from redi.cli.alias import resolve_alias
-from redi.cli.confirm import confirm_delete
+from redi.cli.confirm import confirm_delete, confirm_overwrite
 from redi.i18n import messages
 
 
@@ -30,6 +32,21 @@ def add_attachment_parser(
     )
     a_view_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
+    )
+    a_download_parser = a_subparsers.add_parser(
+        "download",
+        aliases=["dl"],
+        help=messages.arg_help_attachment_download,
+        parents=parents,
+    )
+    a_download_parser.add_argument(
+        "attachment_id", help=messages.arg_help_attachment_download_id
+    )
+    a_download_parser.add_argument(
+        "--output", "-o", help=messages.arg_help_attachment_output
+    )
+    a_download_parser.add_argument(
+        "-y", "--yes", action="store_true", help=messages.arg_help_skip_confirm
     )
     a_update_parser = a_subparsers.add_parser(
         "update",
@@ -64,6 +81,12 @@ def handle_attachment(args: argparse.Namespace) -> None:
     cmd = resolve_alias(args.attachment_command)
     if cmd == "view":
         read_attachment(args.attachment_id, full=args.full)
+    elif cmd == "download":
+        attachment = fetch_attachment(args.attachment_id)
+        path = resolve_download_path(attachment, args.output)
+        if path.exists() and not args.yes:
+            confirm_overwrite(messages.overwrite_target_file.format(path=path))
+        download_attachment(attachment, path)
     elif cmd == "update":
         update_attachment(
             attachment_id=args.attachment_id,

--- a/src/redi/cli/confirm.py
+++ b/src/redi/cli/confirm.py
@@ -15,6 +15,18 @@ def confirm_delete(summary: str) -> None:
         exit(1)
 
 
+def confirm_overwrite(summary: str) -> None:
+    print(summary)
+    try:
+        confirm = prompt(messages.prompt_confirm_overwrite).strip().lower()
+    except (KeyboardInterrupt, EOFError):
+        print(messages.canceled)
+        exit(1)
+    if confirm != "yes":
+        print(messages.canceled)
+        exit(1)
+
+
 def confirm_delete_with_identifier(
     summary: str, expected: str, field_label: str
 ) -> None:

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -196,6 +196,8 @@ class MessagesProto(Protocol):
     """{id}"""
     attachment_updated: str
     """{url}"""
+    attachment_downloaded: str
+    """{path}"""
     issue_journal_updated: str
     """{id}"""
     issue_journal_deleted: str
@@ -259,6 +261,9 @@ class MessagesProto(Protocol):
     time_entry_delete_failed: str
     attachment_delete_failed: str
     attachment_update_failed: str
+    attachment_download_failed: str
+    attachment_content_url_unexpected: str
+    """{url}"""
     issue_journal_update_failed: str
     issue_journal_delete_failed: str
     group_create_failed: str
@@ -327,6 +332,7 @@ class MessagesProto(Protocol):
 
     # ---- prompts (interactive input messages) ----
     prompt_confirm_delete: str
+    prompt_confirm_overwrite: str
     prompt_confirm_delete_with_identifier: str
     """{label}, {expected}"""
     prompt_subject: str
@@ -449,6 +455,8 @@ class MessagesProto(Protocol):
     """{id}, {kind}, {principal_id}, {principal_name}, {roles}"""
     delete_target_attachment: str
     """{id}, {filename}"""
+    overwrite_target_file: str
+    """{path}"""
     delete_target_issue_journal: str
     """{id}, {notes}"""
     delete_target_category: str
@@ -846,6 +854,9 @@ class MessagesProto(Protocol):
     arg_help_attachment_description: str
     arg_help_attachment_delete: str
     arg_help_attachment_delete_id: str
+    arg_help_attachment_download: str
+    arg_help_attachment_download_id: str
+    arg_help_attachment_output: str
 
     # ---- argparse helps (time entry) ----
     arg_help_time_entry_command: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -121,6 +121,7 @@ class En(MessagesProto):
     time_entry_deleted = "Deleted time entry: {id}"
     attachment_deleted = "Deleted attachment: #{id}"
     attachment_updated = "Updated attachment: {url}"
+    attachment_downloaded = "Saved attachment: {path}"
     issue_journal_updated = "Updated issue journal: #{id}"
     issue_journal_deleted = "Deleted issue journal: #{id}"
     group_updated = "Updated group: {id}"
@@ -169,6 +170,10 @@ class En(MessagesProto):
     time_entry_delete_failed = "Failed to delete time entry"
     attachment_delete_failed = "Failed to delete attachment"
     attachment_update_failed = "Failed to update attachment"
+    attachment_download_failed = "Failed to download attachment"
+    attachment_content_url_unexpected = (
+        "Aborted download because content_url is not under redmine_url: {url}"
+    )
     issue_journal_update_failed = "Failed to update issue journal"
     issue_journal_delete_failed = "Failed to delete issue journal"
     group_create_failed = "Failed to create group"
@@ -215,6 +220,7 @@ class En(MessagesProto):
 
     # ---- prompts ----
     prompt_confirm_delete = "Are you sure you want to delete? (yes/No): "
+    prompt_confirm_overwrite = "Are you sure you want to overwrite? (yes/No): "
     prompt_confirm_delete_with_identifier = (
         'Type {label} "{expected}" to confirm deletion: '
     )
@@ -330,6 +336,7 @@ class En(MessagesProto):
         "Membership to delete: {id} [{kind}] {principal_id} {principal_name} - {roles}"
     )
     delete_target_attachment = "Attachment to delete: {id} {filename}"
+    overwrite_target_file = "File already exists: {path}"
     delete_target_issue_journal = "Issue journal to delete: #{id} {notes}"
     delete_target_category = "Issue category to delete: {id} {name}"
     delete_target_group = "Group to delete: {id} {name}"
@@ -704,7 +711,7 @@ class En(MessagesProto):
     arg_help_issue_journal_delete_id = "Journal ID"
 
     # ---- argparse helps (attachment) ----
-    arg_help_attachment_command = "Attachment details/update/delete"
+    arg_help_attachment_command = "Attachment details/download/update/delete"
     arg_help_attachment_view = "Attachment details"
     arg_help_attachment_view_id = "Attachment ID"
     arg_help_attachment_update = "Update attachment"
@@ -713,6 +720,11 @@ class En(MessagesProto):
     arg_help_attachment_description = "Description"
     arg_help_attachment_delete = "Delete attachment"
     arg_help_attachment_delete_id = "Attachment ID"
+    arg_help_attachment_download = "Download attachment"
+    arg_help_attachment_download_id = "Attachment ID"
+    arg_help_attachment_output = (
+        "Output path (defaults to the original filename in the current directory)"
+    )
 
     # ---- argparse helps (time entry) ----
     arg_help_time_entry_command = (

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -125,6 +125,7 @@ class Ja(MessagesProto):
     time_entry_deleted = "作業時間を削除しました: {id}"
     attachment_deleted = "添付ファイルを削除しました: #{id}"
     attachment_updated = "添付ファイルを更新しました: {url}"
+    attachment_downloaded = "添付ファイルを保存しました: {path}"
     issue_journal_updated = "イシューのジャーナルを更新しました: #{id}"
     issue_journal_deleted = "イシューのジャーナルを削除しました: #{id}"
     group_updated = "グループを更新しました: {id}"
@@ -171,6 +172,10 @@ class Ja(MessagesProto):
     time_entry_delete_failed = "作業時間の削除に失敗しました"
     attachment_delete_failed = "添付ファイルの削除に失敗しました"
     attachment_update_failed = "添付ファイルの更新に失敗しました"
+    attachment_download_failed = "添付ファイルのダウンロードに失敗しました"
+    attachment_content_url_unexpected = (
+        "content_url が redmine_url 配下ではないためダウンロードを中止しました: {url}"
+    )
     issue_journal_update_failed = "イシューのジャーナルの更新に失敗しました"
     issue_journal_delete_failed = "イシューのジャーナルの削除に失敗しました"
     group_create_failed = "グループの作成に失敗しました"
@@ -217,6 +222,7 @@ class Ja(MessagesProto):
 
     # ---- prompts ----
     prompt_confirm_delete = "削除してもよろしいですか? (yes/No): "
+    prompt_confirm_overwrite = "上書きしてもよろしいですか? (yes/No): "
     prompt_confirm_delete_with_identifier = (
         '削除するには{label} "{expected}" を入力してください: '
     )
@@ -331,6 +337,7 @@ class Ja(MessagesProto):
     delete_target_wiki_page = "削除するWikiページ: {title}"
     delete_target_membership = "削除するメンバーシップ: {id} [{kind}] {principal_id} {principal_name} - {roles}"
     delete_target_attachment = "削除する添付ファイル: {id} {filename}"
+    overwrite_target_file = "既に存在するファイル: {path}"
     delete_target_issue_journal = "削除するイシューのジャーナル: #{id} {notes}"
     delete_target_category = "削除するイシューカテゴリ: {id} {name}"
     delete_target_group = "削除するグループ: {id} {name}"
@@ -717,7 +724,7 @@ class Ja(MessagesProto):
     arg_help_issue_journal_delete_id = "ジャーナルID"
 
     # ---- argparse helps (attachment) ----
-    arg_help_attachment_command = "添付ファイル詳細/更新/削除"
+    arg_help_attachment_command = "添付ファイル詳細/ダウンロード/更新/削除"
     arg_help_attachment_view = "添付ファイル詳細"
     arg_help_attachment_view_id = "添付ファイルID"
     arg_help_attachment_update = "添付ファイル更新"
@@ -726,6 +733,11 @@ class Ja(MessagesProto):
     arg_help_attachment_description = "説明"
     arg_help_attachment_delete = "添付ファイル削除"
     arg_help_attachment_delete_id = "添付ファイルID"
+    arg_help_attachment_download = "添付ファイルダウンロード"
+    arg_help_attachment_download_id = "添付ファイルID"
+    arg_help_attachment_output = (
+        "保存先パス(省略時はカレントディレクトリに元のファイル名で保存)"
+    )
 
     # ---- argparse helps (time entry) ----
     arg_help_time_entry_command = "list(l): 一覧, view(v): 詳細, create(c): 登録, update(u): 更新, delete(d): 削除"


### PR DESCRIPTION
## 概要

Redmine issue に添付された画像やファイルをローカルへ取得する手段が無かったため、`attachment` のサブコマンドとして `download` を追加する。

Closes #284

## 変更内容

- `redi attachment download <attachment_id>` (alias: `dl`)
- `-o` で保存先を指定でき、既存ディレクトリを渡した場合は元のファイル名を補う
- 保存先が既存の場合は上書き確認し、`-y` でスキップできる
- API キーを redmine_url 以外へ送らないよう、redmine_url 配下でない `content_url` を受け取った場合はダウンロードせず exit(1) する

```
redi attachment download <attachment_id>                    # カレントに元のファイル名で保存
redi attachment download <attachment_id> -o ./renamed.txt   # ファイル名を指定
redi attachment download <attachment_id> -o ./dir           # ディレクトリ指定
redi a dl <attachment_id> -o ./dir -y                       # 上書き確認をスキップ
```

## 動作確認

ローカル Redmine の issue に a.txt / b.txt を添付し、以下を確認した。

- 保存先未指定・ファイル名指定・ディレクトリ指定のいずれでも保存でき、内容が一致する
- 既存ファイルへの保存で上書き確認が出て、`-y` でスキップされる
- 存在しない attachment ID、書き込みできないパスはいずれも exit(1)
- `task check` (format / lint / typecheck / test 329 passed)