### PR TITLE
feat(search): search コマンドに Redmine Search API のフィルターを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ redi search "keyword" # search all projects
 redi search "keyword" -p <project_id> # search within a project
 redi search "keyword" --type issues # limit object types
 redi search "keyword" --type issues,wiki_pages # comma separated (issues, news, documents, changesets, wiki_pages, messages, projects)
-redi search "keyword" --scope my_projects # all, my_projects, bookmarks, subprojects
+redi search "keyword" --scope my_projects # all, my_projects, bookmarks (cannot be combined with -p)
+redi search "keyword" -p <project_id> --scope subprojects # search the project and its subprojects (-p is required)
 redi search "keyword" --titles_only --open_issues
 redi search "keyword" --no_all_words # match any word (default: all words)
 redi search "keyword" --attachments only # 0: description only, 1: description and attachments, only: attachments only

--- a/README.md
+++ b/README.md
@@ -194,6 +194,18 @@ redi issue_category create "category" -p <project_id>
 # This command requires redmine_issue_templates plugin ( https://www.redmine.org/plugins/redmine_issue_templates )
 redi issue_template # list issue_templates
 
+# search (alias: s)
+redi search "keyword" # search all projects
+redi search "keyword" -p <project_id> # search within a project
+redi search "keyword" --type issues # limit object types
+redi search "keyword" --type issues,wiki_pages # comma separated (issues, news, documents, changesets, wiki_pages, messages, projects)
+redi search "keyword" --scope my_projects # all, my_projects, bookmarks, subprojects
+redi search "keyword" --titles_only --open_issues
+redi search "keyword" --no_all_words # match any word (default: all words)
+redi search "keyword" --attachments only # 0: description only, 1: description and attachments, only: attachments only
+redi search "keyword" --limit 10 --offset 10
+redi search "keyword" --full # output full JSON
+
 # others
 redi user # list users (alias: u)
 redi tracker # list trackers (alias: t)
@@ -205,7 +217,6 @@ redi role # list roles (alias: r)
 redi group # list groups (alias: g)
 redi custom_field # list custom fields (alias: cf)
 redi query # list custom queries (alias: q)
-redi search "keyword" # (alias: s)
 redi --version
 ```
 

--- a/src/redi/api/search.py
+++ b/src/redi/api/search.py
@@ -5,11 +5,30 @@ from redi.i18n import messages
 
 
 # https://www.redmine.org/projects/redmine/wiki/Rest_Search
+SEARCH_SCOPES = ("all", "my_projects", "bookmarks", "subprojects")
+SEARCH_TYPES = (
+    "issues",
+    "news",
+    "documents",
+    "changesets",
+    "wiki_pages",
+    "messages",
+    "projects",
+)
+SEARCH_ATTACHMENTS = ("0", "1", "only")
+
+
 # Optinal parameters
 def search(
     query: str,
     limit: int | None = None,
     offset: int | None = None,
+    scope: str | None = None,
+    all_words: bool | None = None,
+    titles_only: bool = False,
+    open_issues: bool = False,
+    attachments: str | None = None,
+    types: list[str] | None = None,
     full: bool = False,
 ) -> None:
     params: dict = {"q": query}
@@ -17,6 +36,19 @@ def search(
         params["limit"] = limit
     if offset is not None:
         params["offset"] = offset
+    if scope is not None:
+        params["scope"] = scope
+    if all_words is not None:
+        # Redmine は値の有無で真偽を判定するため、無効化するには空値を渡す
+        params["all_words"] = "1" if all_words else ""
+    if titles_only:
+        params["titles_only"] = "1"
+    if open_issues:
+        params["open_issues"] = "1"
+    if attachments is not None:
+        params["attachments"] = attachments
+    for search_type in types or []:
+        params[search_type] = "1"
     response = client.get("/search.json", params=params)
     response.raise_for_status()
     data = response.json()

--- a/src/redi/api/search.py
+++ b/src/redi/api/search.py
@@ -30,7 +30,7 @@ def search(
     limit: int | None = None,
     offset: int | None = None,
     scope: SearchScope | None = None,
-    all_words: bool | None = None,
+    all_words: bool = True,
     titles_only: bool = False,
     open_issues: bool = False,
     attachments: SearchAttachments | None = None,
@@ -44,9 +44,9 @@ def search(
         params["offset"] = offset
     if scope is not None:
         params["scope"] = scope
-    if all_words is not None:
+    if not all_words:
         # Redmine は値の有無で真偽を判定するため、無効化するには空値を渡す
-        params["all_words"] = "1" if all_words else ""
+        params["all_words"] = ""
     if titles_only:
         params["titles_only"] = "1"
     if open_issues:

--- a/src/redi/api/search.py
+++ b/src/redi/api/search.py
@@ -1,12 +1,13 @@
 import json
+from typing import Literal, get_args
 
 from redi.client import client
 from redi.i18n import messages
 
 
 # https://www.redmine.org/projects/redmine/wiki/Rest_Search
-SEARCH_SCOPES = ("all", "my_projects", "bookmarks", "subprojects")
-SEARCH_TYPES = (
+SearchScope = Literal["all", "my_projects", "bookmarks", "subprojects"]
+SearchType = Literal[
     "issues",
     "news",
     "documents",
@@ -14,8 +15,13 @@ SEARCH_TYPES = (
     "wiki_pages",
     "messages",
     "projects",
-)
-SEARCH_ATTACHMENTS = ("0", "1", "only")
+]
+SearchAttachments = Literal["0", "1", "only"]
+
+# argparse の choices や検証に使うため、Literal から実行時の値を導出する
+SEARCH_SCOPES: tuple[SearchScope, ...] = get_args(SearchScope)
+SEARCH_TYPES: tuple[SearchType, ...] = get_args(SearchType)
+SEARCH_ATTACHMENTS: tuple[SearchAttachments, ...] = get_args(SearchAttachments)
 
 
 # Optinal parameters
@@ -23,12 +29,12 @@ def search(
     query: str,
     limit: int | None = None,
     offset: int | None = None,
-    scope: str | None = None,
+    scope: SearchScope | None = None,
     all_words: bool | None = None,
     titles_only: bool = False,
     open_issues: bool = False,
-    attachments: str | None = None,
-    types: list[str] | None = None,
+    attachments: SearchAttachments | None = None,
+    types: list[SearchType] | None = None,
     full: bool = False,
 ) -> None:
     params: dict = {"q": query}

--- a/src/redi/api/search.py
+++ b/src/redi/api/search.py
@@ -29,6 +29,7 @@ def search(
     query: str,
     limit: int | None = None,
     offset: int | None = None,
+    project_id: str | None = None,
     scope: SearchScope | None = None,
     all_words: bool = True,
     titles_only: bool = False,
@@ -42,6 +43,9 @@ def search(
         params["limit"] = limit
     if offset is not None:
         params["offset"] = offset
+    if project_id is not None:
+        # ルートが (projects/:id)/search のため、絞り込みのパラメータ名は id になる
+        params["id"] = project_id
     if scope is not None:
         params["scope"] = scope
     if not all_words:

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -36,18 +36,11 @@ def add_search_parser(
     search_parser.add_argument(
         "--scope", choices=SEARCH_SCOPES, help=messages.arg_help_search_scope
     )
-    all_words_group = search_parser.add_mutually_exclusive_group()
-    all_words_group.add_argument(
-        "--all_words",
-        dest="all_words",
-        action="store_true",
-        default=None,
-        help=messages.arg_help_search_all_words,
-    )
-    all_words_group.add_argument(
+    search_parser.add_argument(
         "--no_all_words",
         dest="all_words",
         action="store_false",
+        default=None,
         help=messages.arg_help_search_no_all_words,
     )
     search_parser.add_argument(

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -1,6 +1,11 @@
 import argparse
 
-from redi.api.search import search
+from redi.api.search import (
+    SEARCH_ATTACHMENTS,
+    SEARCH_SCOPES,
+    SEARCH_TYPES,
+    search,
+)
 from redi.i18n import messages
 
 
@@ -16,6 +21,40 @@ def add_search_parser(
         "--offset", "-o", type=int, help=messages.arg_help_offset
     )
     search_parser.add_argument(
+        "--scope", choices=SEARCH_SCOPES, help=messages.arg_help_search_scope
+    )
+    all_words_group = search_parser.add_mutually_exclusive_group()
+    all_words_group.add_argument(
+        "--all_words",
+        dest="all_words",
+        action="store_true",
+        default=None,
+        help=messages.arg_help_search_all_words,
+    )
+    all_words_group.add_argument(
+        "--no_all_words",
+        dest="all_words",
+        action="store_false",
+        help=messages.arg_help_search_no_all_words,
+    )
+    search_parser.add_argument(
+        "--titles_only", action="store_true", help=messages.arg_help_search_titles_only
+    )
+    search_parser.add_argument(
+        "--open_issues", action="store_true", help=messages.arg_help_search_open_issues
+    )
+    search_parser.add_argument(
+        "--attachments",
+        choices=SEARCH_ATTACHMENTS,
+        help=messages.arg_help_search_attachments,
+    )
+    for search_type in SEARCH_TYPES:
+        search_parser.add_argument(
+            f"--{search_type}",
+            action="store_true",
+            help=messages.arg_help_search_type.format(type=search_type),
+        )
+    search_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
 
@@ -25,5 +64,11 @@ def handle_search(args: argparse.Namespace) -> None:
         query=args.query,
         limit=args.limit,
         offset=args.offset,
+        scope=args.scope,
+        all_words=args.all_words,
+        titles_only=args.titles_only,
+        open_issues=args.open_issues,
+        attachments=args.attachments,
+        types=[t for t in SEARCH_TYPES if getattr(args, t)],
         full=args.full,
     )

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -36,6 +36,9 @@ def add_search_parser(
         "--offset", "-o", type=int, help=messages.arg_help_offset
     )
     search_parser.add_argument(
+        "--project_id", "-p", help=messages.arg_help_search_project_id
+    )
+    search_parser.add_argument(
         "--scope", choices=SEARCH_SCOPES, help=messages.arg_help_search_scope
     )
     search_parser.add_argument(
@@ -70,6 +73,7 @@ def handle_search(args: argparse.Namespace) -> None:
         query=args.query,
         limit=args.limit,
         offset=args.offset,
+        project_id=args.project_id,
         scope=args.scope,
         all_words=args.all_words,
         titles_only=args.titles_only,

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -1,15 +1,17 @@
 import argparse
+from typing import cast
 
 from redi.api.search import (
     SEARCH_ATTACHMENTS,
     SEARCH_SCOPES,
     SEARCH_TYPES,
+    SearchType,
     search,
 )
 from redi.i18n import messages
 
 
-def _parse_search_types(value: str) -> list[str]:
+def _parse_search_types(value: str) -> list[SearchType]:
     """カンマ区切りの検索種別を検証してリストに変換する。"""
     types = [t.strip() for t in value.split(",") if t.strip()]
     unknown = [t for t in types if t not in SEARCH_TYPES]
@@ -19,7 +21,7 @@ def _parse_search_types(value: str) -> list[str]:
                 values=",".join(unknown), choices=",".join(SEARCH_TYPES)
             )
         )
-    return types
+    return cast(list[SearchType], types)
 
 
 def add_search_parser(

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -5,10 +5,29 @@ from redi.api.search import (
     SEARCH_ATTACHMENTS,
     SEARCH_SCOPES,
     SEARCH_TYPES,
+    SearchScope,
     SearchType,
     search,
 )
 from redi.i18n import messages
+
+
+def _validate_scope(scope: SearchScope | None, project_id: str | None) -> None:
+    """--scope と --project_id の組み合わせでエラーが返らないものをエラーにする
+
+    - subprojects は project_id がないと成立しないのでproject_idを求める
+    - project_id の指定がある場合は他のスコープの指定を受け付けないようにする
+    """
+    if scope is None:
+        return
+    if scope == "subprojects":
+        if project_id is None:
+            print(messages.error_search_scope_requires_project.format(scope=scope))
+            exit(1)
+        return
+    if project_id is not None:
+        print(messages.error_search_scope_conflicts_project.format(scope=scope))
+        exit(1)
 
 
 def _parse_search_types(value: str) -> list[SearchType]:
@@ -69,6 +88,7 @@ def add_search_parser(
 
 
 def handle_search(args: argparse.Namespace) -> None:
+    _validate_scope(args.scope, args.project_id)
     search(
         query=args.query,
         limit=args.limit,

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -42,7 +42,6 @@ def add_search_parser(
         "--no_all_words",
         dest="all_words",
         action="store_false",
-        default=None,
         help=messages.arg_help_search_no_all_words,
     )
     search_parser.add_argument(

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -9,6 +9,19 @@ from redi.api.search import (
 from redi.i18n import messages
 
 
+def _parse_search_types(value: str) -> list[str]:
+    """カンマ区切りの検索種別を検証してリストに変換する。"""
+    types = [t.strip() for t in value.split(",") if t.strip()]
+    unknown = [t for t in types if t not in SEARCH_TYPES]
+    if unknown:
+        raise argparse.ArgumentTypeError(
+            messages.error_invalid_search_type.format(
+                values=",".join(unknown), choices=",".join(SEARCH_TYPES)
+            )
+        )
+    return types
+
+
 def add_search_parser(
     subparsers: argparse._SubParsersAction, parents: list[argparse.ArgumentParser]
 ) -> None:
@@ -48,12 +61,11 @@ def add_search_parser(
         choices=SEARCH_ATTACHMENTS,
         help=messages.arg_help_search_attachments,
     )
-    for search_type in SEARCH_TYPES:
-        search_parser.add_argument(
-            f"--{search_type}",
-            action="store_true",
-            help=messages.arg_help_search_type.format(type=search_type),
-        )
+    search_parser.add_argument(
+        "--type",
+        type=_parse_search_types,
+        help=messages.arg_help_search_type.format(choices=",".join(SEARCH_TYPES)),
+    )
     search_parser.add_argument(
         "--full", action="store_true", help=messages.arg_help_full_json
     )
@@ -69,6 +81,6 @@ def handle_search(args: argparse.Namespace) -> None:
         titles_only=args.titles_only,
         open_issues=args.open_issues,
         attachments=args.attachments,
-        types=[t for t in SEARCH_TYPES if getattr(args, t)],
+        types=args.type,
         full=args.full,
     )

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -896,6 +896,7 @@ class MessagesProto(Protocol):
     # ---- argparse helps (search) ----
     arg_help_search_command: str
     arg_help_search_query: str
+    arg_help_search_project_id: str
     arg_help_search_scope: str
     arg_help_search_no_all_words: str
     arg_help_search_titles_only: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -896,6 +896,14 @@ class MessagesProto(Protocol):
     # ---- argparse helps (search) ----
     arg_help_search_command: str
     arg_help_search_query: str
+    arg_help_search_scope: str
+    arg_help_search_all_words: str
+    arg_help_search_no_all_words: str
+    arg_help_search_titles_only: str
+    arg_help_search_open_issues: str
+    arg_help_search_attachments: str
+    arg_help_search_type: str
+    """{type}"""
 
     # ---- argparse helps (news) ----
     arg_help_news_command: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -897,7 +897,6 @@ class MessagesProto(Protocol):
     arg_help_search_command: str
     arg_help_search_query: str
     arg_help_search_scope: str
-    arg_help_search_all_words: str
     arg_help_search_no_all_words: str
     arg_help_search_titles_only: str
     arg_help_search_open_issues: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -903,7 +903,9 @@ class MessagesProto(Protocol):
     arg_help_search_open_issues: str
     arg_help_search_attachments: str
     arg_help_search_type: str
-    """{type}"""
+    """{choices}"""
+    error_invalid_search_type: str
+    """{values} {choices}"""
 
     # ---- argparse helps (news) ----
     arg_help_news_command: str

--- a/src/redi/i18n/_protocol.py
+++ b/src/redi/i18n/_protocol.py
@@ -906,6 +906,10 @@ class MessagesProto(Protocol):
     """{choices}"""
     error_invalid_search_type: str
     """{values} {choices}"""
+    error_search_scope_requires_project: str
+    """{scope}"""
+    error_search_scope_conflicts_project: str
+    """{scope}"""
 
     # ---- argparse helps (news) ----
     arg_help_news_command: str

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -766,6 +766,9 @@ class En(MessagesProto):
     # ---- argparse helps (search) ----
     arg_help_search_command = "Search"
     arg_help_search_query = "Search query"
+    arg_help_search_project_id = (
+        "Search within the project (searches all projects if omitted)"
+    )
     arg_help_search_scope = "Search scope"
     arg_help_search_no_all_words = "Match any word in the query (default: all words)"
     arg_help_search_titles_only = "Search titles only"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -769,7 +769,10 @@ class En(MessagesProto):
     arg_help_search_project_id = (
         "Search within the project (searches all projects if omitted)"
     )
-    arg_help_search_scope = "Search scope"
+    arg_help_search_scope = (
+        "Search scope (subprojects requires --project_id, "
+        "the others cannot be combined with it)"
+    )
     arg_help_search_no_all_words = "Match any word in the query (default: all words)"
     arg_help_search_titles_only = "Search titles only"
     arg_help_search_open_issues = "Search open issues only"
@@ -779,6 +782,10 @@ class En(MessagesProto):
     )
     arg_help_search_type = "Object types to search, comma separated ({choices})"
     error_invalid_search_type = "Unknown search type: {values} (available: {choices})"
+    error_search_scope_requires_project = "--scope {scope} requires --project_id"
+    error_search_scope_conflicts_project = (
+        "--scope {scope} cannot be used with --project_id"
+    )
 
     # ---- argparse helps (news) ----
     arg_help_news_command = "List news"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -775,7 +775,8 @@ class En(MessagesProto):
         "Search attachments (0: description only, "
         "1: description and attachments, only: attachments only)"
     )
-    arg_help_search_type = "Include {type} in results"
+    arg_help_search_type = "Object types to search, comma separated ({choices})"
+    error_invalid_search_type = "Unknown search type: {values} (available: {choices})"
 
     # ---- argparse helps (news) ----
     arg_help_news_command = "List news"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -766,6 +766,16 @@ class En(MessagesProto):
     # ---- argparse helps (search) ----
     arg_help_search_command = "Search"
     arg_help_search_query = "Search query"
+    arg_help_search_scope = "Search scope"
+    arg_help_search_all_words = "Match all words in the query (default)"
+    arg_help_search_no_all_words = "Match any word in the query"
+    arg_help_search_titles_only = "Search titles only"
+    arg_help_search_open_issues = "Search open issues only"
+    arg_help_search_attachments = (
+        "Search attachments (0: description only, "
+        "1: description and attachments, only: attachments only)"
+    )
+    arg_help_search_type = "Include {type} in results"
 
     # ---- argparse helps (news) ----
     arg_help_news_command = "List news"

--- a/src/redi/i18n/en.py
+++ b/src/redi/i18n/en.py
@@ -767,8 +767,7 @@ class En(MessagesProto):
     arg_help_search_command = "Search"
     arg_help_search_query = "Search query"
     arg_help_search_scope = "Search scope"
-    arg_help_search_all_words = "Match all words in the query (default)"
-    arg_help_search_no_all_words = "Match any word in the query"
+    arg_help_search_no_all_words = "Match any word in the query (default: all words)"
     arg_help_search_titles_only = "Search titles only"
     arg_help_search_open_issues = "Search open issues only"
     arg_help_search_attachments = (

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -778,8 +778,9 @@ class Ja(MessagesProto):
     arg_help_search_command = "検索"
     arg_help_search_query = "検索クエリ"
     arg_help_search_scope = "検索範囲"
-    arg_help_search_all_words = "クエリの全単語を含むものを検索する(デフォルト)"
-    arg_help_search_no_all_words = "クエリのいずれかの単語を含むものを検索する"
+    arg_help_search_no_all_words = (
+        "クエリのいずれかの単語を含むものを検索する(デフォルトは全単語)"
+    )
     arg_help_search_titles_only = "タイトルのみを検索する"
     arg_help_search_open_issues = "未完了のチケットのみを検索する"
     arg_help_search_attachments = "添付ファイルの検索方法(0: 説明のみ, 1: 説明と添付ファイル, only: 添付ファイルのみ)"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -777,6 +777,7 @@ class Ja(MessagesProto):
     # ---- argparse helps (search) ----
     arg_help_search_command = "検索"
     arg_help_search_query = "検索クエリ"
+    arg_help_search_project_id = "検索対象のプロジェクト(未指定なら全プロジェクト)"
     arg_help_search_scope = "検索範囲"
     arg_help_search_no_all_words = (
         "クエリのいずれかの単語を含むものを検索する(デフォルトは全単語)"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -783,7 +783,8 @@ class Ja(MessagesProto):
     arg_help_search_titles_only = "タイトルのみを検索する"
     arg_help_search_open_issues = "未完了のチケットのみを検索する"
     arg_help_search_attachments = "添付ファイルの検索方法(0: 説明のみ, 1: 説明と添付ファイル, only: 添付ファイルのみ)"
-    arg_help_search_type = "検索結果に {type} を含める"
+    arg_help_search_type = "検索対象の種別をカンマ区切りで指定（{choices}）"
+    error_invalid_search_type = "不明な検索種別です: {values}（指定可能: {choices}）"
 
     # ---- argparse helps (news) ----
     arg_help_news_command = "ニュース一覧"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -777,6 +777,13 @@ class Ja(MessagesProto):
     # ---- argparse helps (search) ----
     arg_help_search_command = "検索"
     arg_help_search_query = "検索クエリ"
+    arg_help_search_scope = "検索範囲"
+    arg_help_search_all_words = "クエリの全単語を含むものを検索する(デフォルト)"
+    arg_help_search_no_all_words = "クエリのいずれかの単語を含むものを検索する"
+    arg_help_search_titles_only = "タイトルのみを検索する"
+    arg_help_search_open_issues = "未完了のチケットのみを検索する"
+    arg_help_search_attachments = "添付ファイルの検索方法(0: 説明のみ, 1: 説明と添付ファイル, only: 添付ファイルのみ)"
+    arg_help_search_type = "検索結果に {type} を含める"
 
     # ---- argparse helps (news) ----
     arg_help_news_command = "ニュース一覧"

--- a/src/redi/i18n/ja.py
+++ b/src/redi/i18n/ja.py
@@ -778,7 +778,7 @@ class Ja(MessagesProto):
     arg_help_search_command = "検索"
     arg_help_search_query = "検索クエリ"
     arg_help_search_project_id = "検索対象のプロジェクト(未指定なら全プロジェクト)"
-    arg_help_search_scope = "検索範囲"
+    arg_help_search_scope = "検索範囲(subprojects は --project_id が必要、それ以外は --project_id と併用不可)"
     arg_help_search_no_all_words = (
         "クエリのいずれかの単語を含むものを検索する(デフォルトは全単語)"
     )
@@ -787,6 +787,12 @@ class Ja(MessagesProto):
     arg_help_search_attachments = "添付ファイルの検索方法(0: 説明のみ, 1: 説明と添付ファイル, only: 添付ファイルのみ)"
     arg_help_search_type = "検索対象の種別をカンマ区切りで指定（{choices}）"
     error_invalid_search_type = "不明な検索種別です: {values}（指定可能: {choices}）"
+    error_search_scope_requires_project = (
+        "--scope {scope} には --project_id の指定が必要です"
+    )
+    error_search_scope_conflicts_project = (
+        "--scope {scope} は --project_id と併用できません"
+    )
 
     # ---- argparse helps (news) ----
     arg_help_news_command = "ニュース一覧"

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -1,0 +1,141 @@
+import pytest
+
+from redi.api import search as search_module
+
+
+class FakeResponse:
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return {"results": []}
+
+
+@pytest.fixture
+def captured_params(monkeypatch) -> dict:
+    """search が client.get に渡した params を捕捉する"""
+    captured: dict = {}
+
+    def fake_get(path: str, **kwargs) -> FakeResponse:
+        captured["path"] = path
+        captured["params"] = kwargs.get("params")
+        return FakeResponse()
+
+    monkeypatch.setattr(search_module.client, "get", fake_get)
+    return captured
+
+
+class TestSearchParams:
+    """search は指定された条件だけをクエリパラメータに組み立てる"""
+
+    def test_query_only(self, captured_params):
+        """クエリのみ指定すると q だけを送る"""
+        search_module.search("redi")
+
+        assert captured_params["path"] == "/search.json"
+        assert captured_params["params"] == {"q": "redi"}
+
+    @pytest.mark.parametrize(
+        ("kwargs", "expected"),
+        [
+            ({"limit": 10}, {"limit": 10}),
+            ({"offset": 20}, {"offset": 20}),
+            ({"scope": "my_projects"}, {"scope": "my_projects"}),
+            ({"titles_only": True}, {"titles_only": "1"}),
+            ({"open_issues": True}, {"open_issues": "1"}),
+            ({"attachments": "only"}, {"attachments": "only"}),
+        ],
+        ids=[
+            "limit",
+            "offset",
+            "scope",
+            "titles_only",
+            "open_issues",
+            "attachments",
+        ],
+    )
+    def test_optional_params(self, captured_params, kwargs, expected):
+        """指定した条件が対応するパラメータとして送られる"""
+        search_module.search("redi", **kwargs)
+
+        assert captured_params["params"] == {"q": "redi", **expected}
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"limit": None},
+            {"offset": None},
+            {"scope": None},
+            {"all_words": None},
+            {"titles_only": False},
+            {"open_issues": False},
+            {"attachments": None},
+            {"types": None},
+            {"types": []},
+        ],
+        ids=[
+            "limit",
+            "offset",
+            "scope",
+            "all_words",
+            "titles_only",
+            "open_issues",
+            "attachments",
+            "types=None",
+            "types=[]",
+        ],
+    )
+    def test_unspecified_params_are_omitted(self, captured_params, kwargs):
+        """未指定の条件はパラメータ自体を送らない"""
+        search_module.search("redi", **kwargs)
+
+        assert captured_params["params"] == {"q": "redi"}
+
+    def test_all_words_false_sends_empty_value(self, captured_params):
+        """all_words の無効化は空値で送る (Redmine は値の有無で真偽を判定する)"""
+        search_module.search("redi", all_words=False)
+
+        assert captured_params["params"] == {"q": "redi", "all_words": ""}
+
+    def test_all_words_true_sends_flag(self, captured_params):
+        """all_words の有効化は 1 で送る"""
+        search_module.search("redi", all_words=True)
+
+        assert captured_params["params"] == {"q": "redi", "all_words": "1"}
+
+    def test_types_are_expanded_to_individual_params(self, captured_params):
+        """種別は issues=1 のような個別パラメータへ展開される"""
+        search_module.search("redi", types=["issues", "wiki_pages"])
+
+        assert captured_params["params"] == {
+            "q": "redi",
+            "issues": "1",
+            "wiki_pages": "1",
+        }
+
+    def test_all_params_combined(self, captured_params):
+        """すべての条件を指定しても互いに上書きしない"""
+        search_module.search(
+            "redi",
+            limit=10,
+            offset=20,
+            scope="my_projects",
+            all_words=False,
+            titles_only=True,
+            open_issues=True,
+            attachments="only",
+            types=["issues", "wiki_pages"],
+        )
+
+        assert captured_params["params"] == {
+            "q": "redi",
+            "limit": 10,
+            "offset": 20,
+            "scope": "my_projects",
+            "all_words": "",
+            "titles_only": "1",
+            "open_issues": "1",
+            "attachments": "only",
+            "issues": "1",
+            "wiki_pages": "1",
+        }

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -66,7 +66,6 @@ class TestSearchParams:
             {"limit": None},
             {"offset": None},
             {"scope": None},
-            {"all_words": None},
             {"titles_only": False},
             {"open_issues": False},
             {"attachments": None},
@@ -77,7 +76,6 @@ class TestSearchParams:
             "limit",
             "offset",
             "scope",
-            "all_words",
             "titles_only",
             "open_issues",
             "attachments",
@@ -97,11 +95,11 @@ class TestSearchParams:
 
         assert captured_params["params"] == {"q": "redi", "all_words": ""}
 
-    def test_all_words_true_sends_flag(self, captured_params):
-        """all_words の有効化は 1 で送る"""
+    def test_all_words_true_is_omitted(self, captured_params):
+        """all_words の有効化は Redmine 側の既定なのでパラメータを送らない"""
         search_module.search("redi", all_words=True)
 
-        assert captured_params["params"] == {"q": "redi", "all_words": "1"}
+        assert captured_params["params"] == {"q": "redi"}
 
     def test_types_are_expanded_to_individual_params(self, captured_params):
         """種別は issues=1 のような個別パラメータへ展開される"""

--- a/tests/unit/api/test_search.py
+++ b/tests/unit/api/test_search.py
@@ -40,6 +40,7 @@ class TestSearchParams:
         [
             ({"limit": 10}, {"limit": 10}),
             ({"offset": 20}, {"offset": 20}),
+            ({"project_id": "reditest"}, {"id": "reditest"}),
             ({"scope": "my_projects"}, {"scope": "my_projects"}),
             ({"titles_only": True}, {"titles_only": "1"}),
             ({"open_issues": True}, {"open_issues": "1"}),
@@ -48,6 +49,7 @@ class TestSearchParams:
         ids=[
             "limit",
             "offset",
+            "project_id",
             "scope",
             "titles_only",
             "open_issues",
@@ -65,6 +67,7 @@ class TestSearchParams:
         [
             {"limit": None},
             {"offset": None},
+            {"project_id": None},
             {"scope": None},
             {"titles_only": False},
             {"open_issues": False},
@@ -75,6 +78,7 @@ class TestSearchParams:
         ids=[
             "limit",
             "offset",
+            "project_id",
             "scope",
             "titles_only",
             "open_issues",
@@ -88,6 +92,12 @@ class TestSearchParams:
         search_module.search("redi", **kwargs)
 
         assert captured_params["params"] == {"q": "redi"}
+
+    def test_project_id_is_sent_as_id(self, captured_params):
+        """プロジェクトの絞り込みは id という名前で送る (project_id は無視される)"""
+        search_module.search("redi", project_id="reditest")
+
+        assert captured_params["params"] == {"q": "redi", "id": "reditest"}
 
     def test_all_words_false_sends_empty_value(self, captured_params):
         """all_words の無効化は空値で送る (Redmine は値の有無で真偽を判定する)"""
@@ -117,6 +127,7 @@ class TestSearchParams:
             "redi",
             limit=10,
             offset=20,
+            project_id="reditest",
             scope="my_projects",
             all_words=False,
             titles_only=True,
@@ -129,6 +140,7 @@ class TestSearchParams:
             "q": "redi",
             "limit": 10,
             "offset": 20,
+            "id": "reditest",
             "scope": "my_projects",
             "all_words": "",
             "titles_only": "1",

--- a/tests/unit/cli/test_search_command.py
+++ b/tests/unit/cli/test_search_command.py
@@ -1,39 +1,6 @@
-import argparse
-
 import pytest
 
 from redi.cli import search_command
-
-
-def _args(**overrides) -> argparse.Namespace:
-    """handle_search が参照する属性を埋めた Namespace を作る"""
-    defaults = {
-        "query": "redi",
-        "limit": None,
-        "offset": None,
-        "project_id": None,
-        "scope": None,
-        "all_words": True,
-        "titles_only": False,
-        "open_issues": False,
-        "attachments": None,
-        "type": None,
-        "full": False,
-    }
-    defaults.update(overrides)
-    return argparse.Namespace(**defaults)
-
-
-@pytest.fixture
-def captured_search(monkeypatch) -> dict:
-    """handle_search が search に渡した引数を捕捉する"""
-    captured: dict = {}
-
-    def fake_search(**kwargs) -> None:
-        captured.update(kwargs)
-
-    monkeypatch.setattr(search_command, "search", fake_search)
-    return captured
 
 
 class TestValidateScope:
@@ -78,21 +45,3 @@ class TestValidateScope:
     def test_accepts_valid_combinations(self, scope, project_id):
         """矛盾しない組み合わせは素通しする"""
         search_command._validate_scope(scope, project_id)
-
-
-class TestHandleSearch:
-    """handle_search は検証を通してから search を呼ぶ"""
-
-    def test_passes_valid_args(self, captured_search):
-        """矛盾しない組み合わせは search にそのまま渡る"""
-        search_command.handle_search(_args(scope="subprojects", project_id="reditest"))
-
-        assert captured_search["scope"] == "subprojects"
-        assert captured_search["project_id"] == "reditest"
-
-    def test_stops_before_search(self, captured_search):
-        """矛盾する組み合わせでは search を呼ばずに終了する"""
-        with pytest.raises(SystemExit):
-            search_command.handle_search(_args(scope="all", project_id="reditest"))
-
-        assert captured_search == {}

--- a/tests/unit/cli/test_search_command.py
+++ b/tests/unit/cli/test_search_command.py
@@ -1,0 +1,98 @@
+import argparse
+
+import pytest
+
+from redi.cli import search_command
+
+
+def _args(**overrides) -> argparse.Namespace:
+    """handle_search が参照する属性を埋めた Namespace を作る"""
+    defaults = {
+        "query": "redi",
+        "limit": None,
+        "offset": None,
+        "project_id": None,
+        "scope": None,
+        "all_words": True,
+        "titles_only": False,
+        "open_issues": False,
+        "attachments": None,
+        "type": None,
+        "full": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+@pytest.fixture
+def captured_search(monkeypatch) -> dict:
+    """handle_search が search に渡した引数を捕捉する"""
+    captured: dict = {}
+
+    def fake_search(**kwargs) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(search_command, "search", fake_search)
+    return captured
+
+
+class TestValidateScope:
+    """--scope と --project_id の矛盾する組み合わせを弾く"""
+
+    @pytest.mark.parametrize("scope", ["all", "my_projects", "bookmarks"])
+    def test_rejects_project_id(self, scope, capsys):
+        """subprojects 以外の scope に --project_id を付けるとエラーになる"""
+        with pytest.raises(SystemExit) as e:
+            search_command._validate_scope(scope, "reditest")
+
+        assert e.value.code == 1
+        assert scope in capsys.readouterr().out
+
+    def test_subprojects_requires_project_id(self, capsys):
+        """subprojects に --project_id がないとエラーになる"""
+        with pytest.raises(SystemExit) as e:
+            search_command._validate_scope("subprojects", None)
+
+        assert e.value.code == 1
+        assert "subprojects" in capsys.readouterr().out
+
+    @pytest.mark.parametrize(
+        ("scope", "project_id"),
+        [
+            (None, None),
+            (None, "reditest"),
+            ("all", None),
+            ("my_projects", None),
+            ("bookmarks", None),
+            ("subprojects", "reditest"),
+        ],
+        ids=[
+            "scope_none",
+            "project_id_only",
+            "all",
+            "my_projects",
+            "bookmarks",
+            "subprojects_with_project_id",
+        ],
+    )
+    def test_accepts_valid_combinations(self, scope, project_id):
+        """矛盾しない組み合わせは素通しする"""
+        search_command._validate_scope(scope, project_id)
+
+
+class TestHandleSearch:
+    """handle_search は検証を通してから search を呼ぶ"""
+
+    def test_passes_valid_args(self, captured_search):
+        """矛盾しない組み合わせは search にそのまま渡る"""
+        search_command.handle_search(_args(scope="subprojects", project_id="reditest"))
+
+        assert captured_search["scope"] == "subprojects"
+        assert captured_search["project_id"] == "reditest"
+
+    def test_stops_before_search(self, captured_search):
+        """矛盾する組み合わせでは search を呼ばずに終了する"""
+        with pytest.raises(SystemExit):
+            search_command.handle_search(_args(scope="all", project_id="reditest"))
+
+        assert captured_search == {}


### PR DESCRIPTION
close #289

## 背景

`redi search` は `q` / `limit` / `offset` しか渡しておらず、[Redmine Search API](https://www.redmine.org/projects/redmine/wiki/Rest_Search) が備えるフィルターを使えなかった。

## 変更内容

`redi search` に以下のオプションを追加した。

| オプション | 送信パラメータ |
| --- | --- |
| `--project_id` / `-p` | `id` |
| `--scope {all,my_projects,bookmarks,subprojects}` | `scope` |
| `--no_all_words` | `all_words` |
| `--titles_only` | `titles_only` |
| `--open_issues` | `open_issues` |
| `--attachments {0,1,only}` | `attachments` |
| `--type issues,wiki_pages,...` | 指定した種別を `1` で送る |

## 動作確認

- -p
    - `redi search "keyword" -p <project_id>`
        - [x] プロジェクト指定で検索結果が絞られること
- --no_all_words
    - `redi search "keyword keyword2" --no_all_words`
        - [x] どちらかだけ含むものも結果に入る
- --open_issues
    - `redi search "keyword" --open_issues`
        - [x] 終了ステータスのイシューが結果に入らなくなること
- --types
    - `redi search "article2" --type wiki_pages`
        - [x] wikiの本文がマッチして検索結果に入ること
    - `redi search "ar" --type wiki_pages,issues`
        - [x] wiki以外にissueも検索結果に入ること
- --attachments
    - 前提:
        - descriptionにkeywordを含むissue:A
        - nameがkeywordを含むattachmentがあるissue:B
        - descriptionがkeywordを含むattachmentがあるissue:C
        - titleにkeywordを含むissue:D
    - [x] `--attachments 1`(A,B,C,Dがヒットする)
    - [x] `--attachments 0`(A,Dがヒットする)
    - [x] `--attachments only`(B,Cがヒットする)
    - [x] 未指定(A,Dがヒットする)
- --scope
    - 前提:
        - keywordを含むissueがあり、ユーザーがメンバーであるプロジェクト(親):E
        - keywordを含むissueがあり、Eの子でユーザーがメンバーのプロジェクト:F
        - keywordを含むissueがあり、ユーザーが非メンバーで親子関係もないプロジェクト:G
    - [x] `--scope all`(E,F,Gがヒットする)
    - [x] `--scope my_projects`(E,Fのみヒットする)
    - [x] `-p <親>`(scope未指定なのでEのみヒットする)
    - [x] `-p <親> --scope subprojects`(E,Fがヒットする)
    - [x] 未指定(E,F,Gがヒットする)
    - `--scope bookmarks`
        - [x] ユーザーがブックマーク指定したプロジェクトに限定される

## 備考

- scopeのオプションについて https://www.redmine.org/projects/redmine/wiki/Rest_Search では
    - `my_project`となっているが`my_projects`で機能する
    - `bookmarks`も機能する

- project_idとscopeの組み合わせで暗黙に無視されるscopeや project_idとscopeで両立する組み合わせで片方が欠けている組み合わせ以外はCLI側でエラーにするようにした

