### PR TITLE
fix(cli): 選択ダイアログで画面外の候補にスクロールできるようにする

### DIFF
--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -8,7 +8,7 @@ import requests
 
 from redi.api.types import IdName
 from redi.api.exceptions import print_http_error_body
-from redi.client import client
+from redi.client import RedmineClient, client
 from redi.config import redmine_url
 from redi.i18n import messages
 
@@ -52,16 +52,20 @@ def list_projects(full: bool = False) -> None:
             print(f"{project['id']} {project['name']}")
 
 
-def fetch_projects() -> list[Project]:
+def fetch_projects(api_client: RedmineClient | None = None) -> list[Project]:
     """アクセスできるプロジェクトを全件返す。
 
     Redmine の一覧 API は limit 未指定だと既定件数しか返さないため、
     `total_count` を見て全件揃うまで offset を進める。
+
+    `api_client` は config 未確定の `redi init` から、入力されたばかりの
+    URL/API キーで呼ぶために受ける。省略時はグローバルの client を使う。
     """
+    target = api_client or client
     projects: list[Project] = []
     offset = 0
     while True:
-        response = client.get(
+        response = target.get(
             "/projects.json", params={"limit": PROJECTS_PAGE_LIMIT, "offset": offset}
         )
         response.raise_for_status()

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -5,8 +5,10 @@ import requests
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import Validator
 
+from redi.api.project import Project, fetch_projects
 from redi.cli.picker import inline_choice
 from redi.cli.validator import UrlValidator
+from redi.client import RedmineClient
 from redi.config import CONFIG_PATH, create_profile
 from redi.i18n import messages
 
@@ -44,22 +46,15 @@ def _verify_connection(url: str, api_key: str) -> dict | None:
     return None
 
 
-def _fetch_projects(url: str, api_key: str) -> list[dict]:
+def _fetch_projects(url: str, api_key: str) -> list[Project]:
     try:
-        response = requests.get(
-            f"{url}/projects.json",
-            headers={"X-Redmine-API-Key": api_key},
-            params={"limit": 100},
-            timeout=10,
-        )
-        response.raise_for_status()
-        return response.json().get("projects", [])
+        return fetch_projects(RedmineClient(url.rstrip("/"), api_key))
     except requests.exceptions.RequestException as e:
         print(messages.project_list_fetch_failed.format(error=e))
         return []
 
 
-def _select_project_id(message: str, projects: list[dict]) -> str:
+def _select_project_id(message: str, projects: list[Project]) -> str:
     options: list[tuple[str, str]] = [
         (str(p["id"]), f"{p['id']} {p['name']}")
         for p in sorted(projects, key=lambda p: p["id"], reverse=True)

--- a/src/redi/cli/picker.py
+++ b/src/redi/cli/picker.py
@@ -1,6 +1,7 @@
 from prompt_toolkit import Application
+from prompt_toolkit.data_structures import Point
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.layout import HSplit, Layout, Window
+from prompt_toolkit.layout import HSplit, Layout, ScrollOffsets, Window
 from prompt_toolkit.layout.controls import FormattedTextControl
 
 
@@ -81,8 +82,14 @@ def inline_checkbox(
                     height=1,
                 ),
                 Window(
-                    FormattedTextControl(render, focusable=True, show_cursor=False),
+                    FormattedTextControl(
+                        render,
+                        focusable=True,
+                        show_cursor=False,
+                        get_cursor_position=lambda: Point(0, cursor),
+                    ),
                     dont_extend_height=True,
+                    scroll_offsets=ScrollOffsets(top=1, bottom=1),
                 ),
             ]
         ),
@@ -154,8 +161,14 @@ def inline_choice(
                     height=1,
                 ),
                 Window(
-                    FormattedTextControl(render, focusable=True, show_cursor=False),
+                    FormattedTextControl(
+                        render,
+                        focusable=True,
+                        show_cursor=False,
+                        get_cursor_position=lambda: Point(0, cursor),
+                    ),
                     dont_extend_height=True,
+                    scroll_offsets=ScrollOffsets(top=1, bottom=1),
                 ),
             ]
         ),


### PR DESCRIPTION
## 概要

`redi init` でプロジェクトが選べない問題を修正した。原因が 2 つあったため、それぞれ別コミットで対応している。

Closes #296

## 1. 画面から見切れた候補にスクロールできない

### 原因

`src/redi/cli/picker.py` の候補一覧 `Window` が `FormattedTextControl` に `get_cursor_position` を渡しておらず、描画がカーソル行に追従していなかった。`j` を押すと内部の `cursor` は進むが、描画は常に先頭行からのままで、端末高を超えた候補は画面外に留まる。

TUI のプロジェクト切替モーダル (`src/redi/tui/project_modal.py`) では既に同じ問題を `get_cursor_position` + `ScrollOffsets` で解決済みで、`picker.py` に横展開されていなかった。

### 変更内容

`inline_choice` / `inline_checkbox` の両方に、TUI 側と同じ手当てを入れた。

- `FormattedTextControl` に `get_cursor_position=lambda: Point(0, cursor)` を渡す
- `Window` に `scroll_offsets=ScrollOffsets(top=1, bottom=1)` を設定する

`picker.py` は `config` / `time_entry` / `wiki` / `issue` / `version` の各コマンドの選択にも使われるため、それらにも同時に効く。

## 2. 101 件目以降がそもそも取得されていない

### 原因

`src/redi/cli/init_command.py` の `_fetch_projects()` が `limit=100` の単発リクエストで、101 件目以降が選択肢に出ていなかった。スクロールを直しても、これらのプロジェクトには到達できない。

### 変更内容

ページングは `src/redi/api/project.py` の `fetch_projects()` に既にあるため、ロジックを重複させず再利用した。

- `fetch_projects(api_client: RedmineClient | None = None)` として client を注入可能にした。省略時は従来どおりグローバルの `client` を使う
- `_fetch_projects()` は `RedmineClient(url.rstrip("/"), api_key)` を渡して呼ぶだけにし、requests 直叩きと `limit=100` を削除した。戻り値の型も `list[dict]` → `list[Project]` に変更

client を注入可能にしたのは、`src/redi/client.py` のグローバル `client` がモジュールロード時に config の値で確定するため。`init` はまだ config に無い、入力されたばかりの URL/API キーで取りに行く必要がある。

## 挙動の変化

旧 `_fetch_projects` は `timeout=10` を指定していたが、`RedmineClient` は timeout を設定しないため、プロジェクト取得はタイムアウトなしになる。他コマンドとは同じ挙動で、init では直前の `_verify_connection` (こちらは `timeout=10` のまま) が疎通確認を行うため、影響は限定的と判断した。

## ~~残課題 (別対応)~~

> 候補が多いとターミナルのスクロールバックを一覧が埋め尽くす。表示高の上限設定は本 PR には含めていない。

課題視しない

## 動作確認

- [x] `redi init`で画面外に見切れたプロジェクトまでスクロールが効くこと
- [x] 100件超のプロジェクトを作成して、それぞれ`redi init` で選べること