### PR TITLE
feat(project): プロジェクト選択ダイアログを ID 降順で表示する

### DIFF
--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -74,6 +74,10 @@ def fetch_projects() -> list[Project]:
         offset += len(page)
 
 
+def sort_projects_by_id_desc(projects: list[Project]) -> list[Project]:
+    return sorted(projects, key=lambda p: p["id"], reverse=True)
+
+
 def resolve_project_id(value: str) -> str:
     if str(value).isdigit():
         return str(value)

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -61,7 +61,8 @@ def _fetch_projects(url: str, api_key: str) -> list[dict]:
 
 def _select_project_id(message: str, projects: list[dict]) -> str:
     options: list[tuple[str, str]] = [
-        (str(p["id"]), f"{p['id']} {p['name']}") for p in projects
+        (str(p["id"]), f"{p['id']} {p['name']}")
+        for p in sorted(projects, key=lambda p: p["id"], reverse=True)
     ]
     try:
         return inline_choice(message, options)

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -227,14 +227,6 @@ def _build_user_choices(
     return choices
 
 
-def _build_project_choices() -> list[tuple[str, str]]:
-    """プロジェクト切替モーダルの選択肢。(プロジェクト id, 表示名) の組。"""
-    return [
-        (str(p["id"]), p.get("name", ""))
-        for p in sort_projects_by_id_desc(fetch_projects())
-    ]
-
-
 def open_project_modal(state: TuiState) -> None:
     """プロジェクト切替モーダルを開く。一覧取得に失敗したら error modal に流す。"""
     modal = state.project_modal

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -24,7 +24,7 @@ from prompt_toolkit.widgets import Frame
 from redi.api.issue_status import fetch_issue_statuses
 from redi.api.me import fetch_my_user_id
 from redi.api.membership import fetch_project_users
-from redi.api.project import fetch_projects
+from redi.api.project import fetch_projects, sort_projects_by_id_desc
 from redi.i18n import messages
 from redi.tui.issue.filter_modal import build_filter_float
 from redi.tui.issue.issue_tab import (
@@ -229,14 +229,17 @@ def _build_user_choices(
 
 def _build_project_choices() -> list[tuple[str, str]]:
     """プロジェクト切替モーダルの選択肢。(プロジェクト id, 表示名) の組。"""
-    return [(str(p["id"]), p.get("name", "")) for p in fetch_projects()]
+    return [
+        (str(p["id"]), p.get("name", ""))
+        for p in sort_projects_by_id_desc(fetch_projects())
+    ]
 
 
 def open_project_modal(state: TuiState) -> None:
     """プロジェクト切替モーダルを開く。一覧取得に失敗したら error modal に流す。"""
     modal = state.project_modal
     try:
-        projects = fetch_projects()
+        projects = sort_projects_by_id_desc(fetch_projects())
     except requests.exceptions.RequestException as e:
         state.error_modal = messages.tui_project_load_failed.format(error=e)
         return

--- a/tests/unit/tui/test_project_switch.py
+++ b/tests/unit/tui/test_project_switch.py
@@ -52,9 +52,9 @@ def _fake_tab(on_activate: Callable[[TuiState], None]) -> TabView:
 class TestBuildProjectChoices:
     """_build_project_choices() は fetch_projects() を (id, name) の組に変換する"""
 
-    def test_converts_projects(self, monkeypatch):
+    def test_converts_projects_in_id_desc(self, monkeypatch):
         monkeypatch.setattr(app, "fetch_projects", lambda: PROJECTS)
-        assert app._build_project_choices() == [("1", "Alpha"), ("2", "Beta")]
+        assert app._build_project_choices() == [("2", "Beta"), ("1", "Alpha")]
 
 
 class TestOpenProjectModal:
@@ -68,8 +68,8 @@ class TestOpenProjectModal:
         app.open_project_modal(state)
 
         assert state.project_modal.show is True
-        assert state.project_modal.choices == [("1", "Alpha"), ("2", "Beta")]
-        assert state.project_modal.cursor == 1
+        assert state.project_modal.choices == [("2", "Beta"), ("1", "Alpha")]
+        assert state.project_modal.cursor == 0
         assert state.project_modal.active_id == "2"
 
     def test_unswitched_marks_config_default_project(self, monkeypatch):
@@ -81,7 +81,7 @@ class TestOpenProjectModal:
         app.open_project_modal(state)
 
         assert state.project_modal.active_id == "1"
-        assert state.project_modal.cursor == 0
+        assert state.project_modal.cursor == 1
 
     def test_config_identifier_is_resolved_to_id(self, monkeypatch):
         """config には identifier も設定できるので id に解決して保持する"""
@@ -92,7 +92,7 @@ class TestOpenProjectModal:
         app.open_project_modal(state)
 
         assert state.project_modal.active_id == "2"
-        assert state.project_modal.cursor == 1
+        assert state.project_modal.cursor == 0
 
     def test_cursor_top_when_no_current_project(self, monkeypatch):
         """未切替かつ config 未設定ならカーソルは先頭で active 無し"""

--- a/tests/unit/tui/test_project_switch.py
+++ b/tests/unit/tui/test_project_switch.py
@@ -49,14 +49,6 @@ def _fake_tab(on_activate: Callable[[TuiState], None]) -> TabView:
     )
 
 
-class TestBuildProjectChoices:
-    """_build_project_choices() は fetch_projects() を (id, name) の組に変換する"""
-
-    def test_converts_projects_in_id_desc(self, monkeypatch):
-        monkeypatch.setattr(app, "fetch_projects", lambda: PROJECTS)
-        assert app._build_project_choices() == [("2", "Beta"), ("1", "Alpha")]
-
-
 class TestOpenProjectModal:
     """open_project_modal() は選択肢を構築し現在プロジェクトへカーソルを合わせる"""
 


### PR DESCRIPTION
## 概要

プロジェクト選択ダイアログを ID 降順で表示するようにした。

新しいプロジェクトほど選択頻度が高い傾向があり、選びやすい位置にあったほうが良いため。

Closes #294

## 動作確認

- [x] `redi --tui` -> `p` -> (プロジェクト一覧がID降順になっていること
- [x] `redi init` で表示されるプロジェクト一覧がID降順になっていること


## 変更内容

- `src/redi/api/project.py` — 並べ替えヘルパー `sort_projects_by_id_desc()` を追加
- `src/redi/tui/app.py` — TUI のプロジェクト切替モーダル (`p` キー) で降順にする
- `src/redi/cli/init_command.py` — `redi init` のプロジェクト選択で降順にする
  - `redi.api.project` は `redi.client` を import しており、プロファイル未作成の `init` 実行時にモジュールロードの副作用を持ち込むため、ヘルパーは使わず `sorted()` をインラインに書いている
- `src/redi/tui/app.py` — 未使用の `_build_project_choices()` を削除
  - `open_project_modal()` が同等の処理を持っており、本体からは呼ばれずテストからのみ参照される状態だった。並び順の変更時に二重管理になるのを避ける
- `tests/unit/tui/test_project_switch.py` — 降順化で期待値がずれるアサーションを修正し、削除した関数のテストクラスを除去

## 補足

`fetch_projects()` 自体は変更していないため、`redi project list` の出力は従来どおり Redmine API の返却順 (ツリー順) のまま。
