### PR TITLE
chore(lint): ruff 0.16 で追加されたルールの一部を ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,19 @@ dev = [
 [tool.uv.build-backend]
 module-name = "redi"
 
+[tool.ruff.lint]
+# ruff 0.16 で拡張されたデフォルトルールのうち、既存コードに適合しないものを除外する
+ignore = [
+  "PLR1722", # exit() の使用を許容する
+  "I001",    # import の並び順を強制しない
+  "DTZ",     # tz を持たない date/datetime の生成を許容する
+  "B006",    # ミュータブルなデフォルト引数を許容する
+  "PLW1510", # subprocess.run() への check 指定を必須としない
+  "SIM114",  # 同一処理となる分岐の統合を必須としない
+  "PIE807",  # lambda: [] の使用を許容する
+  "FURB122", # ループ内の write() を writelines() にまとめない
+]
+
 [tool.pytest.ini_options]
 pythonpath = ["."]
 markers = [


### PR DESCRIPTION
## 概要

ruff 0.16 でデフォルトの lint ルールセットが拡張された。本リポジトリは `[tool.ruff]` の設定を持たずデフォルトに依存していたため、ruff 0.16.1 への更新 (#281) で `ruff check` が 215 件のエラーを検出し CI が落ちる状態だった。

既存コードに適合しないルールのみを `lint.ignore` に列挙する方針とし、拡張されたルールの大半（YTT, ASYNC, BLE, S, B 系など）はそのまま取り込む。有効ルール数は 413 → 396。

### 除外したルールと件数

| ルール | 件数 | 内容 |
| --- | --- | --- |
| PLR1722 | 183 | `exit(1)` → `sys.exit(1)` |
| I001 | 22 | import の並び順 |
| DTZ011 / DTZ005 | 5 | `date.today()` / `datetime.now()` に tz 指定なし |
| B006 | 1 | ミュータブルなデフォルト引数 |
| PLW1510 | 1 | `subprocess.run()` に `check` 指定なし |
| SIM114 | 1 | 同一処理となる分岐 |
| PIE807 | 1 | `lambda: []` |
| FURB122 | 1 | ループ内の `write()` |

これらへの実コード対応は本 PR のスコープ外とし、別途検討する。

## 動作確認

- ruff 0.16.1 / 0.15.22 の両方で `ruff check` `ruff format --check` が通過
- `task check` (format / lint / typecheck / test) が通過 (329 passed)

## マージ後の手順

#281 に `@dependabot rebase` をコメントして CI を再実行する。