### PR TITLE
ruff の ignore を解消するか維持するか判断して対応する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,10 @@ dev = [
 module-name = "redi"
 
 [tool.ruff.lint]
-# ruff 0.16 で拡張されたデフォルトルールのうち、既存コードに適合しないものを除外する
 ignore = [
-  "DTZ",     # tz を持たない date/datetime の生成を許容する
+  # タイムゾーンを意識した実装はしないので許容する
+  "DTZ005", # datetime.now() を tz なしで呼ぶことを許容する
+  "DTZ011", # date.today() の使用を許容する
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ ignore = [
   "I001",    # import の並び順を強制しない
   "DTZ",     # tz を持たない date/datetime の生成を許容する
   "SIM114",  # 同一処理となる分岐の統合を必須としない
-  "PIE807",  # lambda: [] の使用を許容する
   "FURB122", # ループ内の write() を writelines() にまとめない
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ ignore = [
   "PLR1722", # exit() の使用を許容する
   "I001",    # import の並び順を強制しない
   "DTZ",     # tz を持たない date/datetime の生成を許容する
-  "PLW1510", # subprocess.run() への check 指定を必須としない
   "SIM114",  # 同一処理となる分岐の統合を必須としない
   "PIE807",  # lambda: [] の使用を許容する
   "FURB122", # ループ内の write() を writelines() にまとめない

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ module-name = "redi"
 ignore = [
   "DTZ",     # tz を持たない date/datetime の生成を許容する
   "SIM114",  # 同一処理となる分岐の統合を必須としない
-  "FURB122", # ループ内の write() を writelines() にまとめない
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ ignore = [
   "PLR1722", # exit() の使用を許容する
   "I001",    # import の並び順を強制しない
   "DTZ",     # tz を持たない date/datetime の生成を許容する
-  "B006",    # ミュータブルなデフォルト引数を許容する
   "PLW1510", # subprocess.run() への check 指定を必須としない
   "SIM114",  # 同一処理となる分岐の統合を必須としない
   "PIE807",  # lambda: [] の使用を許容する

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ module-name = "redi"
 # ruff 0.16 で拡張されたデフォルトルールのうち、既存コードに適合しないものを除外する
 ignore = [
   "DTZ",     # tz を持たない date/datetime の生成を許容する
-  "SIM114",  # 同一処理となる分岐の統合を必須としない
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,6 @@ module-name = "redi"
 [tool.ruff.lint]
 # ruff 0.16 で拡張されたデフォルトルールのうち、既存コードに適合しないものを除外する
 ignore = [
-  "PLR1722", # exit() の使用を許容する
-  "I001",    # import の並び順を強制しない
   "DTZ",     # tz を持たない date/datetime の生成を許容する
   "SIM114",  # 同一処理となる分岐の統合を必須としない
   "FURB122", # ループ内の write() を writelines() にまとめない

--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -1,6 +1,7 @@
 import json
 import mimetypes
 import os
+import sys
 from pathlib import Path
 
 import requests
@@ -10,7 +11,6 @@ from redi.api.types import Attachment
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 

--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -84,7 +84,8 @@ def download_attachment(attachment: Attachment, path: Path) -> None:
         sys.exit(1)
     try:
         with open(path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+            # writelines() でも等価だが、チャンク単位の書き込みは for の方が可読性が高い
+            for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):  # noqa: FURB122
                 f.write(chunk)
     except OSError as e:
         print(e)

--- a/src/redi/api/attachment.py
+++ b/src/redi/api/attachment.py
@@ -10,6 +10,7 @@ from redi.api.types import Attachment
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 
@@ -17,7 +18,7 @@ DOWNLOAD_CHUNK_SIZE = 1024 * 1024
 def upload_file(file_path: str) -> dict:
     if not os.path.isfile(file_path):
         print(messages.file_not_found.format(path=file_path))
-        exit(1)
+        sys.exit(1)
     filename = os.path.basename(file_path)
     content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
     with open(file_path, "rb") as f:
@@ -32,7 +33,7 @@ def upload_file(file_path: str) -> dict:
         print(e)
         print_http_error_body(e)
         print(messages.file_upload_failed_with_path.format(path=file_path))
-        exit(1)
+        sys.exit(1)
     token = response.json()["upload"]["token"]
     return {
         "token": token,
@@ -45,7 +46,7 @@ def fetch_attachment(attachment_id: str) -> Attachment:
     response = client.get(f"/attachments/{attachment_id}.json")
     if response.status_code == 404:
         print(messages.attachment_not_found.format(id=attachment_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["attachment"]
 
@@ -65,7 +66,7 @@ def resolve_download_url_path(attachment: Attachment) -> str:
     content_url = attachment.get("content_url") or ""
     if not redmine_url or not content_url.startswith(redmine_url):
         print(messages.attachment_content_url_unexpected.format(url=content_url))
-        exit(1)
+        sys.exit(1)
     return content_url[len(redmine_url) :]
 
 
@@ -73,14 +74,14 @@ def download_attachment(attachment: Attachment, path: Path) -> None:
     response = client.get(resolve_download_url_path(attachment), stream=True)
     if response.status_code == 404:
         print(messages.attachment_not_found.format(id=attachment["id"]))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.attachment_download_failed)
-        exit(1)
+        sys.exit(1)
     try:
         with open(path, "wb") as f:
             for chunk in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
@@ -88,7 +89,7 @@ def download_attachment(attachment: Attachment, path: Path) -> None:
     except OSError as e:
         print(e)
         print(messages.attachment_download_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.attachment_downloaded.format(path=path))
 
 
@@ -120,14 +121,14 @@ def delete_attachment(attachment_id: str) -> None:
     response = client.delete(f"/attachments/{attachment_id}.json")
     if response.status_code == 404:
         print(messages.attachment_not_found.format(id=attachment_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.attachment_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.attachment_deleted.format(id=attachment_id))
 
 
@@ -143,20 +144,20 @@ def update_attachment(
         data["description"] = description
     if not data:
         print(messages.update_canceled)
-        exit()
+        sys.exit()
     response = client.patch(
         f"/attachments/{attachment_id}.json", json={"attachment": data}
     )
     if response.status_code == 404:
         print(messages.attachment_not_found.format(id=attachment_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.attachment_update_failed)
-        exit(1)
+        sys.exit(1)
     print(
         messages.attachment_updated.format(
             url=f"{redmine_url}/attachments/{attachment_id}"

--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -1,10 +1,10 @@
 import json
-from typing import NotRequired, TypedDict, cast, Literal
+import sys
+from typing import Literal, NotRequired, TypedDict, cast
 
 from redi import cache
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 CACHE_KEY = "custom_fields"
 

--- a/src/redi/api/custom_field.py
+++ b/src/redi/api/custom_field.py
@@ -4,6 +4,7 @@ from typing import NotRequired, TypedDict, cast, Literal
 from redi import cache
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 CACHE_KEY = "custom_fields"
 
@@ -65,7 +66,7 @@ def list_custom_fields(full: bool = False) -> None:
     custom_fields = fetch_custom_fields()
     if custom_fields is None:
         print(messages.custom_field_admin_required)
-        exit(1)
+        sys.exit(1)
     if full:
         print(json.dumps(custom_fields, ensure_ascii=False))
     else:

--- a/src/redi/api/file.py
+++ b/src/redi/api/file.py
@@ -6,13 +6,14 @@ from redi.api.attachment import upload_file
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 def list_files(project_id: str, full: bool = False) -> None:
     response = client.get(f"/projects/{project_id}/files.json")
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     files = response.json()["files"]
     if full:
@@ -46,12 +47,12 @@ def create_file(
     )
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.file_upload_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.file_uploaded.format(filename=upload["filename"]))

--- a/src/redi/api/file.py
+++ b/src/redi/api/file.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import requests
 
@@ -6,7 +7,6 @@ from redi.api.attachment import upload_file
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 def list_files(project_id: str, full: bool = False) -> None:

--- a/src/redi/api/group.py
+++ b/src/redi/api/group.py
@@ -6,6 +6,7 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 
 def list_groups(full: bool = False) -> None:
@@ -26,10 +27,10 @@ def fetch_group(group_id: str, include: str = "") -> dict:
     response = client.get(f"/groups/{group_id}.json", params=params)
     if response.status_code == 404:
         print(messages.group_not_found.format(id=group_id))
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.group_get_admin_required)
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["group"]
 
@@ -72,21 +73,21 @@ def update_group(
         data["user_ids"] = user_ids
     if len(data) == 0:
         print(messages.update_canceled)
-        exit()
+        sys.exit()
     response = client.put(f"/groups/{group_id}.json", json={"group": data})
     if response.status_code == 404:
         print(messages.group_not_found.format(id=group_id))
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.group_update_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.group_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.group_updated.format(id=group_id))
 
 
@@ -97,17 +98,17 @@ def add_group_user(group_id: str, user_id: int) -> None:
     )
     if response.status_code == 404:
         print(messages.group_not_found.format(id=group_id))
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.group_add_user_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.group_add_user_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.group_user_added.format(group_id=group_id, user_id=user_id))
 
 
@@ -117,17 +118,17 @@ def remove_group_user(group_id: str, user_id: int) -> None:
         print(
             messages.group_or_user_not_found.format(group_id=group_id, user_id=user_id)
         )
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.group_remove_user_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.group_remove_user_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.group_user_removed.format(group_id=group_id, user_id=user_id))
 
 
@@ -135,17 +136,17 @@ def delete_group(group_id: str) -> None:
     response = client.delete(f"/groups/{group_id}.json")
     if response.status_code == 404:
         print(messages.group_not_found.format(id=group_id))
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.group_delete_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.group_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.group_deleted.format(id=group_id))
 
 
@@ -156,14 +157,14 @@ def create_group(name: str, user_ids: list[int] | None = None) -> None:
     response = client.post("/groups.json", json={"group": group_data})
     if response.status_code == 403:
         print(messages.group_create_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.group_create_failed)
-        exit(1)
+        sys.exit(1)
     created = response.json()["group"]
     print(
         messages.group_created.format(

--- a/src/redi/api/group.py
+++ b/src/redi/api/group.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import requests
 
@@ -6,7 +7,6 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 
 def list_groups(full: bool = False) -> None:

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -398,7 +398,7 @@ def update_issue(
     estimated_hours: float | None = None,
     notes: str = "",
     custom_fields: str | None = None,
-    attachments: list[str] = [],
+    attachments: list[str] | None = None,
 ) -> None:
     """イシューを更新する
 

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -13,6 +13,7 @@ from redi.api.exceptions import RedmineValidationException, print_http_error_bod
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 
 class IssuesPageResponse(TypedDict):
@@ -182,7 +183,7 @@ def fetch_issue(issue_id: str, include: str = "") -> Issue:
     response = client.get(f"/issues/{issue_id}.json", params=params)
     if response.status_code == 404:
         print(messages.issue_not_found.format(id=issue_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["issue"]
 
@@ -375,7 +376,7 @@ def create_issue(
         print(e)
         print_http_error_body(e)
         print(messages.issue_create_failed)
-        exit(1)
+        sys.exit(1)
     created = response.json()["issue"]
     url = f"{redmine_url}/issues/{created['id']}"
     print(messages.issue_created.format(url=url))
@@ -437,7 +438,7 @@ def update_issue(
         issue_data["uploads"] = [upload_file(file_path) for file_path in attachments]
     if len(issue_data) == 0:
         print(messages.update_canceled)
-        exit()
+        sys.exit()
     response = client.put(f"/issues/{issue_id}.json", json={"issue": issue_data})
     if response.status_code == 422:
         raise RedmineValidationException.from_response("issue", "update", response)
@@ -447,7 +448,7 @@ def update_issue(
         print(e)
         print_http_error_body(e)
         print(messages.issue_update_failed)
-        exit(1)
+        sys.exit(1)
     url = f"{redmine_url}/issues/{issue_id}"
     print(messages.issue_updated.format(url=url))
 
@@ -459,14 +460,14 @@ def add_watcher(issue_id: str, user_id: int) -> None:
     )
     if response.status_code == 404:
         print(messages.issue_not_found.format(id=issue_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.watcher_add_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.watcher_added.format(issue_id=issue_id, user_id=user_id))
 
 
@@ -476,14 +477,14 @@ def remove_watcher(issue_id: str, user_id: int) -> None:
         print(
             messages.issue_or_user_not_found.format(issue_id=issue_id, user_id=user_id)
         )
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.watcher_remove_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.watcher_removed.format(issue_id=issue_id, user_id=user_id))
 
 
@@ -491,14 +492,14 @@ def delete_issue(issue_id: str) -> None:
     response = client.delete(f"/issues/{issue_id}.json")
     if response.status_code == 404:
         print(messages.issue_not_found.format(id=issue_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.issue_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.issue_deleted.format(id=issue_id))
 
 

--- a/src/redi/api/issue.py
+++ b/src/redi/api/issue.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 import json
+import sys
 import webbrowser
 from collections import defaultdict
 from typing import NotRequired, TypedDict, cast
 
 import requests
 
-from redi.api.types import IdName
 from redi.api.attachment import upload_file
 from redi.api.exceptions import RedmineValidationException, print_http_error_body
+from redi.api.types import IdName
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 
 class IssuesPageResponse(TypedDict):

--- a/src/redi/api/issue_category.py
+++ b/src/redi/api/issue_category.py
@@ -1,11 +1,11 @@
 import json
+import sys
 
 import requests
 
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 def list_issue_categories(project_id: str, full: bool = False) -> None:

--- a/src/redi/api/issue_category.py
+++ b/src/redi/api/issue_category.py
@@ -5,6 +5,7 @@ import requests
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 def list_issue_categories(project_id: str, full: bool = False) -> None:
@@ -32,7 +33,7 @@ def fetch_issue_category(category_id: str) -> dict:
     response = client.get(f"/issue_categories/{category_id}.json")
     if response.status_code == 404:
         print(messages.category_not_found.format(id=category_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["issue_category"]
 
@@ -78,7 +79,7 @@ def create_issue_category(
         print(e)
         print_http_error_body(e)
         print(messages.category_create_failed)
-        exit(1)
+        sys.exit(1)
     created = response.json()["issue_category"]
     print(messages.category_created.format(id=created["id"], name=created["name"]))
 
@@ -95,21 +96,21 @@ def update_issue_category(
         data["assigned_to_id"] = assigned_to_id
     if len(data) == 0:
         print(messages.update_canceled)
-        exit()
+        sys.exit()
     response = client.put(
         f"/issue_categories/{category_id}.json",
         json={"issue_category": data},
     )
     if response.status_code == 404:
         print(messages.category_not_found.format(id=category_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.category_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.category_updated.format(id=category_id))
 
 
@@ -120,12 +121,12 @@ def delete_issue_category(category_id: str, reassign_to_id: int | None = None) -
     response = client.delete(f"/issue_categories/{category_id}.json", params=params)
     if response.status_code == 404:
         print(messages.category_not_found.format(id=category_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.category_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.category_deleted.format(id=category_id))

--- a/src/redi/api/issue_journal.py
+++ b/src/redi/api/issue_journal.py
@@ -1,9 +1,10 @@
+import sys
+
 import requests
 
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 def update_issue_journal(journal_id: str, notes: str) -> None:

--- a/src/redi/api/issue_journal.py
+++ b/src/redi/api/issue_journal.py
@@ -3,6 +3,7 @@ import requests
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 def update_issue_journal(journal_id: str, notes: str) -> None:
@@ -12,14 +13,14 @@ def update_issue_journal(journal_id: str, notes: str) -> None:
     )
     if response.status_code == 404:
         print(messages.issue_journal_not_found.format(id=journal_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.issue_journal_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.issue_journal_updated.format(id=journal_id))
 
 
@@ -30,12 +31,12 @@ def delete_issue_journal(journal_id: str) -> None:
     )
     if response.status_code == 404:
         print(messages.issue_journal_not_found.format(id=journal_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.issue_journal_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.issue_journal_deleted.format(id=journal_id))

--- a/src/redi/api/issue_relation.py
+++ b/src/redi/api/issue_relation.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import requests
 
@@ -6,7 +7,6 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 
 def fetch_relation(relation_id: str) -> dict:

--- a/src/redi/api/issue_relation.py
+++ b/src/redi/api/issue_relation.py
@@ -6,13 +6,14 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 
 def fetch_relation(relation_id: str) -> dict:
     response = client.get(f"/relations/{relation_id}.json")
     if response.status_code == 404:
         print(messages.relation_not_found.format(id=relation_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["relation"]
 
@@ -51,7 +52,7 @@ def create_relation(
         print(e)
         print_http_error_body(e)
         print(messages.relation_create_failed)
-        exit(1)
+        sys.exit(1)
     print(
         messages.relation_created.format(
             from_id=issue_id, type=relation_type, to_id=issue_to_id
@@ -78,7 +79,7 @@ def delete_relation(issue_id: str, issue_to_id: str) -> None:
                 from_id=issue_id, to_id=issue_to_id
             )
         )
-        exit(1)
+        sys.exit(1)
     response = client.delete(f"/relations/{target_relation['id']}.json")
     try:
         response.raise_for_status()

--- a/src/redi/api/issue_template.py
+++ b/src/redi/api/issue_template.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import TypedDict
 
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 class IssueTemplate(TypedDict):

--- a/src/redi/api/issue_template.py
+++ b/src/redi/api/issue_template.py
@@ -5,6 +5,7 @@ from typing import TypedDict
 
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 class IssueTemplate(TypedDict):
@@ -34,7 +35,7 @@ def fetch_issue_templates(project_id: str) -> dict[str, list[IssueTemplate]]:
     # プラグイン非インストール時
     if response.status_code == 404:
         print(messages.issue_template_not_available)
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()
 

--- a/src/redi/api/me.py
+++ b/src/redi/api/me.py
@@ -1,11 +1,11 @@
 import json
+import sys
 
 import requests
 
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 def fetch_my_user_id() -> str | None:

--- a/src/redi/api/me.py
+++ b/src/redi/api/me.py
@@ -5,6 +5,7 @@ import requests
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 def fetch_my_user_id() -> str | None:
@@ -59,7 +60,7 @@ def update_my_account(
         data["mail"] = mail
     if not data:
         print(messages.update_canceled_no_changes)
-        exit(1)
+        sys.exit(1)
     response = client.put("/my/account.json", json={"user": data})
     try:
         response.raise_for_status()
@@ -67,5 +68,5 @@ def update_my_account(
         print(e)
         print_http_error_body(e)
         print(messages.account_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.account_updated)

--- a/src/redi/api/membership.py
+++ b/src/redi/api/membership.py
@@ -6,6 +6,7 @@ import requests
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 class ProjectUser(TypedDict):
@@ -65,7 +66,7 @@ def fetch_membership(membership_id: str) -> dict:
     response = client.get(f"/memberships/{membership_id}.json")
     if response.status_code == 404:
         print(messages.membership_not_found.format(id=membership_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["membership"]
 
@@ -105,7 +106,7 @@ def create_membership(
         data["user_id"] = group_id
     else:
         print(messages.user_or_group_id_required)
-        exit(1)
+        sys.exit(1)
     response = client.post(
         f"/projects/{project_id}/memberships.json", json={"membership": data}
     )
@@ -115,7 +116,7 @@ def create_membership(
         print(e)
         print_http_error_body(e)
         print(messages.membership_create_failed)
-        exit(1)
+        sys.exit(1)
     created = response.json()["membership"]
     print(messages.membership_created.format(line=_format_membership_line(created)))
 
@@ -123,7 +124,7 @@ def create_membership(
 def update_membership(membership_id: str, role_ids: list[int]) -> None:
     if not role_ids:
         print(messages.update_canceled)
-        exit()
+        sys.exit()
     response = client.put(
         f"/memberships/{membership_id}.json",
         json={"membership": {"role_ids": role_ids}},
@@ -134,7 +135,7 @@ def update_membership(membership_id: str, role_ids: list[int]) -> None:
         print(e)
         print_http_error_body(e)
         print(messages.membership_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.membership_updated.format(id=membership_id))
 
 
@@ -142,14 +143,14 @@ def delete_membership(membership_id: str) -> None:
     response = client.delete(f"/memberships/{membership_id}.json")
     if response.status_code == 404:
         print(messages.membership_not_found.format(id=membership_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.membership_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.membership_deleted.format(id=membership_id))
 
 

--- a/src/redi/api/membership.py
+++ b/src/redi/api/membership.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from typing import NotRequired, TypedDict, cast
 
 import requests
@@ -6,7 +7,6 @@ import requests
 from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 class ProjectUser(TypedDict):

--- a/src/redi/api/news.py
+++ b/src/redi/api/news.py
@@ -1,8 +1,8 @@
 import json
+import sys
 
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 def list_news(project_id: str | None = None, full: bool = False) -> None:

--- a/src/redi/api/news.py
+++ b/src/redi/api/news.py
@@ -2,6 +2,7 @@ import json
 
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 def list_news(project_id: str | None = None, full: bool = False) -> None:
@@ -12,7 +13,7 @@ def list_news(project_id: str | None = None, full: bool = False) -> None:
     response = client.get(path)
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     news_list = response.json()["news"]
     if full:

--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -11,6 +11,7 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import RedmineClient, client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 # Redmine の一覧 API が 1 リクエストで返せる上限
 PROJECTS_PAGE_LIMIT = 100
@@ -90,7 +91,7 @@ def resolve_project_id(value: str) -> str:
         if p.get("identifier") == value or p.get("name") == value:
             return str(p["id"])
     print(messages.project_not_found.format(id=value))
-    exit(1)
+    sys.exit(1)
 
 
 def fetch_project(project_id: str, include: str = "") -> Project:
@@ -100,7 +101,7 @@ def fetch_project(project_id: str, include: str = "") -> Project:
     response = client.get(f"/projects/{project_id}.json", params=params)
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return cast("Project", response.json()["project"])
 
@@ -133,7 +134,7 @@ def create_project(
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
-        exit(1)
+        sys.exit(1)
 
 
 def update_project(
@@ -157,7 +158,7 @@ def update_project(
         data["tracker_ids"] = tracker_ids
     if len(data) == 0:
         print(messages.update_canceled)
-        exit()
+        sys.exit()
     response = client.put(f"/projects/{project_id}.json", json={"project": data})
     try:
         response.raise_for_status()
@@ -165,7 +166,7 @@ def update_project(
         print(e)
         print_http_error_body(e)
         print(messages.project_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.project_updated.format(id=project_id))
 
 
@@ -173,14 +174,14 @@ def archive_project(project_id: str) -> None:
     response = client.put(f"/projects/{project_id}/archive.json")
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.project_archive_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.project_archived.format(id=project_id))
 
 
@@ -188,14 +189,14 @@ def unarchive_project(project_id: str) -> None:
     response = client.put(f"/projects/{project_id}/unarchive.json")
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.project_unarchive_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.project_unarchived.format(id=project_id))
 
 
@@ -203,14 +204,14 @@ def delete_project(project_id: str) -> None:
     response = client.delete(f"/projects/{project_id}.json")
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.project_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.project_deleted.format(id=project_id))
 
 
@@ -228,7 +229,7 @@ def read_project(
     response = client.get(f"/projects/{project_id}.json", params=params)
     if response.status_code == 404:
         print(messages.project_not_found.format(id=project_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     project = cast("Project", response.json()["project"])
     if full:

--- a/src/redi/api/project.py
+++ b/src/redi/api/project.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
 import json
+import sys
 import webbrowser
 from typing import NotRequired, TypedDict, cast
 
 import requests
 
-from redi.api.types import IdName
 from redi.api.exceptions import print_http_error_body
+from redi.api.types import IdName
 from redi.client import RedmineClient, client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 # Redmine の一覧 API が 1 リクエストで返せる上限
 PROJECTS_PAGE_LIMIT = 100

--- a/src/redi/api/role.py
+++ b/src/redi/api/role.py
@@ -1,8 +1,8 @@
 import json
+import sys
 
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 def list_roles(full: bool = False) -> None:

--- a/src/redi/api/role.py
+++ b/src/redi/api/role.py
@@ -2,6 +2,7 @@ import json
 
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 def list_roles(full: bool = False) -> None:
@@ -19,7 +20,7 @@ def fetch_role(role_id: str) -> dict:
     response = client.get(f"/roles/{role_id}.json")
     if response.status_code == 404:
         print(messages.role_not_found.format(id=role_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["role"]
 

--- a/src/redi/api/search.py
+++ b/src/redi/api/search.py
@@ -4,7 +4,6 @@ from typing import Literal, get_args
 from redi.client import client
 from redi.i18n import messages
 
-
 # https://www.redmine.org/projects/redmine/wiki/Rest_Search
 SearchScope = Literal["all", "my_projects", "bookmarks", "subprojects"]
 SearchType = Literal[

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from typing import NotRequired, TypedDict, cast
 
 import requests
@@ -10,7 +11,6 @@ from redi.api.project import resolve_project_id
 from redi.api.types import IdName
 from redi.client import client
 from redi.i18n import messages
-import sys
 
 
 class TimeEntry(TypedDict):

--- a/src/redi/api/time_entry.py
+++ b/src/redi/api/time_entry.py
@@ -10,6 +10,7 @@ from redi.api.project import resolve_project_id
 from redi.api.types import IdName
 from redi.client import client
 from redi.i18n import messages
+import sys
 
 
 class TimeEntry(TypedDict):
@@ -63,7 +64,7 @@ def create_time_entry(
     """
     if not issue_id and not project_id:
         print(messages.issue_or_project_id_required)
-        exit(1)
+        sys.exit(1)
     # time_entries は他の API と異なり project_id に slug を受け付けず整数のみ許容
     # https://www.redmine.org/projects/redmine/wiki/Rest_TimeEntries
     if project_id is not None:
@@ -88,7 +89,7 @@ def create_time_entry(
         print(e)
         print_http_error_body(e)
         print(messages.time_entry_create_failed)
-        exit(1)
+        sys.exit(1)
     created = cast("TimeEntry", response.json()["time_entry"])
     print(
         messages.time_entry_created.format(
@@ -218,7 +219,7 @@ def fetch_time_entry(time_entry_id: str) -> TimeEntry:
     response = client.get(f"/time_entries/{time_entry_id}.json")
     if response.status_code == 404:
         print(messages.time_entry_not_found.format(id=time_entry_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return cast("TimeEntry", response.json()["time_entry"])
 
@@ -277,7 +278,7 @@ def update_time_entry(
         data["comments"] = comments
     if not data:
         print(messages.update_canceled_no_changes)
-        exit(1)
+        sys.exit(1)
     response = client.put(
         f"/time_entries/{time_entry_id}.json", json={"time_entry": data}
     )
@@ -289,7 +290,7 @@ def update_time_entry(
         print(e)
         print_http_error_body(e)
         print(messages.time_entry_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.time_entry_updated.format(id=time_entry_id))
 
 
@@ -301,5 +302,5 @@ def delete_time_entry(time_entry_id: str) -> None:
         print(e)
         print_http_error_body(e)
         print(messages.time_entry_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.time_entry_deleted.format(id=time_entry_id))

--- a/src/redi/api/user.py
+++ b/src/redi/api/user.py
@@ -6,6 +6,7 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 
 def create_user(
@@ -41,14 +42,14 @@ def create_user(
     response = client.post("/users.json", json={"user": user_data})
     if response.status_code == 403:
         print(messages.user_create_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.user_create_failed)
-        exit(1)
+        sys.exit(1)
     created = response.json()["user"]
     print(
         messages.user_created.format(
@@ -87,10 +88,10 @@ def fetch_user(user_id: str, include: list[str] | None = None) -> dict:
     response = client.get(f"/users/{user_id}.json", params=params)
     if response.status_code == 404:
         print(messages.user_not_found.format(id=user_id))
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.user_detail_permission_required)
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return pop_apikey(response.json()["user"])
 
@@ -164,21 +165,21 @@ def update_user(
         data["admin"] = admin
     if not data:
         print(messages.update_canceled_no_changes)
-        exit(1)
+        sys.exit(1)
     response = client.put(f"/users/{user_id}.json", json={"user": data})
     if response.status_code == 404:
         print(messages.user_not_found.format(id=user_id))
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.user_update_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.user_update_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.user_updated.format(id=user_id))
 
 
@@ -186,15 +187,15 @@ def delete_user(user_id: str) -> None:
     response = client.delete(f"/users/{user_id}.json")
     if response.status_code == 404:
         print(messages.user_not_found.format(id=user_id))
-        exit(1)
+        sys.exit(1)
     if response.status_code == 403:
         print(messages.user_delete_admin_required)
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.user_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.user_deleted.format(id=user_id))

--- a/src/redi/api/user.py
+++ b/src/redi/api/user.py
@@ -1,4 +1,5 @@
 import json
+import sys
 
 import requests
 
@@ -6,7 +7,6 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 
 def create_user(

--- a/src/redi/api/version.py
+++ b/src/redi/api/version.py
@@ -7,6 +7,7 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 
 def create_version(
@@ -35,7 +36,7 @@ def create_version(
         print(e)
         print_http_error_body(e)
         print(messages.version_create_failed)
-        exit(1)
+        sys.exit(1)
     created = response.json()["version"]
     print(
         messages.version_created.format(
@@ -67,7 +68,7 @@ def update_version(
         version_data["sharing"] = sharing
     if len(version_data) == 0:
         print(messages.update_canceled)
-        exit()
+        sys.exit()
     response = client.put(
         f"/versions/{version_id}.json", json={"version": version_data}
     )
@@ -77,7 +78,7 @@ def update_version(
         print(e)
         print_http_error_body(e)
         print(messages.version_update_failed)
-        exit(1)
+        sys.exit(1)
     print(
         messages.version_updated.format(
             id=version_id, url=f"{redmine_url}/versions/{version_id}"
@@ -89,7 +90,7 @@ def fetch_version(version_id: str) -> dict:
     response = client.get(f"/versions/{version_id}.json")
     if response.status_code == 404:
         print(messages.version_not_found.format(id=version_id))
-        exit(1)
+        sys.exit(1)
     response.raise_for_status()
     return response.json()["version"]
 
@@ -130,14 +131,14 @@ def delete_version(version_id: str) -> None:
     response = client.delete(f"/versions/{version_id}.json")
     if response.status_code == 404:
         print(messages.version_not_found.format(id=version_id))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.version_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.version_deleted.format(id=version_id))
 
 

--- a/src/redi/api/version.py
+++ b/src/redi/api/version.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import webbrowser
 
 import requests
@@ -7,7 +8,6 @@ from redi.api.exceptions import print_http_error_body
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 
 def create_version(

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -12,6 +12,7 @@ from redi.api.types import Attachment, IdName
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
+import sys
 
 
 class WikiPage(TypedDict):
@@ -158,7 +159,7 @@ def read_wiki(
             )
         else:
             print(messages.wiki_page_not_found.format(title=page_title))
-        exit(1)
+        sys.exit(1)
     if full:
         print(json.dumps(wiki, ensure_ascii=False, indent=2))
     else:
@@ -205,14 +206,14 @@ def delete_wiki(project_id: str, page_title: str) -> None:
     response = client.delete(f"/projects/{project_id}/wiki/{page_title}.json")
     if response.status_code == 404:
         print(messages.wiki_page_not_found.format(title=page_title))
-        exit(1)
+        sys.exit(1)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError as e:
         print(e)
         print_http_error_body(e)
         print(messages.wiki_page_delete_failed)
-        exit(1)
+        sys.exit(1)
     print(messages.wiki_page_deleted.format(title=page_title))
 
 

--- a/src/redi/api/wiki.py
+++ b/src/redi/api/wiki.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import webbrowser
 from collections import defaultdict
 from typing import NotRequired, TypedDict, cast
@@ -12,7 +13,6 @@ from redi.api.types import Attachment, IdName
 from redi.client import client
 from redi.config import redmine_url
 from redi.i18n import messages
-import sys
 
 
 class WikiPage(TypedDict):

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -115,7 +115,9 @@ def handle_config(args: argparse.Namespace) -> None:
         if not result.created:
             sys.exit(1)
         print(messages.profile_created.format(name=args.profile_name))
-        if result.set_as_default:
+        # or で統合できるが、副作用のある set_default_profile() を
+        # 条件式に埋めない方が可読性が高い
+        if result.set_as_default:  # noqa: SIM114
             print(messages.default_profile_set.format(name=args.profile_name))
         elif args.set_default and set_default_profile(args.profile_name):
             print(messages.default_profile_set.format(name=args.profile_name))

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from redi.cli.alias import resolve_alias
 from redi.cli.picker import inline_choice
@@ -12,7 +13,6 @@ from redi.config import (
     update_config,
 )
 from redi.i18n import messages, select_messages
-import sys
 
 
 def add_config_parser(

--- a/src/redi/cli/config_command.py
+++ b/src/redi/cli/config_command.py
@@ -12,6 +12,7 @@ from redi.config import (
     update_config,
 )
 from redi.i18n import messages, select_messages
+import sys
 
 
 def add_config_parser(
@@ -80,7 +81,7 @@ def _interactive_select_default_profile() -> None:
     profile_names = list_profile_names()
     if not profile_names:
         print(messages.no_profiles_available)
-        exit(1)
+        sys.exit(1)
     current_default = get_default_profile()
     options: list[tuple[str, str]] = [
         (name, f"{name} (default)" if name == current_default else name)
@@ -94,7 +95,7 @@ def _interactive_select_default_profile() -> None:
         )
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if set_default_profile(selected):
         print(messages.default_profile_set.format(name=selected))
 
@@ -112,7 +113,7 @@ def handle_config(args: argparse.Namespace) -> None:
             language=args.language,
         )
         if not result.created:
-            exit(1)
+            sys.exit(1)
         print(messages.profile_created.format(name=args.profile_name))
         if result.set_as_default:
             print(messages.default_profile_set.format(name=args.profile_name))

--- a/src/redi/cli/confirm.py
+++ b/src/redi/cli/confirm.py
@@ -1,6 +1,7 @@
 from prompt_toolkit import prompt
 
 from redi.i18n import messages
+import sys
 
 
 def confirm_delete(summary: str) -> None:
@@ -9,10 +10,10 @@ def confirm_delete(summary: str) -> None:
         confirm = prompt(messages.prompt_confirm_delete).strip().lower()
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if confirm != "yes":
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 def confirm_overwrite(summary: str) -> None:
@@ -21,10 +22,10 @@ def confirm_overwrite(summary: str) -> None:
         confirm = prompt(messages.prompt_confirm_overwrite).strip().lower()
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if confirm != "yes":
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 def confirm_delete_with_identifier(
@@ -39,7 +40,7 @@ def confirm_delete_with_identifier(
         ).strip()
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if entered != expected:
         print(messages.canceled_field_mismatch.format(field=field_label))
-        exit(1)
+        sys.exit(1)

--- a/src/redi/cli/confirm.py
+++ b/src/redi/cli/confirm.py
@@ -1,7 +1,8 @@
+import sys
+
 from prompt_toolkit import prompt
 
 from redi.i18n import messages
-import sys
 
 
 def confirm_delete(summary: str) -> None:

--- a/src/redi/cli/file_command.py
+++ b/src/redi/cli/file_command.py
@@ -1,10 +1,10 @@
 import argparse
+import sys
 
 from redi.api.file import create_file, list_files
 from redi.cli.alias import resolve_alias
 from redi.config import default_project_id
 from redi.i18n import messages
-import sys
 
 
 def add_file_parser(

--- a/src/redi/cli/file_command.py
+++ b/src/redi/cli/file_command.py
@@ -4,6 +4,7 @@ from redi.api.file import create_file, list_files
 from redi.cli.alias import resolve_alias
 from redi.config import default_project_id
 from redi.i18n import messages
+import sys
 
 
 def add_file_parser(
@@ -39,7 +40,7 @@ def handle_file(args: argparse.Namespace) -> None:
     project_id = args.project_id or default_project_id
     if not project_id:
         print(messages.project_id_required)
-        exit(1)
+        sys.exit(1)
     cmd = resolve_alias(args.file_command)
     if cmd == "create":
         create_file(

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -13,6 +13,7 @@ from redi.api.group import (
     remove_group_user,
     update_group,
 )
+import sys
 
 
 def add_group_parser(
@@ -106,7 +107,7 @@ def handle_group(args: argparse.Namespace) -> None:
             remove_group_user(args.group_id, user_id)
         if not should_update and not args.add_user_ids and not args.remove_user_ids:
             print(messages.update_canceled)
-            exit()
+            sys.exit()
         return
     if cmd == "delete":
         if not args.yes:

--- a/src/redi/cli/group_command.py
+++ b/src/redi/cli/group_command.py
@@ -1,8 +1,6 @@
 import argparse
+import sys
 
-from redi.cli.alias import resolve_alias
-from redi.cli.confirm import confirm_delete
-from redi.i18n import messages
 from redi.api.group import (
     add_group_user,
     create_group,
@@ -13,7 +11,9 @@ from redi.api.group import (
     remove_group_user,
     update_group,
 )
-import sys
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.i18n import messages
 
 
 def add_group_parser(

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 import tomllib
 
 import requests
@@ -11,7 +12,6 @@ from redi.cli.validator import UrlValidator
 from redi.client import RedmineClient
 from redi.config import CONFIG_PATH, create_profile
 from redi.i18n import messages
-import sys
 
 PROFILE_NAME = "default"
 

--- a/src/redi/cli/init_command.py
+++ b/src/redi/cli/init_command.py
@@ -11,6 +11,7 @@ from redi.cli.validator import UrlValidator
 from redi.client import RedmineClient
 from redi.config import CONFIG_PATH, create_profile
 from redi.i18n import messages
+import sys
 
 PROFILE_NAME = "default"
 
@@ -63,7 +64,7 @@ def _select_project_id(message: str, projects: list[Project]) -> str:
         return inline_choice(message, options)
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 def _has_existing_profile() -> bool:
@@ -77,7 +78,7 @@ def _has_existing_profile() -> bool:
 def handle_init(_args: argparse.Namespace) -> None:
     if _has_existing_profile():
         print(messages.init_profile_already_exists.format(path=CONFIG_PATH))
-        exit(1)
+        sys.exit(1)
 
     non_empty_validator = Validator.from_callable(
         lambda text: len(text.strip()) > 0,
@@ -93,12 +94,12 @@ def handle_init(_args: argparse.Namespace) -> None:
         ).strip()
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
     print(messages.checking_connection)
     user = _verify_connection(url, api_key)
     if user is None:
-        exit(1)
+        sys.exit(1)
     name = " ".join(filter(None, [user.get("firstname"), user.get("lastname")]))
     print(messages.connection_success.format(login=user.get("login", ""), name=name))
 
@@ -134,5 +135,5 @@ def handle_init(_args: argparse.Namespace) -> None:
         wiki_project_id=wiki_project_id,
     )
     if not result.created:
-        exit(1)
+        sys.exit(1)
     print(messages.config_created.format(path=CONFIG_PATH))

--- a/src/redi/cli/issue_category_command.py
+++ b/src/redi/cli/issue_category_command.py
@@ -12,6 +12,7 @@ from redi.api.issue_category import (
     read_issue_category,
     update_issue_category,
 )
+import sys
 
 
 def add_issue_category_parser(
@@ -110,7 +111,7 @@ def handle_issue_category(args: argparse.Namespace) -> None:
         project_id = args.project_id or default_project_id
         if not project_id:
             print(messages.project_id_required)
-            exit(1)
+            sys.exit(1)
         create_issue_category(
             project_id=project_id,
             name=args.name,
@@ -141,5 +142,5 @@ def handle_issue_category(args: argparse.Namespace) -> None:
         project_id = args.project_id or default_project_id
         if not project_id:
             print(messages.project_id_required)
-            exit(1)
+            sys.exit(1)
         list_issue_categories(project_id, full=args.full)

--- a/src/redi/cli/issue_category_command.py
+++ b/src/redi/cli/issue_category_command.py
@@ -1,9 +1,6 @@
 import argparse
+import sys
 
-from redi.cli.alias import resolve_alias
-from redi.cli.confirm import confirm_delete
-from redi.config import default_project_id
-from redi.i18n import messages
 from redi.api.issue_category import (
     create_issue_category,
     delete_issue_category,
@@ -12,7 +9,10 @@ from redi.api.issue_category import (
     read_issue_category,
     update_issue_category,
 )
-import sys
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.config import default_project_id
+from redi.i18n import messages
 
 
 def add_issue_category_parser(

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -54,6 +54,7 @@ from redi.api.custom_field import (
     filter_optional_issue_custom_fields,
     filter_required_issue_custom_fields,
 )
+import sys
 
 
 def add_issue_parser(
@@ -316,7 +317,7 @@ def _interactive_select_issue_id() -> str:
     issues = fetch_issues(project_id=default_project_id)
     if not issues:
         print(messages.no_issues_available)
-        exit(1)
+        sys.exit(1)
     options: list[tuple[str, str]] = [
         (str(i["id"]), f"#{i['id']} {i['subject']}") for i in issues
     ]
@@ -325,7 +326,7 @@ def _interactive_select_issue_id() -> str:
         issue_id = inline_choice(messages.prompt_select_issue_to_update, options)
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     print(messages.update_target_issue.format(label=labels[issue_id]))
     return issue_id
 
@@ -376,10 +377,10 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
         )
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if not selected:
         print(messages.canceled_no_items_selected)
-        exit(1)
+        sys.exit(1)
     labels = dict(field_values)
     print(messages.update_items.format(items=", ".join(labels[v] for v in selected)))
     try:
@@ -387,7 +388,7 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
             project_id = (current.get("project") or {}).get("id")
             if not project_id:
                 print(messages.canceled_no_project)
-                exit(1)
+                sys.exit(1)
             project = fetch_project(str(project_id), include="trackers")
             trackers = project.get("trackers") or []
             tracker_options: list[tuple[str, str]] = [
@@ -430,7 +431,7 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
             project_id = (current.get("project") or {}).get("id")
             if not project_id:
                 print(messages.canceled_no_project)
-                exit(1)
+                sys.exit(1)
             users = fetch_project_users(str(project_id))
             assignee_options: list[tuple[str, str]] = [
                 ("", messages.prompt_select_assignee_none)
@@ -454,7 +455,7 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
             project_id = (current.get("project") or {}).get("id")
             if not project_id:
                 print(messages.canceled_no_project)
-                exit(1)
+                sys.exit(1)
             versions = fetch_versions(str(project_id))
             version_options: list[tuple[str, str]] = [
                 (str(v["id"]), f"{v['name']} ({v['status']})") for v in versions
@@ -579,7 +580,7 @@ def _interactive_fill_issue_update_args(args: argparse.Namespace) -> None:
                 args.custom_fields = ",".join(added_custom_fields)
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 # attachment 型のような未対応フィールドで「スキップしてブラウザでの編集に倒す」ことを示すセンチネル
@@ -777,7 +778,7 @@ def _interactive_fill_required_custom_fields(
             value = _prompt_custom_field_value(cf, project_id)
         except (KeyboardInterrupt, EOFError):
             print(messages.canceled)
-            exit(1)
+            sys.exit(1)
         if value is _SKIP_UNSUPPORTED_FIELD:
             browser_only = True
             continue
@@ -837,7 +838,7 @@ def _interactive_fill_optional_create_fields(
         )
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if not selected:
         return custom_fields
     added_cfs: list[str] = []
@@ -919,7 +920,7 @@ def _interactive_fill_optional_create_fields(
                 added_cfs.append(f"{cf['id']}={cf_value}")
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if not added_cfs:
         return custom_fields
     if custom_fields:
@@ -946,7 +947,7 @@ def _interactive_select_issue_template(
         selected = inline_choice(messages.prompt_select_template, options)
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if not selected:
         return None
     template = template_map[selected]
@@ -966,7 +967,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
     project_id = args.project_id or default_project_id
     if not project_id:
         print(messages.project_id_required)
-        exit(1)
+        sys.exit(1)
     subject = args.subject
     tracker_id = args.tracker_id
     custom_fields = args.custom_fields
@@ -987,7 +988,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
                 )
             except KeyboardInterrupt:
                 print(messages.canceled)
-                exit(1)
+                sys.exit(1)
             print(messages.tracker_label.format(value=labels[tracker_id]))
         # テンプレートを選択し、題名・説明の初期値として反映させる
         template = _interactive_select_issue_template(project_id, tracker_id)
@@ -999,10 +1000,10 @@ def handle_issue_create(args: argparse.Namespace) -> None:
             subject = prompt(messages.prompt_subject, default=subject_default).strip()
         except (KeyboardInterrupt, EOFError):
             print(messages.canceled)
-            exit(1)
+            sys.exit(1)
         if not subject:
             print(messages.canceled_empty_subject)
-            exit(1)
+            sys.exit(1)
         # 必要なカスタムフィールドを対話的に入力
         custom_fields, browser_only = _interactive_fill_required_custom_fields(
             project_id=project_id,
@@ -1039,7 +1040,7 @@ def handle_issue_create(args: argparse.Namespace) -> None:
                 action = inline_choice(messages.prompt_what_next, action_options)
             except KeyboardInterrupt:
                 print(messages.canceled)
-                exit(1)
+                sys.exit(1)
             if action == "optional":
                 custom_fields = _interactive_fill_optional_create_fields(
                     args, project_id, tracker_id, custom_fields
@@ -1162,7 +1163,7 @@ def handle_issue_update(args: argparse.Namespace) -> None:
     if args.delete_relation:
         if not args.relate_to:
             print(messages.delete_relation_requires_to)
-            exit(1)
+            sys.exit(1)
         delete_relation(
             issue_id=args.issue_id,
             issue_to_id=args.relate_to,
@@ -1175,7 +1176,7 @@ def handle_issue_update(args: argparse.Namespace) -> None:
         )
     elif args.relate or args.relate_to:
         print(messages.relate_and_to_required)
-        exit(1)
+        sys.exit(1)
     if should_create_time_entry:
         create_time_entry(
             issue_id=args.issue_id,
@@ -1196,7 +1197,7 @@ def handle_issue_update(args: argparse.Namespace) -> None:
         and not should_update_watchers
     ):
         print(messages.update_canceled_no_changes)
-        exit(1)
+        sys.exit(1)
 
 
 def handle_issue(args: argparse.Namespace) -> None:

--- a/src/redi/cli/issue_command.py
+++ b/src/redi/cli/issue_command.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 import urllib.parse
 import webbrowser
 from datetime import date
@@ -6,24 +7,13 @@ from typing import cast
 
 from prompt_toolkit import prompt
 
-from redi.cli.alias import resolve_alias
-from redi.cli.editor import open_editor, save_text_to_tempfile
-from redi.cli.keybinding import (
-    date_key_bindings,
-    digit_and_period_key_bindings,
-    digit_only_key_bindings,
+from redi.api.custom_field import (
+    CustomField,
+    fetch_custom_fields,
+    fetch_project_issue_custom_field_ids,
+    filter_optional_issue_custom_fields,
+    filter_required_issue_custom_fields,
 )
-from redi.cli.picker import inline_checkbox, inline_choice
-from redi.cli.confirm import confirm_delete
-from redi.cli.validator import (
-    DateValidator,
-    DueDateValidator,
-    FloatValidator,
-    HourValidator,
-    IntValidator,
-    RequiredValidator,
-)
-from redi.config import default_project_id, redmine_url
 from redi.api.enumeration import fetch_issue_priorities, fetch_time_entry_activities
 from redi.api.issue import (
     add_note,
@@ -45,16 +35,25 @@ from redi.api.membership import fetch_project_users
 from redi.api.project import fetch_project
 from redi.api.time_entry import create_time_entry
 from redi.api.version import fetch_versions
-from redi.i18n import messages
-
-from redi.api.custom_field import (
-    CustomField,
-    fetch_custom_fields,
-    fetch_project_issue_custom_field_ids,
-    filter_optional_issue_custom_fields,
-    filter_required_issue_custom_fields,
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.cli.editor import open_editor, save_text_to_tempfile
+from redi.cli.keybinding import (
+    date_key_bindings,
+    digit_and_period_key_bindings,
+    digit_only_key_bindings,
 )
-import sys
+from redi.cli.picker import inline_checkbox, inline_choice
+from redi.cli.validator import (
+    DateValidator,
+    DueDateValidator,
+    FloatValidator,
+    HourValidator,
+    IntValidator,
+    RequiredValidator,
+)
+from redi.config import default_project_id, redmine_url
+from redi.i18n import messages
 
 
 def add_issue_parser(

--- a/src/redi/cli/issue_template_command.py
+++ b/src/redi/cli/issue_template_command.py
@@ -1,9 +1,9 @@
 import argparse
+import sys
 
 from redi.api.issue_template import list_issue_templates
 from redi.config import default_project_id
 from redi.i18n import messages
-import sys
 
 
 def add_issue_template_parser(

--- a/src/redi/cli/issue_template_command.py
+++ b/src/redi/cli/issue_template_command.py
@@ -3,6 +3,7 @@ import argparse
 from redi.api.issue_template import list_issue_templates
 from redi.config import default_project_id
 from redi.i18n import messages
+import sys
 
 
 def add_issue_template_parser(
@@ -24,5 +25,5 @@ def handle_issue_template(args: argparse.Namespace) -> None:
     project_id = args.project_id or default_project_id
     if not project_id:
         print(messages.project_id_required)
-        exit(1)
+        sys.exit(1)
     list_issue_templates(project_id, full=args.full)

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -66,6 +66,7 @@ from redi.api.tracker import list_trackers
 from redi.api.wiki import WikiUpdateConflictException
 from redi.i18n import messages
 from redi.tui import TuiState, run_issue_tui
+import sys
 
 
 def _format_validation_error(e: RedmineValidationException) -> str:
@@ -342,7 +343,7 @@ def main() -> None:
             handle_issue(args)
         except RedmineValidationException as e:
             print(_format_validation_error(e))
-            exit(1)
+            sys.exit(1)
     elif args.command in ("version", "v"):
         handle_version(args)
     elif args.command in ("wiki", "w"):
@@ -350,10 +351,10 @@ def main() -> None:
             handle_wiki(args)
         except WikiUpdateConflictException as e:
             print(messages.wiki_page_update_conflict.format(title=e.title))
-            exit(1)
+            sys.exit(1)
         except RedmineValidationException as e:
             print(_format_validation_error(e))
-            exit(1)
+            sys.exit(1)
     elif args.command in ("user", "u"):
         handle_user(args)
     elif args.command == "me":
@@ -393,7 +394,7 @@ def main() -> None:
             handle_time_entry(args)
         except RedmineValidationException as e:
             print(_format_validation_error(e))
-            exit(1)
+            sys.exit(1)
     elif args.command in ("file", "f"):
         handle_file(args)
     elif args.command in ("issue_journal", "ij"):

--- a/src/redi/cli/main.py
+++ b/src/redi/cli/main.py
@@ -1,14 +1,28 @@
 # PYTHON_ARGCOMPLETE_OK
 import argparse
 import logging
+import sys
 from datetime import datetime
 from importlib.metadata import version
 
 import argcomplete
 
+from redi.api.custom_field import list_custom_fields
+from redi.api.enumeration import (
+    list_document_categories,
+    list_issue_priorities,
+    list_time_entry_activities,
+)
+from redi.api.exceptions import RedmineValidationException
+from redi.api.issue import add_note
+from redi.api.issue_journal import delete_issue_journal, update_issue_journal
+from redi.api.issue_status import list_issue_statuses
+from redi.api.query import list_queries
+from redi.api.tracker import list_trackers
+from redi.api.wiki import WikiUpdateConflictException
 from redi.cli.attachment_command import add_attachment_parser, handle_attachment
 from redi.cli.config_command import add_config_parser, handle_config
-from redi.cli.file_command import add_file_parser, handle_file
+from redi.cli.editor import open_editor
 from redi.cli.enumerations_command import (
     add_custom_field_parser,
     add_document_category_parser,
@@ -18,7 +32,7 @@ from redi.cli.enumerations_command import (
     add_time_entry_activity_parser,
     add_tracker_parser,
 )
-from redi.cli.editor import open_editor
+from redi.cli.file_command import add_file_parser, handle_file
 from redi.cli.group_command import add_group_parser, handle_group
 from redi.cli.init_command import add_init_parser, handle_init
 from redi.cli.issue_category_command import (
@@ -51,22 +65,8 @@ from redi.cli.user_command import add_user_parser, handle_user
 from redi.cli.version_command import add_version_parser, handle_version
 from redi.cli.wiki_command import add_wiki_parser, handle_wiki
 from redi.config import CONFIG_PATH, check_config, list_profile_names
-from redi.api.custom_field import list_custom_fields
-from redi.api.enumeration import (
-    list_document_categories,
-    list_issue_priorities,
-    list_time_entry_activities,
-)
-from redi.api.exceptions import RedmineValidationException
-from redi.api.issue import add_note
-from redi.api.issue_journal import delete_issue_journal, update_issue_journal
-from redi.api.issue_status import list_issue_statuses
-from redi.api.query import list_queries
-from redi.api.tracker import list_trackers
-from redi.api.wiki import WikiUpdateConflictException
 from redi.i18n import messages
 from redi.tui import TuiState, run_issue_tui
-import sys
 
 
 def _format_validation_error(e: RedmineValidationException) -> str:

--- a/src/redi/cli/me_command.py
+++ b/src/redi/cli/me_command.py
@@ -1,8 +1,8 @@
 import argparse
 
+from redi.api.me import read_my_account, update_my_account
 from redi.cli.alias import resolve_alias
 from redi.i18n import messages
-from redi.api.me import read_my_account, update_my_account
 
 
 def add_me_parser(

--- a/src/redi/cli/membership_command.py
+++ b/src/redi/cli/membership_command.py
@@ -1,9 +1,6 @@
 import argparse
+import sys
 
-from redi.cli.alias import resolve_alias
-from redi.cli.confirm import confirm_delete
-from redi.config import default_project_id
-from redi.i18n import messages
 from redi.api.membership import (
     create_membership,
     delete_membership,
@@ -12,7 +9,10 @@ from redi.api.membership import (
     read_membership,
     update_membership,
 )
-import sys
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.config import default_project_id
+from redi.i18n import messages
 
 
 def _parse_role_ids(value: str) -> list[int]:

--- a/src/redi/cli/membership_command.py
+++ b/src/redi/cli/membership_command.py
@@ -12,6 +12,7 @@ from redi.api.membership import (
     read_membership,
     update_membership,
 )
+import sys
 
 
 def _parse_role_ids(value: str) -> list[int]:
@@ -107,10 +108,10 @@ def handle_membership(args: argparse.Namespace) -> None:
         project_id = args.project_id or default_project_id
         if not project_id:
             print(messages.project_id_required)
-            exit(1)
+            sys.exit(1)
         if args.user_id is None and args.group_id is None:
             print(messages.user_or_group_flag_required)
-            exit(1)
+            sys.exit(1)
         create_membership(
             project_id=project_id,
             role_ids=_parse_role_ids(args.role_ids),
@@ -146,5 +147,5 @@ def handle_membership(args: argparse.Namespace) -> None:
         project_id = args.project_id or default_project_id
         if not project_id:
             print(messages.project_id_required)
-            exit(1)
+            sys.exit(1)
         list_memberships(project_id, full=args.full)

--- a/src/redi/cli/news_command.py
+++ b/src/redi/cli/news_command.py
@@ -1,8 +1,8 @@
 import argparse
 
+from redi.api.news import list_news
 from redi.config import default_project_id
 from redi.i18n import messages
-from redi.api.news import list_news
 
 
 def add_news_parser(

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -13,6 +13,7 @@ from redi.api.project import (
     unarchive_project,
     update_project,
 )
+import sys
 
 
 def add_project_parser(
@@ -161,6 +162,6 @@ def handle_project(args: argparse.Namespace) -> None:
             unarchive_project(args.project_id)
         elif not should_update:
             print(messages.update_canceled)
-            exit()
+            sys.exit()
     elif cmd == "list" or cmd is None:
         list_projects(full=args.full)

--- a/src/redi/cli/project_command.py
+++ b/src/redi/cli/project_command.py
@@ -1,8 +1,6 @@
 import argparse
+import sys
 
-from redi.cli.alias import resolve_alias
-from redi.cli.confirm import confirm_delete_with_identifier
-from redi.i18n import messages
 from redi.api.project import (
     archive_project,
     create_project,
@@ -13,7 +11,9 @@ from redi.api.project import (
     unarchive_project,
     update_project,
 )
-import sys
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete_with_identifier
+from redi.i18n import messages
 
 
 def add_project_parser(

--- a/src/redi/cli/role_command.py
+++ b/src/redi/cli/role_command.py
@@ -1,8 +1,8 @@
 import argparse
 
+from redi.api.role import list_roles, read_role
 from redi.cli.alias import resolve_alias
 from redi.i18n import messages
-from redi.api.role import list_roles, read_role
 
 
 def add_role_parser(

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -10,6 +10,7 @@ from redi.api.search import (
     search,
 )
 from redi.i18n import messages
+import sys
 
 
 def _validate_scope(scope: SearchScope | None, project_id: str | None) -> None:
@@ -23,11 +24,11 @@ def _validate_scope(scope: SearchScope | None, project_id: str | None) -> None:
     if scope == "subprojects":
         if project_id is None:
             print(messages.error_search_scope_requires_project.format(scope=scope))
-            exit(1)
+            sys.exit(1)
         return
     if project_id is not None:
         print(messages.error_search_scope_conflicts_project.format(scope=scope))
-        exit(1)
+        sys.exit(1)
 
 
 def _parse_search_types(value: str) -> list[SearchType]:

--- a/src/redi/cli/search_command.py
+++ b/src/redi/cli/search_command.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from typing import cast
 
 from redi.api.search import (
@@ -10,7 +11,6 @@ from redi.api.search import (
     search,
 )
 from redi.i18n import messages
-import sys
 
 
 def _validate_scope(scope: SearchScope | None, project_id: str | None) -> None:

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -1,20 +1,10 @@
 import argparse
+import sys
 
 from prompt_toolkit import prompt
 from prompt_toolkit.completion import WordCompleter
 from prompt_toolkit.validation import Validator
 
-from redi.cli.alias import resolve_alias
-from redi.cli.keybinding import (
-    date_key_bindings,
-    digit_and_period_key_bindings,
-    digit_only_key_bindings,
-)
-from redi.cli.picker import inline_checkbox, inline_choice
-from redi.cli.confirm import confirm_delete
-from redi.cli.validator import DateValidator, HourValidator
-from redi.config import default_project_id
-from redi.i18n import messages
 from redi.api.enumeration import fetch_time_entry_activities
 from redi.api.issue import fetch_issue
 from redi.api.project import fetch_projects
@@ -26,7 +16,17 @@ from redi.api.time_entry import (
     read_time_entry,
     update_time_entry,
 )
-import sys
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.cli.keybinding import (
+    date_key_bindings,
+    digit_and_period_key_bindings,
+    digit_only_key_bindings,
+)
+from redi.cli.picker import inline_checkbox, inline_choice
+from redi.cli.validator import DateValidator, HourValidator
+from redi.config import default_project_id
+from redi.i18n import messages
 
 
 def add_time_entry_parser(

--- a/src/redi/cli/time_entry_command.py
+++ b/src/redi/cli/time_entry_command.py
@@ -26,6 +26,7 @@ from redi.api.time_entry import (
     read_time_entry,
     update_time_entry,
 )
+import sys
 
 
 def add_time_entry_parser(
@@ -211,7 +212,7 @@ def _interactive_fill_time_entry_create_args(args: argparse.Namespace) -> None:
             args.comments = prompt(messages.prompt_comment).strip() or None
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 def _interactive_fill_time_entry_update_args(args: argparse.Namespace) -> None:
@@ -227,10 +228,10 @@ def _interactive_fill_time_entry_update_args(args: argparse.Namespace) -> None:
         selected = inline_checkbox(messages.prompt_select_update_items, field_values)
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if not selected:
         print(messages.canceled_no_items_selected)
-        exit(1)
+        sys.exit(1)
     labels = dict(field_values)
     print(messages.update_items.format(items=", ".join(labels[v] for v in selected)))
     try:
@@ -288,7 +289,7 @@ def _interactive_fill_time_entry_update_args(args: argparse.Namespace) -> None:
                 args.issue_id = issue_id
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 def handle_time_entry(args: argparse.Namespace) -> None:

--- a/src/redi/cli/user_command.py
+++ b/src/redi/cli/user_command.py
@@ -1,8 +1,5 @@
 import argparse
 
-from redi.cli.alias import resolve_alias
-from redi.cli.confirm import confirm_delete_with_identifier
-from redi.i18n import messages
 from redi.api.user import (
     create_user,
     delete_user,
@@ -11,7 +8,9 @@ from redi.api.user import (
     read_user,
     update_user,
 )
-
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete_with_identifier
+from redi.i18n import messages
 
 MAIL_NOTIFICATION_CHOICES = [
     "all",

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from prompt_toolkit import prompt
 from prompt_toolkit.key_binding import KeyBindings
@@ -7,11 +8,6 @@ from prompt_toolkit.keys import Keys
 from prompt_toolkit.shortcuts import choice
 from prompt_toolkit.validation import Validator
 
-from redi.cli.alias import resolve_alias
-from redi.cli.picker import inline_checkbox, inline_choice
-from redi.cli.confirm import confirm_delete
-from redi.config import default_project_id
-from redi.i18n import messages
 from redi.api.version import (
     create_version,
     delete_version,
@@ -21,7 +17,11 @@ from redi.api.version import (
     read_version,
     update_version,
 )
-import sys
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.cli.picker import inline_checkbox, inline_choice
+from redi.config import default_project_id
+from redi.i18n import messages
 
 
 def add_version_parser(

--- a/src/redi/cli/version_command.py
+++ b/src/redi/cli/version_command.py
@@ -21,6 +21,7 @@ from redi.api.version import (
     read_version,
     update_version,
 )
+import sys
 
 
 def add_version_parser(
@@ -109,7 +110,7 @@ def _interactive_select_version_id(project_id: str) -> str:
     versions = fetch_versions(project_id)
     if not versions:
         print(messages.no_versions_available)
-        exit(1)
+        sys.exit(1)
     options: list[tuple[str, str]] = [
         (str(v["id"]), f"{v['id']} {v['name']} ({v['status']})") for v in versions
     ]
@@ -118,7 +119,7 @@ def _interactive_select_version_id(project_id: str) -> str:
         selected = inline_choice(messages.prompt_select_version_to_update, options)
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     print(messages.update_target_version.format(label=labels[selected]))
     return selected
 
@@ -136,10 +137,10 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
         selected = inline_checkbox(messages.prompt_select_update_items, field_values)
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     if not selected:
         print(messages.canceled_no_items_selected)
-        exit(1)
+        sys.exit(1)
     labels = dict(field_values)
     print(messages.update_items.format(items=", ".join(labels[v] for v in selected)))
     try:
@@ -188,7 +189,7 @@ def _interactive_fill_version_update_args(args: argparse.Namespace) -> None:
             print(messages.sharing_label.format(value=args.sharing))
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 def _interactive_create_version(project_id: str, args: argparse.Namespace) -> None:
@@ -202,19 +203,19 @@ def _interactive_create_version(project_id: str, args: argparse.Namespace) -> No
         ).strip()
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
     try:
         due_date = prompt(messages.prompt_due_date_optional).strip() or None
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
     try:
         description = prompt(messages.prompt_description_optional).strip() or None
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
     sharing_options: list[tuple[str, str]] = [
         ("none", messages.sharing_none),
@@ -242,7 +243,7 @@ def _interactive_create_version(project_id: str, args: argparse.Namespace) -> No
         )
     except KeyboardInterrupt:
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
     sharing = sharing_input if sharing_input != "none" else None
 
     create_version(
@@ -262,7 +263,7 @@ def handle_version(args: argparse.Namespace) -> None:
         project_id = args.project_id or default_project_id
         if not project_id:
             print(messages.project_id_required)
-            exit(1)
+            sys.exit(1)
         if args.name is None:
             _interactive_create_version(project_id, args)
         else:
@@ -288,7 +289,7 @@ def handle_version(args: argparse.Namespace) -> None:
             project_id = args.project_id or default_project_id
             if not project_id:
                 print(messages.project_id_required)
-                exit(1)
+                sys.exit(1)
             args.version_id = _interactive_select_version_id(project_id)
         no_args_provided = not (
             args.name
@@ -311,5 +312,5 @@ def handle_version(args: argparse.Namespace) -> None:
         project_id = args.project_id or default_project_id
         if not project_id:
             print(messages.project_id_required)
-            exit(1)
+            sys.exit(1)
         list_versions(project_id, full=args.full)

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -21,6 +21,7 @@ from redi.api.wiki import (
     read_wiki,
     update_wiki,
 )
+import sys
 
 
 def _prompt_wiki_comments() -> str:
@@ -29,7 +30,7 @@ def _prompt_wiki_comments() -> str:
         return prompt(messages.prompt_wiki_comments).strip()
     except (KeyboardInterrupt, EOFError):
         print(messages.canceled)
-        exit(1)
+        sys.exit(1)
 
 
 def build_wiki_tree_choices(pages: list[WikiPage]) -> list[tuple[str, str]]:
@@ -129,7 +130,7 @@ def handle_wiki(args: argparse.Namespace) -> None:
     project_id = args.project_id or wiki_project_id or default_project_id
     if not project_id:
         print(messages.wiki_project_id_required)
-        exit(1)
+        sys.exit(1)
     cmd = resolve_alias(args.wiki_command)
     if cmd == "view":
         read_wiki(
@@ -164,10 +165,10 @@ def handle_wiki(args: argparse.Namespace) -> None:
                 ).strip()
             except (KeyboardInterrupt, EOFError):
                 print(messages.canceled)
-                exit(1)
+                sys.exit(1)
             if not page_title:
                 print(messages.canceled_empty_title)
-                exit(1)
+                sys.exit(1)
             if parent_title is None:
                 parent_options = build_wiki_tree_choices(pages)
                 if parent_options:
@@ -178,7 +179,7 @@ def handle_wiki(args: argparse.Namespace) -> None:
                         )
                     except KeyboardInterrupt:
                         print(messages.canceled)
-                        exit(1)
+                        sys.exit(1)
                     print(
                         messages.parent_page_label.format(
                             label=parent_labels[parent_title].strip()
@@ -209,7 +210,7 @@ def handle_wiki(args: argparse.Namespace) -> None:
             page = fetch_wiki(project_id, title)
             if page is None:
                 print(messages.wiki_page_not_found.format(title=title))
-                exit(1)
+                sys.exit(1)
             confirm_delete(
                 messages.delete_target_wiki_page.format(title=page.get("title", title))
             )
@@ -220,14 +221,14 @@ def handle_wiki(args: argparse.Namespace) -> None:
             pages = fetch_wikis(project_id)
             if not pages:
                 print(messages.wiki_page_does_not_exist)
-                exit(1)
+                sys.exit(1)
             page_options = build_wiki_tree_choices(pages)
             page_labels = dict(page_options)
             try:
                 page_title = inline_choice(messages.prompt_edit_page, page_options)
             except KeyboardInterrupt:
                 print(messages.canceled)
-                exit(1)
+                sys.exit(1)
             print(
                 messages.edit_target_page.format(label=page_labels[page_title].strip())
             )
@@ -239,7 +240,7 @@ def handle_wiki(args: argparse.Namespace) -> None:
             current = fetch_wiki(project_id, page_title)
             if current is None:
                 print(messages.wiki_page_not_found.format(title=page_title))
-                exit(1)
+                sys.exit(1)
             version = current.get("version")
             text = open_editor(current.get("text") or "")
             comments = args.comments or _prompt_wiki_comments()

--- a/src/redi/cli/wiki_command.py
+++ b/src/redi/cli/wiki_command.py
@@ -1,14 +1,9 @@
 import argparse
+import sys
 
 from prompt_toolkit import prompt
 from prompt_toolkit.validation import ValidationError, Validator
 
-from redi.cli.alias import resolve_alias
-from redi.cli.editor import open_editor
-from redi.cli.picker import inline_choice
-from redi.cli.confirm import confirm_delete
-from redi.config import default_project_id, wiki_project_id
-from redi.i18n import messages
 from redi.api.wiki import (
     WikiPage,
     build_children_map,
@@ -21,7 +16,12 @@ from redi.api.wiki import (
     read_wiki,
     update_wiki,
 )
-import sys
+from redi.cli.alias import resolve_alias
+from redi.cli.confirm import confirm_delete
+from redi.cli.editor import open_editor
+from redi.cli.picker import inline_choice
+from redi.config import default_project_id, wiki_project_id
+from redi.i18n import messages
 
 
 def _prompt_wiki_comments() -> str:

--- a/src/redi/config.py
+++ b/src/redi/config.py
@@ -82,10 +82,10 @@ language: str = merged_config["language"]
 def check_config() -> None:
     if not redmine_url:
         print(f"set REDMINE_URL or add redmine_url to {CONFIG_PATH}")
-        exit(1)
+        sys.exit(1)
     if not redmine_api_key:
         print(f"set REDMINE_API_KEY or add redmine_api_key to {CONFIG_PATH}")
-        exit(1)
+        sys.exit(1)
 
 
 def update_config(
@@ -105,11 +105,11 @@ def update_config(
     target_profile = profile or doc.get("default_profile")
     if not target_profile:
         print("default_profile not found")
-        exit(1)
+        sys.exit(1)
     profile_table = doc.get(target_profile) if target_profile in doc else None
     if not isinstance(profile_table, Table):
         print(f"profile '{target_profile}' not found in {path}")
-        exit(1)
+        sys.exit(1)
 
     profile_table[key] = value
     with open(path, "w") as f:

--- a/src/redi/tui/app.py
+++ b/src/redi/tui/app.py
@@ -58,8 +58,14 @@ from redi.tui.time_entry.filter_modal import (
 )
 from redi.tui.time_entry.time_entry_tab import (
     TIME_ENTRY_TAB,
+)
+from redi.tui.time_entry.time_entry_tab import (
     confirm_delete as time_entry_confirm_delete,
+)
+from redi.tui.time_entry.time_entry_tab import (
     reload_with_filter as time_entry_reload_with_filter,
+)
+from redi.tui.time_entry.time_entry_tab import (
     request_delete as time_entry_request_delete,
 )
 from redi.tui.wiki.wiki_tab import WIKI_TAB

--- a/tests/e2e/test_project_cli.py
+++ b/tests/e2e/test_project_cli.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import pytest
 
 from tests.e2e.utils import run_redi, unique_identifier
@@ -12,15 +14,9 @@ class TestProjectList:
         identifier = unique_identifier("e2e-list")
         name = f"e2e list {identifier}"
 
-        create_result = run_redi("project", "create", name, identifier)
-        assert create_result.returncode == 0, (
-            f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
-        )
+        run_redi("project", "create", name, identifier)
 
         result = run_redi("project", "list")
-        assert result.returncode == 0, (
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
         assert identifier in result.stdout
 
 
@@ -31,9 +27,6 @@ class TestProjectView:
     def test_succeeds_for_existing_project_id(self):
         """init-redmine.sh で作成された id=1 のプロジェクト(reditest)を表示すると exit 0 で成功する"""
         result = run_redi("project", "view", "1")
-        assert result.returncode == 0, (
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
         assert "reditest" in result.stdout
 
 
@@ -46,15 +39,9 @@ class TestProjectCreate:
         identifier = unique_identifier("e2e-create")
         name = f"e2e create {identifier}"
 
-        create_result = run_redi("project", "create", name, identifier)
-        assert create_result.returncode == 0, (
-            f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
-        )
+        run_redi("project", "create", name, identifier)
 
         view_result = run_redi("project", "view", identifier)
-        assert view_result.returncode == 0, (
-            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
-        )
         assert name in view_result.stdout
         assert identifier in view_result.stdout
 
@@ -69,22 +56,10 @@ class TestProjectUpdate:
         original_name = f"e2e update original {identifier}"
         updated_name = f"e2e update updated {identifier}"
 
-        create_result = run_redi("project", "create", original_name, identifier)
-        assert create_result.returncode == 0, (
-            f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
-        )
-
-        update_result = run_redi(
-            "project", "update", identifier, "--name", updated_name
-        )
-        assert update_result.returncode == 0, (
-            f"stdout:\n{update_result.stdout}\nstderr:\n{update_result.stderr}"
-        )
+        run_redi("project", "create", original_name, identifier)
+        run_redi("project", "update", identifier, "--name", updated_name)
 
         view_result = run_redi("project", "view", identifier)
-        assert view_result.returncode == 0, (
-            f"stdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
-        )
         assert updated_name in view_result.stdout
         assert original_name not in view_result.stdout
 
@@ -98,20 +73,12 @@ class TestProjectDelete:
         identifier = unique_identifier("e2e-delete")
         name = f"e2e delete {identifier}"
 
-        create_result = run_redi("project", "create", name, identifier)
-        assert create_result.returncode == 0, (
-            f"stdout:\n{create_result.stdout}\nstderr:\n{create_result.stderr}"
-        )
+        run_redi("project", "create", name, identifier)
+        run_redi("project", "delete", identifier, "-y")
 
-        delete_result = run_redi("project", "delete", identifier, "-y")
-        assert delete_result.returncode == 0, (
-            f"stdout:\n{delete_result.stdout}\nstderr:\n{delete_result.stderr}"
-        )
-
-        view_result = run_redi("project", "view", identifier)
-        assert view_result.returncode != 0, (
-            f"削除後 view が成功してしまった\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
-        )
-        assert "Project not found" in view_result.stdout, (
-            f"想定外のエラーで view が失敗\nstdout:\n{view_result.stdout}\nstderr:\n{view_result.stderr}"
+        with pytest.raises(subprocess.CalledProcessError) as view_error_info:
+            run_redi("project", "view", identifier)
+        view_error = view_error_info.value
+        assert "Project not found" in view_error.stdout, (
+            f"想定外のエラーで view が失敗\nstdout:\n{view_error.stdout}\nstderr:\n{view_error.stderr}"
         )

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -5,11 +5,16 @@ import uuid
 
 
 def run_redi(*args: str) -> subprocess.CompletedProcess[str]:
-    """`redi <args...>` を subprocess で実行する (例: `run_redi("project", "list")`)。"""
+    """`redi <args...>` を subprocess で実行する (例: `run_redi("project", "list")`)。
+
+    異常終了を見逃さないよう `check=True` で実行する。
+    異常終了を検証する場合は `subprocess.CalledProcessError` を捕捉する。
+    """
     return subprocess.run(
         ["redi", *args],
         capture_output=True,
         text=True,
+        check=True,
     )
 
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -11,7 +11,7 @@ class TestProfileFlagPlacement:
 
     @pytest.fixture
     def parser(self, monkeypatch) -> argparse.ArgumentParser:
-        monkeypatch.setattr(main_module, "list_profile_names", lambda: [])
+        monkeypatch.setattr(main_module, "list_profile_names", list)
         return build_redi_parser()
 
     def test_before_subcommand(self, parser):

--- a/tests/unit/i18n/test_i18n.py
+++ b/tests/unit/i18n/test_i18n.py
@@ -6,7 +6,6 @@ from redi.i18n._protocol import MessagesProto
 from redi.i18n.en import En
 from redi.i18n.ja import Ja
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
 

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,8 +1,9 @@
 import json
 import time
 
-from redi import cache, config
 import pytest
+
+from redi import cache, config
 
 
 class TestSave:

--- a/tests/unit/tui/test_project_switch.py
+++ b/tests/unit/tui/test_project_switch.py
@@ -11,9 +11,9 @@ from redi.api.time_entry import TimeEntry
 from redi.i18n import messages
 from redi.tui import app, project_modal
 from redi.tui.issue import issue_tab
-from redi.tui.time_entry import time_entry_tab
 from redi.tui.state import IssueFilter, TimeEntryFilter, TuiState
 from redi.tui.tab import TabView, noop, noop_jump
+from redi.tui.time_entry import time_entry_tab
 
 PROJECTS = cast(
     list[Project],

--- a/tests/unit/tui/test_tab_reload.py
+++ b/tests/unit/tui/test_tab_reload.py
@@ -5,10 +5,10 @@ from typing import cast
 from redi.api.issue import Issue
 from redi.api.time_entry import TimeEntry
 from redi.api.wiki import WikiPage
-from redi.tui.wiki import wiki_tab
 from redi.tui.issue import issue_tab
-from redi.tui.time_entry import time_entry_tab
 from redi.tui.state import TuiState
+from redi.tui.time_entry import time_entry_tab
+from redi.tui.wiki import wiki_tab
 
 
 class TestIssueReload:

--- a/tests/unit/tui/time_entry/test_time_entry_tab.py
+++ b/tests/unit/tui/time_entry/test_time_entry_tab.py
@@ -1,8 +1,8 @@
 from typing import cast
 
 from redi.api.time_entry import TimeEntry
-from redi.tui.time_entry import time_entry_tab
 from redi.tui.state import TuiState
+from redi.tui.time_entry import time_entry_tab
 
 
 def _make_state(


### PR DESCRIPTION
## 概要

#287 で ignore にした ruff のルールを 1 件ずつ解消するか維持するか判断し、対応した。

`[tool.ruff.lint]` の `ignore` は 8 件から 2 件になり、ファミリ指定 (`DTZ`) もピンポイント指定に絞られた。

## 各ルールの判断

| ルール | 判断 | 内容 |
| --- | --- | --- |
| PLR1722 (185件) | 解消 | `exit()` は `site` が注入する組み込みで `python -S` や凍結環境では利用できないため `sys.exit()` に置き換え |
| I001 (23ファイル) | 解消 | import を isort 順に整列。PLR1722 の自動修正で末尾に入った `import sys` もあわせて解消 |
| B006 (1件) | 解消 | `update_issue()` の `attachments` を `list[str] \| None = None` に。呼び出し側の `--attach` は `action="append"` で default 未指定のため実際に `None` が渡っており、型注釈も実態に合った |
| PLW1510 (1件) | 解消 | e2e の `run_redi()` を `check=True` に。異常終了を検証していたテストは `CalledProcessError` の捕捉に切り替え、到達しなくなった `returncode` の assert を削除 |
| PIE807 (1件) | 解消 | `lambda: []` を `list` に |
| FURB122 (1件) | ルール有効化 + noqa | `writelines()` でも等価だが、チャンク単位の書き込みは `for` の方が可読性が高いため該当行のみ noqa |
| SIM114 (1件) | ルール有効化 + noqa | `or` で統合できるが、副作用のある `set_default_profile()` を条件式に埋めない方が可読性が高いため該当行のみ noqa |
| DTZ005 / DTZ011 (5件) | 維持 | デバッグ出力の時刻と日付プロンプトの初期値はユーザーのローカル時刻が意図通りで、比較・保存にも使わないため。ファミリ全体の `DTZ` 指定をやめ、該当する 2 ルールのみに絞った |

FURB122 と SIM114 は ignore を残すとルール自体が無効になり新規の混入を防げないため、ルールは有効にしたうえで該当箇所を理由付きの noqa にした。


Close #288
